### PR TITLE
chore:降低日志等级

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -1317,7 +1317,7 @@ Re:
         ''' </summary>
         Public Function Check(LocalPath As String) As String
             Try
-                Log($"[Checker] 开始校验文件 {LocalPath}", LogLevel.Debug)
+                Log($"[Checker] 开始校验文件 {LocalPath}", LogLevel.Developer)
                 Dim Info As New FileInfo(LocalPath)
                 If Not Info.Exists Then Return "文件不存在：" & LocalPath
                 Dim FileSize As Long = Info.Length


### PR DESCRIPTION
既然只是开发想看，完全没有必要弄成调试模式等级，这样只会让开了调试模式的用户体验下降（并且大量输出日志还会很卡）