### PR TITLE
fix(log): 修复部分地方使用原版日志的问题

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -494,7 +494,7 @@ Public Class FormMain
                 FeedbackInfo()
                 Log("请在 https://github.com/PCL-Community/PCL2-CE/issues 提交错误报告，以便于社区解决此问题！（这也有可能是原版 PCL 的问题）")
                 IsLogShown = True
-                ShellOnly(Path & "PCL\Log1.txt")
+                ShellOnly(Path & "PCL\Log-CE1.log")
             End If
             Thread.Sleep(500) '防止 PCL 在记事本打开前就被掐掉
         End If

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.vb
@@ -179,7 +179,7 @@ Extracted:
                    MatchName = "游戏崩溃前的输出.txt" OrElse MatchName = "rawoutput.log" Then
                 TargetType = AnalyzeFileType.MinecraftLog
                 If DirectFile Is Nothing Then DirectFile = LogFile
-            ElseIf MatchName = "启动器日志.txt" OrElse MatchName = "PCL2 启动器日志.txt" OrElse MatchName = "PCL 启动器日志.txt" OrElse MatchName = "log1.txt" Then
+            ElseIf MatchName = "启动器日志.txt" OrElse MatchName = "PCL2 启动器日志.txt" OrElse MatchName = "PCL 启动器日志.txt" OrElse MatchName = "log1.txt" OrElse MatchName = "log-ce1.log" Then
                 If LogFile.Value.Any(Function(s) s.Contains("以下为游戏输出的最后一段内容")) Then
                     TargetType = AnalyzeFileType.MinecraftLog
                     If DirectFile Is Nothing Then DirectFile = LogFile
@@ -245,7 +245,7 @@ Extracted:
                             Log("[Crash] 输出报告：" & SelectedFile.Key & "，作为 Minecraft 或启动器日志")
                         Next
                         '选择一份最佳的来自启动器的游戏日志
-                        For Each FileName As String In {"rawoutput.log", "启动器日志.txt", "log1.txt", "游戏崩溃前的输出.txt", "PCL2 启动器日志.txt", "PCL 启动器日志.txt"}
+                        For Each FileName As String In {"rawoutput.log", "启动器日志.txt", "log1.txt", "log-ce1.log", "游戏崩溃前的输出.txt", "PCL2 启动器日志.txt", "PCL 启动器日志.txt"}
                             If FileNameDict.ContainsKey(FileName) Then
                                 Dim CurrentLog = FileNameDict(FileName)
                                 '截取 “以下为游戏输出的最后一段内容” 后的内容
@@ -900,7 +900,7 @@ NextStack:
                         Select Case FileName
                             Case "LatestLaunch.bat"
                                 FileName = "启动脚本.bat"
-                            Case "Log1.txt"
+                            Case "Log-CE1.log"
                                 FileName = "PCL 启动器日志.txt"
                                 FileEncoding = Encoding.UTF8
                             Case "RawOutput.log"

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.vb
@@ -360,7 +360,7 @@
                     Analyzer.Prepare()
                     Analyzer.Analyze(Version)
                     Analyzer.Output(False, New List(Of String) From
-                        {Version.Path & Version.Name & ".json", Path & "PCL\Log1.txt", Path & "PCL\LatestLaunch.bat"})
+                        {Version.Path & Version.Name & ".json", Path & "PCL\Log-CE1.log", Path & "PCL\LatestLaunch.bat"})
                 Catch ex As Exception
                     Log(ex, "崩溃分析失败", LogLevel.Feedback)
                 End Try

--- a/Plain Craft Launcher 2/Resources/Custom.xaml
+++ b/Plain Craft Launcher 2/Resources/Custom.xaml
@@ -98,7 +98,7 @@
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                     Text="此外，PCL 会将文件中的 “花括号 path” 替换为 PCL 可执行文件所在文件夹（{path}），可以用于执行特定程序或加载图片。" />
         <local:MyButton Margin="0,4,0,10" Width="200" Height="35"
-                    Text="打开 PCL 日志" EventType="打开文件" EventData="Log1.txt" ToolTip="PCL 的日志文件就在 PCL 文件夹内，且名为 Log1.txt" />
+                    Text="打开 PCL-CE 日志" EventType="打开文件" EventData="Log-CE1.log" ToolTip="PCL 社区版的日志文件就在 PCL 文件夹内，且名为 Log-CE1.log" />
         <TextBlock TextWrapping="Wrap" Margin="0,0,0,4"
                     Text="就像为游戏指定服务器 IP 一样，你也可以在 EventData 的竖线后为程序添加启动参数。" />
         <local:MyButton Margin="0,4,0,0" Width="200" Height="35"


### PR DESCRIPTION
以下功能中，PCL CE 错误使用了原版 PCL 日志文件，现已修复：

- 由于 `Exception` 强制关闭程序、打开日志文件；
- 导出错误报告；
- 自定义主页模板；
- 部分地方进行崩溃分析。

同时，现在进行崩溃分析时，会考虑 `Log-CE1.log`，以便准确分析。

检索式：`(Log OR 日志) AND (PCL OR 原版)`

如有问题请指出，感谢。