### PR TITLE
优化截图查看页面

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionScreenshot.xaml
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionScreenshot.xaml
@@ -37,7 +37,7 @@
                         <local:MyButton Grid.Column="0" MinWidth="140" Text="打开截图文件夹" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" Click="BtnOpenFolder_Click" ColorType="Highlight"/>
                     </Grid>
                 </local:MyCard>
-                <WrapPanel Margin="8,0,8,25" Name="PanList" HorizontalAlignment="Center" Orientation="Horizontal">
+                <WrapPanel Margin="8,0,8,25" Name="PanList" HorizontalAlignment="Left" Orientation="Horizontal">
                     <!--<local:MyCard Height="220" Width="120" Margin="7" Tag="Path">
             <Grid>
                 <Grid.RowDefinitions>

--- a/Plain Craft Launcher 2/Pages/PageVersion/PageVersionScreenshot.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageVersion/PageVersionScreenshot.xaml.vb
@@ -92,7 +92,7 @@ Public Class PageVersionScreenshot
                 If New FileInfo(i).Length = 0 Then Continue For ' 空文件
                 Dim myCard As New MyCard With {
                 .Height = Double.NaN, ' 允许高度自适应
-                .Width = Double.NaN,  ' 允许宽度自适应
+                .Width = 221.5,  ' 宽度
                 .Margin = New Thickness(7),
                 .Tag = i,
                 .ToolTip = i.Replace(ScreenshotPath, "") '适配高清截图模组
@@ -204,7 +204,8 @@ Public Class PageVersionScreenshot
     End Function
 
     Private Sub btnOpen_Click(sender As MyIconTextButton, e As EventArgs)
-        OpenExplorer(GetPathFromSender(sender))
+        Dim filePath As String = GetPathFromSender(sender)
+        Process.Start(filePath) ' 使用默认程序打开
     End Sub
     Private Sub btnDelete_Click(sender As MyIconTextButton, e As EventArgs)
         Path = GetPathFromSender(sender)


### PR DESCRIPTION
1.修改截图展示卡片的排版，使其在pcl2的默认分辨率(900x550)下可以展示更多内容
2.当用户点击“打开”按钮时，用系统默认图片查看器打开截图
![PixPin_2025-06-06_14-45-03](https://github.com/user-attachments/assets/d8776c38-a713-44ae-82cf-6e3f19f40837)
