### PR TITLE
fix(ResourcesSort): use case-insensitive comparison

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
@@ -684,11 +684,11 @@ Install:
         Select Case Method
             Case SortMethod.FileName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return -StrComp(a.FileName, b.FileName)
+                           Return String.Compare(a.FileName, b.FileName, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.ModName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return -StrComp(a.Name, b.Name)
+                           Return String.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.TagNums
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer

--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
@@ -684,11 +684,11 @@ Install:
         Select Case Method
             Case SortMethod.FileName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return String.Compare(a.FileName, b.FileName, StringComparison.OrdinalIgnoreCase)
+                           Return -String.Compare(b.FileName, a.FileName, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.ModName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return String.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase)
+                           Return -String.Compare(b.Name, a.Name, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.TagNums
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer

--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
@@ -684,11 +684,11 @@ Install:
         Select Case Method
             Case SortMethod.FileName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return -String.Compare(b.FileName, a.FileName, StringComparison.OrdinalIgnoreCase)
+                           Return String.Compare(b.FileName, a.FileName, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.ModName
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer
-                           Return -String.Compare(b.Name, a.Name, StringComparison.OrdinalIgnoreCase)
+                           Return String.Compare(b.Name, a.Name, StringComparison.OrdinalIgnoreCase)
                        End Function
             Case SortMethod.TagNums
                 Return Function(a As LocalCompFile, b As LocalCompFile) As Integer


### PR DESCRIPTION
修改了 `SortMethod.FileName` 和 `SortMethod.ModName` 的实现方式
现在排序应当不会受大小写 ASCII 码位差而优先大写了

fix #381