### PR TITLE
修复重置个性化设置时的空指针异常

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.vb
@@ -219,7 +219,7 @@ Public Class PageSetupUI
 
     Private Sub ComboFontChange(sender As MyComboBox, e As Object) Handles ComboUiFont.SelectionChanged
         If AniControlEnabled = 0 Then
-            If sender.SelectedIndex = 0 Then
+            If sender.SelectedIndex = 0 Or sender.SelectedItem Is Nothing Then
                 Setup.Set("UiFont", "")
                 SetLaunchFont()
             Else


### PR DESCRIPTION
异常原因是重置设置使字体选择的 ComboBox 丢失选项，触发 SelectionChanged 事件判定是否为默认选项时没有考虑 SelectedItem 为空的情况