### PR TITLE
fix: check available mod updates for quilt and fabric on quilt instance

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMod.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMod.vb
@@ -1142,6 +1142,7 @@ Finished:
         If PageVersionLeft.Version.Version.HasForge Then ModLoaders.Add(CompModLoaderType.Forge)
         If PageVersionLeft.Version.Version.HasNeoForge Then ModLoaders.Add(CompModLoaderType.NeoForge)
         If PageVersionLeft.Version.Version.HasFabric Then ModLoaders.Add(CompModLoaderType.Fabric)
+        If PageVersionLeft.Version.Version.HasQuilt Then ModLoaders.AddRange({CompModLoaderType.Fabric, CompModLoaderType.Quilt})
         If PageVersionLeft.Version.Version.HasLiteLoader Then ModLoaders.Add(CompModLoaderType.LiteLoader)
         If Not ModLoaders.Any() Then ModLoaders.AddRange({CompModLoaderType.Forge, CompModLoaderType.NeoForge, CompModLoaderType.Fabric, CompModLoaderType.LiteLoader, CompModLoaderType.Quilt})
         Return ModLoaders


### PR DESCRIPTION
resolves https://github.com/PCL-Community/PCL2-CE/issues/296

---

基于 https://github.com/PCL-Community/PCL2-CE/issues/296#issuecomment-2664969902 的讨论，本 PR 在 Quilt 游戏版本上会检查针对 Fabric 和 Quilt 的可用 Mod 更新。

这样，

- 一些 Mod 仅标记支持 Fabric<i>（此类 Mod 通常不排斥 Quilt 加载）</i>
- 一些 Mod 仅标记支持 Quilt<i>（此类 Mod 仅支持 Quilt）</i>
- 一些 Mod 标记同时支持两者

的情况下，在 Quilt 游戏版本上都能检测到更新。