### PR TITLE
fix: 长于当前收藏夹的选项名显示不完整

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyComboBox.vb
+++ b/Plain Craft Launcher 2/Controls/MyComboBox.vb
@@ -99,14 +99,17 @@
         End If
     End Sub
 
+    Public Property DropDownWidthSync As Boolean = True
     Private RealWidth As Double '由于下拉框 Popup 宽度与 Width 一致，故不能为 NaN（Auto）
     Private Sub MyComboBox_DropDownOpened(sender As Object, e As EventArgs) Handles Me.DropDownOpened
         RealWidth = Width
-        Width = ActualWidth
+        If DropDownWidthSync Then Width = ActualWidth
         Try
-            CType(Template.FindName("PanPopup", Me), Grid).Opacity = FrmMain.Opacity
+            Dim popup = CType(Template.FindName("PanPopup", Me), Grid)
+            popup.Opacity = FrmMain.Opacity
+            If Not DropDownWidthSync Then popup.MinWidth = ActualWidth
         Catch ex As Exception
-            Log(ex, "设置下拉框透明度失败", LogLevel.Feedback)
+            Log(ex, "设置下拉框属性失败", LogLevel.Feedback)
         End Try
     End Sub
     Private Sub MyComboBox_DropDownClosed(sender As Object, e As EventArgs) Handles Me.DropDownClosed

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml
@@ -16,13 +16,13 @@
                             <local:MySearchBox HintText="搜索收藏夹内容" x:Name="PanSearchBox" Grid.Column="0"/>
                             <local:MyCard Margin="15,0,0,0" Height="40" CanSwap="False" Grid.Column="1">
                                 <StackPanel Orientation="Horizontal">
-                                    <local:MyButton Text=" 管理 " Margin="8,0,4,0" VerticalAlignment="Center" Padding="5" ColorType="Highlight" Click="Manage_Click"/>
-                                    <local:MyComboBox Margin="4,0,8,0" VerticalAlignment="Center" Height="27" x:Name="ComboTargetFav" MaxWidth="180" MinWidth="60">
+                                    <local:MyComboBox Margin="8,0,-1,0" VerticalAlignment="Center" Height="27" x:Name="ComboTargetFav" MaxWidth="160" MinWidth="80" DropDownWidthSync="False">
                                     </local:MyComboBox>
+                                    <local:MyIconButton LogoScale="1.1" Margin="4,8,5,8" VerticalAlignment="Center" x:Name="Btn_ManageTargetFav" ToolTip="管理"/>
                                 </StackPanel>
                             </local:MyCard>
                         </Grid>
-                        <local:MyHint Text="部分资源在线信息获取失败，点此查看详情" IsWarn="True" Margin="0,0,0,15" x:Name="HintGetFail" Visibility="Collapsed"/>
+                        <local:MyHint Text="部分资源在线信息获取失败，点此查看详情" Theme="Yellow" Margin="0,0,0,15" x:Name="HintGetFail" Visibility="Collapsed"/>
                         <StackPanel  x:Name="PanContentList">
                             
                         </StackPanel>

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
@@ -43,6 +43,16 @@
         End Get
     End Property
 
+    Public Sub New()
+        InitializeComponent()
+        '这是选择收藏夹旁边那个图标按钮
+        '实在不想把布局写动态代码里，但是奈何龙猫的石山没办法在 XAML 里定义 Logo 属性为已有常量值
+        '还有一个很扯淡的点，同样自定义的 MyButton 能在 XAML 直接设置 Click 事件
+        '到 MyIconButton 就不行了，死活跑不了，也不知道是不是漏了什么依赖属性没写
+        Btn_ManageTargetFav.Logo = Logo.IconButtonSetup
+        AddHandler Btn_ManageTargetFav.Click, AddressOf Manage_Click
+    End Sub
+
 #Region "UI 化 - 自适应卡片"
     Class CompListItemContainer ' 用来存储自动依据类型生成的卡片及其相关信息
         Public Property Card As MyCard


### PR DESCRIPTION
Close #639
直接让它变长了，没加 ToolTip，因为会飞很远不知道为什么（效果如图）

![68e7b74a8390b6debb8e1f0bbec91f11](https://github.com/user-attachments/assets/04492991-6ffb-47c9-bf69-6f695eba77d4)
