### PR TITLE
修复新功能投票 URL 中斜杠重复的问题

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherVote.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherVote.xaml.vb
@@ -55,7 +55,7 @@ Public Class PageOtherVote
             If SingleMatch.Success Then
                 ' 输出匹配到的href和文本内容
                 item.Title = SingleMatch.Groups(2).Value.Trim()
-                item.Url = "https://github.com/" & SingleMatch.Groups(1).Value
+                item.Url = "https://github.com" & SingleMatch.Groups(1).Value
             End If
             ' 抓取时间
             pattern = "<relative-time datetime=""(.*?)"" class=""no-wrap"""


### PR DESCRIPTION
打开新功能投票详情页时，网址中的斜杠重复，如图。
![image](https://github.com/user-attachments/assets/6cb3debe-c7e2-4bb9-a016-9e13d2469c2a)