### PR TITLE
fix(Proxy): 没有系统代理时会获取到错误的系统代理

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -6,7 +6,7 @@
     ''' <returns>返回 WebProxy 或者 Nothing</returns>
     Public Function GetProxy()
         Dim proxy As String = Setup.Get("SystemHttpProxy")
-        Dim ProxyServer = WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com"))
+        Dim ProxyServer As String = WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com")).ToString
         '没有系统代理的情况下会返回原始 Uri，这导致了使用此方法获取系统代理的网络请求全部炸掉 （#517）
         If ProxyServer = "https://www.example.com" Then 
             GoTo IgnoreSystemProxy

--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -8,7 +8,7 @@
         Dim proxy As String = Setup.Get("SystemHttpProxy")
         Dim ProxyServer As String = WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com")).ToString
         '没有系统代理的情况下会返回原始 Uri，这导致了使用此方法获取系统代理的网络请求全部炸掉 （#517）
-        If ProxyServer = "https://www.example.com" Then 
+        If ProxyServer.ContainsF("www.example.com") Then 
             GoTo IgnoreSystemProxy
         Else If Not ProxyServer.StartsWithF("http:") Then 
                 Log("[Net] 检测到不支持的代理服务器协议，已忽略系统代理。")

--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -8,7 +8,8 @@
         Dim proxy As String = Setup.Get("SystemHttpProxy")
         Dim ProxyServer = WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com"))
         '没有系统代理的情况下会返回原始 Uri，这导致了使用此方法获取系统代理的网络请求全部炸掉 （#517）
-        If ProxyServer = "https://www.example.com" Then GoTo IgnoreSystemProxy
+        If ProxyServer = "https://www.example.com" Then 
+            GoTo IgnoreSystemProxy
         Else If Not ProxyServer.StartsWithF("http:") Then 
                 Log("[Net] 检测到不支持的代理服务器协议，已忽略系统代理。")
                 GoTo IgnoreSystemProxy

--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -20,7 +20,7 @@
             Return SystemProxy
         End If
 IgnoreSystemProxy:
-        If Not String.IsNullOrWhiteSpace(proxy) AndAlso Not Setup.Get("SystemUseDefaultProxy") Then
+        If Not String.IsNullOrWhiteSpace(proxy) Then
             Log("[Net] 当前代理状态：自定义")
             Dim ProxyUri As New Uri(proxy)
             Try

--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -8,6 +8,7 @@
     Public Function GetProxy()
         Dim proxy As String = Setup.Get("SystemHttpProxy")
         Dim SystemProxy As New WebProxy(WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com")))
+        Log($"[Net] 获取到的系统代理为{WebRequest.GetSystemWebProxy().GetProxy(New Uri("https://www.example.com"))}")
         If SystemProxy IsNot Nothing AndAlso Setup.Get("SystemUseDefaultProxy") Then
             Log("[Net] 当前代理状态：跟随系统代理设置")
             Return SystemProxy


### PR DESCRIPTION
由于 GetProxy 方法会在没有设置系统代理的情况下返回原始地址，导致代理服务器被错误的设置为 https://www.example.com

为此类问题做了缓解性修复，现在不会允许使用非 http 协议代理

Resolve #517 