### PR TITLE
fix(PageOtherTest): 添加默认服务器图标处理逻辑

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherTest.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherTest.xaml.vb
@@ -490,6 +490,12 @@ Public Class PageOtherTest
                                                    bitmapImage.EndInit()
                                                End Using
                                                ImgServerLogo.Source = bitmapImage
+                                           Else
+                                               Dim defaultImage As New BitmapImage()
+                                               defaultImage.BeginInit()
+                                               defaultImage.UriSource = New Uri("pack://application:,,,/Plain Craft Launcher 2;component/Images/icon.ico")
+                                               defaultImage.EndInit()
+                                               ImgServerLogo.Source = defaultImage
                                            End If
                                        End Sub)
                                Hint("查询完成", HintType.Finish)


### PR DESCRIPTION
当服务器图标加载失败时，使用应用程序默认图标作为替代，避免界面显示异常。(如果能给我一个MC的就更好了，目前就当broken image处理)