### PR TITLE
perf: 为 HTTP 请求扔出来的异常添加状态属性

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModNet.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModNet.vb
@@ -98,10 +98,15 @@ Public Module ModNet
         Inherits HttpRequestException
         Public ReadOnly Property StatusCode As HttpStatusCode
         Public ReadOnly Property ReasonPhrase As String
-        Public Sub New(statusCode As HttpStatusCode, reasonPhrase As String)
-            MyBase.New($"HTTP 响应失败: {reasonPhrase} ({CType(statusCode, Integer)})")
-            Me.StatusCode = statusCode
-            Me.ReasonPhrase = reasonPhrase
+        ''' <summary>
+        ''' 不要尝试读取 <c>Content</c> 属性的内容，它已经被 dispose 了
+        ''' </summary>
+        Public ReadOnly Property Response As HttpResponseMessage
+        Public Sub New(response As HttpResponseMessage)
+            MyBase.New($"HTTP 响应失败: {response.ReasonPhrase} ({CType(response.StatusCode, Integer)})")
+            Me.Response = response
+            StatusCode = response.StatusCode
+            ReasonPhrase = response.ReasonPhrase
         End Sub
     End Class
     
@@ -131,7 +136,7 @@ Public Module ModNet
     Private Sub EnsureSuccessStatusCode(response As HttpResponseMessage)
         If Not response.IsSuccessStatusCode Then
             response.Content?.Dispose()
-            Throw New HttpRequestFailedException(response.StatusCode, response.ReasonPhrase)
+            Throw New HttpRequestFailedException(response)
         End If
     End Sub
 


### PR DESCRIPTION
可以用来直接判断异常原因而无需解析异常的 `Message` 字符串（比如隔壁修 404 的 PR 里面那个判断就能用上）以提高性能。
考虑兼容性问题，异常类继承自 `HttpRequestException` 以确保原本通过捕获 `HttpRequestException` 解析 `Message` 的判断逻辑正常工作。

这个改动在 .NET 5 已经官方实装，谁知道为什么 Framework 连最新的 4.8.1 都这么原始.... 趁早拥抱 .NET 5+ 吧....