### PR TITLE
improve: 提升调试体验

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -5,7 +5,7 @@ Imports System.IO.Compression
 
 Public Class Application
 
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
     ''' <summary>
     ''' 用于开始程序时的一些测试。
     ''' </summary>
@@ -53,7 +53,7 @@ Public Class Application
                     Else
                         Environment.Exit((My.Computer.Info.AvailablePhysicalMemory - Ram) / 1024) '返回清理的内存量（K）
                     End If
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
                     '制作更新包
                 ElseIf e.Args(0) = "--edit1" Then
                     ExeEdit(e.Args(1), True)
@@ -83,7 +83,7 @@ Public Class Application
             Directory.CreateDirectory(PathTemp & "Download")
             Directory.CreateDirectory(PathAppdata)
             '检测单例
-#If Not DEBUG1 Then
+#If Not DEBUGRESERVED Then
             Dim ShouldWaitForExit As Boolean = e.Args.Length > 0 AndAlso e.Args(0) = "--wait" '要求等待已有的 PCL 退出
             Dim WaitRetryCount As Integer = 0
 WaitRetry:
@@ -185,7 +185,7 @@ WaitRetry:
             Log("[Start] 第一阶段加载用时：" & GetTimeTick() - ApplicationStartTick & " ms")
             ApplicationStartTick = GetTimeTick()
             '执行测试
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
             Test()
 #End If
             AniControlEnabled += 1

--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -5,7 +5,7 @@ Imports System.IO.Compression
 
 Public Class Application
 
-#If DEBUG Then
+#If DEBUG1 Then
     ''' <summary>
     ''' 用于开始程序时的一些测试。
     ''' </summary>
@@ -53,7 +53,7 @@ Public Class Application
                     Else
                         Environment.Exit((My.Computer.Info.AvailablePhysicalMemory - Ram) / 1024) '返回清理的内存量（K）
                     End If
-#If DEBUG Then
+#If DEBUG1 Then
                     '制作更新包
                 ElseIf e.Args(0) = "--edit1" Then
                     ExeEdit(e.Args(1), True)
@@ -83,7 +83,7 @@ Public Class Application
             Directory.CreateDirectory(PathTemp & "Download")
             Directory.CreateDirectory(PathAppdata)
             '检测单例
-#If Not DEBUG Then
+#If Not DEBUG1 Then
             Dim ShouldWaitForExit As Boolean = e.Args.Length > 0 AndAlso e.Args(0) = "--wait" '要求等待已有的 PCL 退出
             Dim WaitRetryCount As Integer = 0
 WaitRetry:
@@ -185,7 +185,7 @@ WaitRetry:
             Log("[Start] 第一阶段加载用时：" & GetTimeTick() - ApplicationStartTick & " ms")
             ApplicationStartTick = GetTimeTick()
             '执行测试
-#If DEBUG Then
+#If DEBUG1 Then
             Test()
 #End If
             AniControlEnabled += 1

--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -321,7 +321,12 @@ Public Class FormMain
         FrmLaunchRight.PageState = MyPageRight.PageStates.ContentStay
         '模式提醒
 #If DEBUG Then
-        Hint("[开发者模式] PCL 正以开发者模式运行，这可能会造成严重的性能下降，请务必立即向开发者反馈此问题！", HintType.Critical)
+        'Hint("[开发者模式] PCL 正以开发者模式运行，这可能会造成严重的性能下降，请务必立即向开发者反馈此问题！", HintType.Critical)
+        If Environment.GetEnvironmentVariable("PCL_DISABLE_DEBUG_HINT") Is Nothing Then
+            MyMsgBox("当前运行的 PCL2 社区版为开发者版本, " & vbCrLf &
+                     "如果不是社区开发者要求您这么做或您自己想要这么做，请向开发者反馈这个问题" & vbCrLf &
+                     "可以添加 PCL_DISABLE_DEBUG_HINT 环境变量来隐藏这个提示", "开发者版本提示", IsWarn:=True)
+        End If
 #End If
         If ModeDebug Then Hint("[调试模式] PCL 正以调试模式运行，这可能会导致性能下降，若无必要请不要开启！")
         '尽早执行的加载池

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -3186,7 +3186,7 @@ Retry:
 
         '输出提示
         Select Case Level
-#If DEBUG Then
+#If DEBUG1 Then
             Case LogLevel.Developer
                 Hint("[开发者模式] " & Text, HintType.Info, False)
             Case LogLevel.Debug
@@ -3253,7 +3253,7 @@ Retry:
         '输出提示
         Select Case Level
             Case LogLevel.Normal
-#If DEBUG Then
+#If DEBUG1 Then
             Case LogLevel.Developer
                 Dim ExLine As String = Desc & "：" & GetExceptionSummary(Ex)
                 Hint("[开发者模式] " & ExLine, HintType.Info, False)

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -3186,7 +3186,7 @@ Retry:
 
         '输出提示
         Select Case Level
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
             Case LogLevel.Developer
                 Hint("[开发者模式] " & Text, HintType.Info, False)
             Case LogLevel.Debug
@@ -3253,7 +3253,7 @@ Retry:
         '输出提示
         Select Case Level
             Case LogLevel.Normal
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
             Case LogLevel.Developer
                 Dim ExLine As String = Desc & "：" & GetExceptionSummary(Ex)
                 Hint("[开发者模式] " & ExLine, HintType.Info, False)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.vb
@@ -1186,7 +1186,7 @@ Finished:
         Return "Nothing"
     End Function
 
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
     ''' <summary>
     ''' 检查 Mod 列表中存在的错误，返回错误信息的集合。
     ''' </summary>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.vb
@@ -1186,7 +1186,7 @@ Finished:
         Return "Nothing"
     End Function
 
-#If DEBUG Then
+#If DEBUG1 Then
     ''' <summary>
     ''' 检查 Mod 列表中存在的错误，返回错误信息的集合。
     ''' </summary>

--- a/Plain Craft Launcher 2/Modules/ModDevelop.vb
+++ b/Plain Craft Launcher 2/Modules/ModDevelop.vb
@@ -1,6 +1,6 @@
 ﻿Public Module ModDevelop
 
-#If DEBUG Then
+#If DEBUG1 Then
     Public Sub Start()
     End Sub
 #End If

--- a/Plain Craft Launcher 2/Modules/ModDevelop.vb
+++ b/Plain Craft Launcher 2/Modules/ModDevelop.vb
@@ -1,6 +1,6 @@
 ﻿Public Module ModDevelop
 
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
     Public Sub Start()
     End Sub
 #End If

--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -10,20 +10,39 @@ Friend Module ModSecret
 
 #Region "杂项"
 
-#If RELEASE Or BETA Then
-    Public Const RegFolder As String = "PCLCE" 'PCL 社区版的注册表与 PCL 的注册表隔离，以防数据冲突
-#Else
+#If DEBUG Then
     Public Const RegFolder As String = "PCLCEDebug" '社区开发版的注册表与社区常规版的注册表隔离，以防数据冲突
+#Else
+    Public Const RegFolder As String = "PCLCE" 'PCL 社区版的注册表与 PCL 的注册表隔离，以防数据冲突
 #End If
 
     '用于微软登录的 ClientId
+#If DEBUG Then
+    Public OAuthClientId As String = If(Environment.GetEnvironmentVariable("PCL_MS_CLIENT_ID"), "")
+#Else
     Public Const OAuthClientId As String = ""
+#End If
+
     'CurseForge API Key
+#If DEBUG Then
+    Public CurseForgeAPIKey = If(Environment.GetEnvironmentVariable("PCL_CURSEFORGE_API_KEY"), "")
+#Else
     Public Const CurseForgeAPIKey As String = ""
+#End If
+
     'LittleSkin OAuth ClientId
+#If DEBUG Then
+    Public LittleSkinClientId = If(Environment.GetEnvironmentVariable("PCL_LITTLESKIN_CLIENT_ID"), "")
+#Else
     Public Const LittleSkinClientId As String = ""
+#End If
+
     '遥测鉴权密钥
+#If DEBUG Then
+    Public TelemetryKey = If(Environment.GetEnvironmentVariable("PCL_TELEMETRY_KEY"), "")
+#Else
     Public Const TelemetryKey As String = ""
+#End If
 
     Friend Sub SecretOnApplicationStart()
         '提升 UI 线程优先级

--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
@@ -360,7 +360,7 @@
         End Try
     End Sub
 
-#If DEBUG Then
+#If DEBUG1 Then
     ''' <summary>
     ''' 检查 Mod。
     ''' </summary>

--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionCompResource.xaml.vb
@@ -360,7 +360,7 @@
         End Try
     End Sub
 
-#If DEBUG1 Then
+#If DEBUGRESERVED Then
     ''' <summary>
     ''' 检查 Mod。
     ''' </summary>

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -34,7 +34,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>false</DefineDebug>
+    <DefineDebug>true</DefineDebug>
     <DefineTrace>false</DefineTrace>
     <IncrementalBuild>true</IncrementalBuild>
     <OutputPath>.\bin\</OutputPath>
@@ -147,6 +147,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>ARM64</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <DefineDebug>true</DefineDebug>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
     <OutputPath>bin\ARM64\Release\</OutputPath>
@@ -197,6 +198,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <DefineDebug>true</DefineDebug>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>


### PR DESCRIPTION
## 启用 DEBUG 标记并修复上游的历史遗留编译问题

历史遗留是龙猫为了让开源代码能跑直接把 DEBUG 标记删掉了而没有去掉散落在各文件中的一些对已移除代码的调用，见 [HexDragon/PCL2@56cb6bc](https://github.com/Hex-Dragon/PCL2/commit/56cb6bc7d9ab96801c1357f9516bd796f48f0f97#diff-a506f26079ea21d508b421744064ed41baae8620ab2f9c9b88dde5dd5843f36fR38)

这里使用的修复方式是把原本 `#If DEBUG` 但其中代码已没有实际用处的宏改成 `#If DEBUG1`

有些包含在 `#If DEBUG` 宏中的代码目前仍是有实际用处的，所以没有进行更改，比如 Log 模块在 Debug 配置时会调用 `Console.Write()` 向 stdout 输出日志内容

同时为 Debug 配置添加了一个提示弹窗，如果使用的是 Debug 配置的二进制文件就会提醒用户，可以通过添加任意值的 `PCL_DISABLE_DEBUG_HINT` 环境变量来隐藏

## 为 ModSecret.vb 添加自动环境变量读取

当前编译配置为 Debug 时自动从环境变量中读取 secrets 内容而不是直接空着等 CI 填
*注：CI 没有 Debug 配置所以这个更改不会有什么破坏性影响*

现在开发者可以直接添加以下环境变量作为 CI 上 secrets 的值使用：
- `PCL_MS_CLIENT_ID` - 微软登录 ClientId
- `PCL_CURSEFORGE_API_KEY` - CurseForge API Key
- `PCL_LITTLESKIN_CLIENT_ID` - LittleSkin OAuth ClientId (似乎现在已经没用了)
- `PCL_TELEMETRY_KEY` - 遥测鉴权密钥

至于 VS 只支持 .NET 5+ 的 WPF 应用添加环境变量这回事，只能怪曾经 .NET Framework 时代巨硬开发团队的脑子过于原始想不到这种极其先进的功能，这里建议去用已经免费了的 Rider，除了不能热重载，它比 VS Community 好用太多了

替代方案也是有的，[PowerToys](https://github.com/microsoft/powertoys) 提供了一个基于配置文件的环境变量编辑器可以很方便地添加和移除环境变量
注意更改环境变量需要重启 VS 才能在调试中生效

![image](https://github.com/user-attachments/assets/88a0271c-4ab3-45cf-b34e-41bcf05740a4)
