### PR TITLE
当用户试图更改第三方验证档案的披风时将其引导到皮肤站内修改

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfileSkin.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfileSkin.xaml.vb
@@ -73,6 +73,7 @@
             ChangeSkinMs()
         ElseIf SelectedProfile.Type = McLoginType.Auth Then
             OpenWebsite(SelectedProfile.Server.BeforeFirst("api/yggdrasil/authserver") + "user/closet")
+            Hint("请移步至皮肤站修改！")
         Else
             Hint("当前档案不支持修改皮肤！")
         End If
@@ -89,6 +90,9 @@
     Private Sub BtnSkinCape_Click(sender As Object, e As RoutedEventArgs)
         If SelectedProfile.Type = McLoginType.Ms Then
             Skin.BtnSkinCape_Click()
+        ElseIf SelectedProfile.Type = McLoginType.Auth Then
+            OpenWebsite(SelectedProfile.Server.BeforeFirst("api/yggdrasil/authserver") + "user/closet")
+            Hint("请移步至皮肤站修改！")
         Else
             Hint("当前档案不支持修改披风！")
         End If

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfileSkin.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfileSkin.xaml.vb
@@ -73,7 +73,6 @@
             ChangeSkinMs()
         ElseIf SelectedProfile.Type = McLoginType.Auth Then
             OpenWebsite(SelectedProfile.Server.BeforeFirst("api/yggdrasil/authserver") + "user/closet")
-            Hint("请移步至皮肤站修改！")
         Else
             Hint("当前档案不支持修改皮肤！")
         End If
@@ -92,7 +91,6 @@
             Skin.BtnSkinCape_Click()
         ElseIf SelectedProfile.Type = McLoginType.Auth Then
             OpenWebsite(SelectedProfile.Server.BeforeFirst("api/yggdrasil/authserver") + "user/closet")
-            Hint("请移步至皮肤站修改！")
         Else
             Hint("当前档案不支持修改披风！")
         End If


### PR DESCRIPTION
把“此档案不支持修改”改为在浏览器中打开皮肤站页面并提示"请移步至皮肤站修改"