### PR TITLE
fix(ModLaunch): 修复检查存档快捷启动失败的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1363,50 +1363,24 @@ LoginFinish:
 #Region "启动参数"
 
     Public Class LaunchArgument
-        Private _features As New Dictionary(Of String, String)
+        Private _features As New List(Of String)
         Public Sub New(Minecraft As McVersion)
             Dim curArgu As String = String.Empty
             If Minecraft.IsOldJson Then
-                '分隔开参数
-                Dim param = Minecraft.JsonObject("minecraftArguments").ToString.Split(" "c).ToList()
-                For Each p In param
-                    If p.StartsWithF("--") Then
-                        curArgu = p
-                        Continue For
-                    End If
-                    If p.StartsWithF("$") Then
-                        _features.Add(curArgu, p)
-                    End If
-                Next
+                _features = Minecraft.JsonObject("minecraftArguments").ToString.Split(" "c).ToList()
             Else
                 For Each item In Minecraft.JsonObject("arguments")("game")
                     If item.Type = JTokenType.String Then
-                        If item.ToString().StartsWithF("$") Then
-                            curArgu = item.ToString()
-                            Continue For
-                        End If
-                        If item.ToString().StartsWithF("--") Then
-                            _features.Add(curArgu, item.ToString())
-                        End If
+                        _features.Add(item.ToString)
                     ElseIf item.Type = JTokenType.Object Then
-                        For Each values In item("value")
-                            If values.ToString().StartsWithF("--") Then
-                                curArgu = values.ToString()
-                                _features.Add(curArgu, String.Empty)
-                            End If
-                            If values.ToString().StartsWithF("$") AndAlso
-                                _features.ContainsKey(curArgu) AndAlso
-                                String.IsNullOrEmpty(_features(curArgu)) Then
-                                _features(curArgu) = values.ToString()
-                            End If
-                        Next
+                        _features.AddRange(item("value").Select(Function(x) x.ToString))
                     End If
                 Next
             End If
         End Sub
 
         Public Function HasArguments(key As String)
-            Return _features.ContainsKey(key)
+            Return _features.Contains(key)
         End Function
     End Class
 


### PR DESCRIPTION
Closes PCL-Community/PCL2-CE#746

把 `ModLaunch.LaunchArgument` 完全重构了一遍，现在仅使用 `List` 作为启动参数的判断依据。但是在我的电脑上，`1.21.1` 以前会检查失败的核心，现在是没问题的；`1.7.10` 的版本也可以正常检查出无法快捷启动。

如果之后还要调用这个类，读取启动参数信息的话，可能还需要再重写……之前那个版本读出来的 `Dictionary` 完全是炸的。

如有问题请提出，感谢！