### PR TITLE
修复一些剪贴板资源识别相关的 Bug

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -449,6 +449,8 @@ Public Class FormMain
                 Log(ex, "清理自动更新文件失败")
             End Try
         End Sub, "Start Loader", ThreadPriority.Lowest)
+        '剪贴板识别
+        If Setup.Get("ToolDownloadClipboard") Then RunInNewThread(Sub() CompClipboard.ClipboardListening(), "Clipboard Listener", ThreadPriority.Lowest)
 
         Log("[Start] 第三阶段加载用时：" & GetTimeTick() - ApplicationStartTick & " ms")
     End Sub
@@ -1139,8 +1141,10 @@ Public Class FormMain
                         Return "整合包下载 - " & Project.TranslatedName
                     Case CompType.ResourcePack
                         Return "资源包下载 - " & Project.TranslatedName
-                    Case Else 'CompType.Shader
+                    Case CompType.Shader
                         Return "光影包下载 - " & Project.TranslatedName
+                    Case Else
+                        Return "资源下载 - " & Project.TranslatedName
                 End Select
             Case PageType.HelpDetail
                 Dim Entry As HelpEntry = Stack.Additional(0)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
@@ -17,6 +17,10 @@
         ''' 光影包。
         ''' </summary>
         Shader = 3
+        ''' <summary>
+        ''' 其他。
+        ''' </summary>
+        Other = 4
     End Enum
     Public Enum CompModLoaderType
         'https://docs.curseforge.com/?http#tocS_ModLoaderType
@@ -285,8 +289,10 @@
                         Type = CompType.ModPack
                     ElseIf Website.Contains("/texture-packs/") Then
                         Type = CompType.ResourcePack
-                    Else 'Website.Contains("/shaders/")
+                    ElseIf Website.Contains("/shaders/") Then
                         Type = CompType.Shader
+                    Else
+                        Type = CompType.Other
                     End If
                     'Tags
                     Tags = New List(Of String)
@@ -384,6 +390,7 @@
                         Case "modpack" : Type = CompType.ModPack
                         Case "resourcepack" : Type = CompType.ResourcePack
                         Case "shader" : Type = CompType.Shader
+                        Case Else : Type = CompType.Other
                     End Select
                     'Tags & ModLoaders
                     Tags = New List(Of String)
@@ -1735,16 +1742,44 @@ Retry:
                 Dim Text As String = Nothing
                 Dim Slug As String = Nothing
                 Dim ProjectId As String = Nothing
+                Dim CategoryURL As String = Nothing
+                Dim ReturnData = Nothing
                 RunInUiWait(Sub()
                                 Text = My.Computer.Clipboard.GetText().Replace("https://", "").Replace("http://", "")
                             End Sub)
                 If Text = CurrentText Then Continue While
                 CurrentText = Text
 
-                If Text.Contains("curseforge.com/") Then 'e.g. www.curseforge.com/minecraft/mc-mods/jei
+                If Text.Contains("curseforge.com/minecraft/") Then 'e.g. www.curseforge.com/minecraft/mc-mods/jei
+                    Dim ClassIds As List(Of String) = New List(Of String) From {"6", "4471", "12", "6552"}
                     Try
+                        CategoryURL = Text.Split("/")(2)
                         Slug = Text.Split("/")(3)
-                        ProjectId = DlModRequest("https://api.curseforge.com/v1/mods/search?gameId=432&slug=" + Slug, IsJson:=True)("data")(0)("id")
+                        ReturnData = DlModRequest("https://api.curseforge.com/v1/mods/search?gameId=432&slug=" + Slug, IsJson:=True) '获取资源信息
+                        Dim ReceivedClassId As String = ReturnData("data")(0)("categories")(0)("classId") '获取资源的 ClassId
+
+                        '判断资源的分类是否匹配，不在支持的资源类型中的就直接显示
+                        Dim IsCategoryMatched As Boolean = True
+                        Dim ResClassId As String = Nothing
+                        If CategoryURL = "mc-mods" AndAlso Not ReceivedClassId = "6" Then
+                            IsCategoryMatched = False
+                            ResClassId = "6"
+                        ElseIf CategoryURL = "modpacks" AndAlso Not ReceivedClassId = "4471" Then
+                            IsCategoryMatched = False
+                            ResClassId = "4471"
+                        ElseIf CategoryURL = "texture-packs" AndAlso Not ReceivedClassId = "12" Then
+                            IsCategoryMatched = False
+                            ResClassId = "12"
+                        ElseIf CategoryURL = "shaders" AndAlso Not ReceivedClassId = "6552" Then
+                            IsCategoryMatched = False
+                            ResClassId = "6552"
+                        End If
+
+                        If Not IsCategoryMatched Then
+                            ReturnData = DlModRequest("https://api.curseforge.com/v1/mods/search?gameId=432&slug=" + Slug + "&classId=" + ResClassId, IsJson:=True)
+                        End If
+
+                        ProjectId = ReturnData("data")(0)("id")
                     Catch ex As Exception
                         Log("[Clipboard] 获取剪贴板 CurseForge 资源链接 ID 失败: " + ex.ToString(), LogLevel.Normal)
                         Continue While


### PR DESCRIPTION
Close #166 

fix: Curse 部分资源 Slug 相同导致不能正确跳转
fix: 部分意外分类的资源标题栏分类不正确
fix: 在启动器重启后不会自动识别剪贴板