### PR TITLE
feat(Markdown): 初步实现 Markdown

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml
+++ b/Plain Craft Launcher 2/Application.xaml
@@ -7,6 +7,9 @@
     ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Resources/Markdown.xaml" />
+            </ResourceDictionary.MergedDictionaries>
             <sys:Double x:Key="BlurValue">16</sys:Double>
             
             <!-- Converter -->

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml
@@ -1,0 +1,39 @@
+﻿<Grid x:Class="MyMsgMarkdown"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:my="clr-namespace:PCL"
+             xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+             RenderTransformOrigin="0,0.5" UseLayoutRounding="True" SnapsToDevicePixels="True" MinWidth="400" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="25">
+    <Grid.RenderTransform>
+        <TransformGroup>
+            <RotateTransform x:Name="TransformRotate" Angle="-4" />
+            <TranslateTransform x:Name="TransformPos" X="0" Y="40" />
+        </TransformGroup>
+    </Grid.RenderTransform>
+    <Border Name="PanBorder" CornerRadius="7" Background="{DynamicResource ColorBrushMsgBox}">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource ColorObjectMsgBoxShadow}" BlurRadius="20" ShadowDepth="2" RenderingBias="Performance" Opacity="0.8" x:Name="EffectShadow" />
+        </Border.Effect>
+        <Grid Name="PanMain" VerticalAlignment="Top" Margin="22,22,22,23">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="2" />
+                <RowDefinition Height="13" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" FontSize="23" TextTrimming="None" Foreground="{DynamicResource ColorBrush2}" HorizontalAlignment="Left" Name="LabTitle" Margin="7,-1,70,9" Text="测试标题文本" VerticalAlignment="Top" SnapsToDevicePixels="False" UseLayoutRounding="False" />
+            <Rectangle x:Name="ShapeLine" Grid.Row="1" Height="2" Fill="{Binding Foreground, ElementName=LabTitle}" />
+            <my:MyScrollViewer Grid.Row="3" VerticalAlignment="Top" x:Name="PanCaption" Margin="0,0,0,17" Padding="7,0,15,0"
+                               VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" DeltaMult="0.7">
+                <markdig:MarkdownViewer VerticalAlignment="Top" Name="LabCaption" FontSize="15"
+                           Foreground="{DynamicResource ColorBrushMsgBoxText}" FontWeight="Normal" Padding="1" />
+            </my:MyScrollViewer>
+            <StackPanel Grid.Row="4" Name="PanBtn" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="150,0,8,0" Orientation="Horizontal">
+                <my:MyButton ColorType="Normal" x:FieldModifier="public" Text="测试按钮1" x:Name="Btn1" Margin="12,0,0,0" TextPadding="7" SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False" />
+                <my:MyButton ColorType="Normal" x:FieldModifier="public" Text="测试按钮2" x:Name="Btn2" Margin="12,0,0,0" TextPadding="7" SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False" />
+                <my:MyButton ColorType="Normal" x:FieldModifier="public" Text="测试按钮3" x:Name="Btn3" Margin="12,0,0,0" TextPadding="7" SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Grid>

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml
@@ -24,10 +24,10 @@
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" FontSize="23" TextTrimming="None" Foreground="{DynamicResource ColorBrush2}" HorizontalAlignment="Left" Name="LabTitle" Margin="7,-1,70,9" Text="测试标题文本" VerticalAlignment="Top" SnapsToDevicePixels="False" UseLayoutRounding="False" />
             <Rectangle x:Name="ShapeLine" Grid.Row="1" Height="2" Fill="{Binding Foreground, ElementName=LabTitle}" />
-            <my:MyScrollViewer Grid.Row="3" VerticalAlignment="Top" x:Name="PanCaption" Margin="0,0,0,17" Padding="7,0,15,0"
+            <my:MyScrollViewer Grid.Row="3" VerticalAlignment="Top" x:Name="PanCaption" Margin="0,0,0,17" Padding="0,0,7,0"
                                VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" DeltaMult="0.7">
-                <markdig:MarkdownViewer VerticalAlignment="Top" Name="LabCaption" FontSize="15"
-                           Foreground="{DynamicResource ColorBrushMsgBoxText}" FontWeight="Normal" Padding="1" />
+                <markdig:MarkdownViewer VerticalAlignment="Top" Name="LabCaption"
+                           Foreground="{DynamicResource ColorBrushMsgBoxText}" FontWeight="Normal" />
             </my:MyScrollViewer>
             <StackPanel Grid.Row="4" Name="PanBtn" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="150,0,8,0" Orientation="Horizontal">
                 <my:MyButton ColorType="Normal" x:FieldModifier="public" Text="测试按钮1" x:Name="Btn1" Margin="12,0,0,0" TextPadding="7" SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False" />

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.vb
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgMarkdown.xaml.vb
@@ -1,0 +1,110 @@
+Imports PCL.Core.Controls
+
+Public Class MyMsgMarkdown
+
+    Private ReadOnly MyConverter As MyMsgBoxConverter
+    Private ReadOnly Uuid As Integer = GetUuid()
+    Public Sub New(Converter As MyMsgBoxConverter)
+        Try
+
+            InitializeComponent()
+            Btn1.Name = Btn1.Name & GetUuid()
+            Btn2.Name = Btn2.Name & GetUuid()
+            Btn3.Name = Btn3.Name & GetUuid()
+            MyConverter = Converter
+            LabTitle.Text = Converter.Title
+            LabCaption.Markdown = Converter.Text
+            DataContext = Me
+            Btn1.Text = Converter.Button1
+            If Converter.IsWarn Then
+                Btn1.ColorType = MyButton.ColorState.Red
+                LabTitle.SetResourceReference(TextBlock.ForegroundProperty, "ColorBrushRedLight")
+            End If
+            Btn2.Text = Converter.Button2
+            Btn3.Text = Converter.Button3
+            Btn2.Visibility = If(Converter.Button2 = "", Visibility.Collapsed, Visibility.Visible)
+            Btn3.Visibility = If(Converter.Button3 = "", Visibility.Collapsed, Visibility.Visible)
+            ShapeLine.StrokeThickness = GetWPFSize(1)
+
+        Catch ex As Exception
+            Log(ex, "普通弹窗初始化失败", LogLevel.Hint)
+        End Try
+    End Sub
+
+    Private Sub Load(sender As Object, e As EventArgs) Handles MyBase.Loaded
+        Try
+
+            'UI 初始化
+            If Btn2.IsVisible AndAlso Not Btn1.ColorType = MyButton.ColorState.Red Then Btn1.ColorType = MyButton.ColorState.Highlight
+            Btn1.Focus()
+            '动画
+            Opacity = 0
+            AniStart(AaColor(FrmMain.PanMsgBackground, BlurBorder.BackgroundProperty, If(MyConverter.IsWarn, New MyColor(140, 80, 0, 0), New MyColor(90, 0, 0, 0)) - FrmMain.PanMsgBackground.Background, 200), "PanMsgBackground Background")
+            AniStart({
+                AaOpacity(Me, 1, 120, 60),
+                AaDouble(Sub(i) TransformPos.Y += i, -TransformPos.Y, 300, 60, New AniEaseOutBack(AniEasePower.Weak)),
+                AaDouble(Sub(i) TransformRotate.Angle += i, -TransformRotate.Angle, 300, 60, New AniEaseOutFluent(AniEasePower.Weak))
+            }, "MyMsgBox " & Uuid)
+            '记录日志
+            Log("[Control] 普通弹窗：" & LabTitle.Text & vbCrLf & LabCaption.Markdown)
+
+        Catch ex As Exception
+            Log(ex, "普通弹窗加载失败", LogLevel.Hint)
+        End Try
+    End Sub
+    Private Sub Close()
+        '结束线程阻塞
+        If MyConverter.ForceWait OrElse Not MyConverter.Button2 = "" Then MyConverter.WaitFrame.Continue = False
+        Interop.ComponentDispatcher.PopModal()
+        '动画
+        AniStart({
+            AaCode(
+            Sub()
+                If Not WaitingMyMsgBox.Any() Then
+                    AniStart(AaColor(FrmMain.PanMsgBackground, BlurBorder.BackgroundProperty, New MyColor(0, 0, 0, 0) - FrmMain.PanMsgBackground.Background, 200, Ease:=New AniEaseOutFluent(AniEasePower.Weak)))
+                End If
+            End Sub, 30),
+            AaOpacity(Me, -Opacity, 80, 20),
+            AaDouble(Sub(i) TransformPos.Y += i, 20 - TransformPos.Y, 150, 0, New AniEaseOutFluent),
+            AaDouble(Sub(i) TransformRotate.Angle += i, 6 - TransformRotate.Angle, 150, 0, New AniEaseInFluent(AniEasePower.Weak)),
+            AaCode(Sub() CType(Parent, Grid).Children.Remove(Me), , True)
+        }, "MyMsgBox " & Uuid)
+    End Sub
+
+    Public Sub Btn1_Click() Handles Btn1.Click
+        If MyConverter.IsExited Then Return
+        If MyConverter.Button1Action IsNot Nothing Then
+            MyConverter.Button1Action()
+        Else
+            MyConverter.IsExited = True
+            MyConverter.Result = 1
+            Close()
+        End If
+    End Sub
+    Public Sub Btn2_Click() Handles Btn2.Click
+        If MyConverter.IsExited Then Return
+        If MyConverter.Button2Action IsNot Nothing Then
+            MyConverter.Button2Action()
+        Else
+            MyConverter.IsExited = True
+            MyConverter.Result = 2
+            Close()
+        End If
+    End Sub
+    Public Sub Btn3_Click() Handles Btn3.Click
+        If MyConverter.IsExited Then Return
+        If MyConverter.Button3Action IsNot Nothing Then
+            MyConverter.Button3Action()
+        Else
+            MyConverter.IsExited = True
+            MyConverter.Result = 3
+            Close()
+        End If
+    End Sub
+
+    Private Sub Drag(sender As Object, e As MouseButtonEventArgs) Handles PanBorder.MouseLeftButtonDown, LabTitle.MouseLeftButtonDown
+        On Error Resume Next
+        If e.GetPosition(ShapeLine).Y <= 2 Then FrmMain.DragMove()
+    End Sub
+
+End Class

--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -18,7 +18,7 @@ Public Class FormMain
             Else
                 Changelog = "欢迎使用呀~"
             End If
-            If MyMsgBox(Changelog, "PCL CE 已更新至 " & VersionBranchName & " " & VersionBaseName, "确定", "完整更新日志") = 2 Then
+            If MyMsgBoxMarkdown(Changelog, "PCL CE 已更新至 " & VersionBranchName & " " & VersionBaseName, "确定", "完整更新日志") = 2 Then
                 OpenWebsite("https://github.com/PCL-Community/PCL2-CE/releases")
             End If
         End Sub, "UpdateLog Output")

--- a/Plain Craft Launcher 2/Modules/ModMain.vb
+++ b/Plain Craft Launcher 2/Modules/ModMain.vb
@@ -231,6 +231,7 @@ EndHint:
         [Select]
         Input
         Login
+        Markdown
     End Enum
 
     ''' <summary>
@@ -251,6 +252,65 @@ EndHint:
                              Optional Button1Action As Action = Nothing, Optional Button2Action As Action = Nothing, Optional Button3Action As Action = Nothing) As Integer
         '将弹窗列入队列
         Dim Converter As New MyMsgBoxConverter With {.Type = MyMsgBoxType.Text, .Button1 = Button1, .Button2 = Button2, .Button3 = Button3, .Text = Caption, .IsWarn = IsWarn, .Title = Title, .HighLight = HighLight, .ForceWait = True, .Button1Action = Button1Action, .Button2Action = Button2Action, .Button3Action = Button3Action}
+        WaitingMyMsgBox.Add(Converter)
+        If RunInUi() Then
+            '若为 UI 线程，立即执行弹窗刻， 避免快速（连点器）点击时多次弹窗
+            MyMsgBoxTick()
+        End If
+        If Button2.Length > 0 OrElse ForceWait Then
+            '若有多个按钮则开始等待
+            If FrmMain Is Nothing OrElse FrmMain.PanMsg Is Nothing AndAlso RunInUi() Then
+                '主窗体尚未加载，用老土的弹窗来替代
+                WaitingMyMsgBox.Remove(Converter)
+                If Button2.Length > 0 Then
+                    Dim RawResult As MsgBoxResult = MsgBox(Caption, If(Button3.Length > 0, MsgBoxStyle.YesNoCancel, MsgBoxStyle.YesNo) + If(IsWarn, MsgBoxStyle.Critical, MsgBoxStyle.Question), Title)
+                    Select Case RawResult
+                        Case MsgBoxResult.Yes
+                            Converter.Result = 1
+                        Case MsgBoxResult.No
+                            Converter.Result = 2
+                        Case MsgBoxResult.Cancel
+                            Converter.Result = 3
+                    End Select
+                Else
+                    MsgBox(Caption, MsgBoxStyle.OkOnly + If(IsWarn, MsgBoxStyle.Critical, MsgBoxStyle.Question), Title)
+                    Converter.Result = 1
+                End If
+                Log("[Control] 主窗体加载完成前出现意料外的等待弹窗：" & Button1 & "," & Button2 & "," & Button3, LogLevel.Debug)
+            Else
+                Try
+                    FrmMain.DragStop()
+                    ComponentDispatcher.PushModal()
+                    Dispatcher.PushFrame(Converter.WaitFrame)
+                Finally
+                    ComponentDispatcher.PopModal()
+                End Try
+            End If
+            Log("[Control] 普通弹框返回：" & If(Converter.Result, "null"))
+            Return Converter.Result
+        Else
+            '不进行等待，直接返回
+            Return 1
+        End If
+    End Function
+    ''' <summary>
+    ''' 显示弹窗，返回点击按钮的编号（从 1 开始）。
+    ''' </summary>
+    ''' <param name="Title">弹窗的标题。</param>
+    ''' <param name="Caption">弹窗的内容。</param>
+    ''' <param name="Button1">显示的第一个按钮，默认为“确定”。</param>
+    ''' <param name="Button2">显示的第二个按钮，默认为空。</param>
+    ''' <param name="Button3">显示的第三个按钮，默认为空。</param>
+    ''' <param name="Button1Action">点击第一个按钮将执行该方法，不关闭弹窗。</param>
+    ''' <param name="Button2Action">点击第二个按钮将执行该方法，不关闭弹窗。</param>
+    ''' <param name="Button3Action">点击第三个按钮将执行该方法，不关闭弹窗。</param>
+    ''' <param name="IsWarn">是否为警告弹窗，若为 True，弹窗配色和背景会变为红色。</param>
+    Public Function MyMsgBoxMarkdown(Caption As String, Optional Title As String = "提示",
+                             Optional Button1 As String = "确定", Optional Button2 As String = "", Optional Button3 As String = "",
+                             Optional IsWarn As Boolean = False, Optional HighLight As Boolean = True, Optional ForceWait As Boolean = False,
+                             Optional Button1Action As Action = Nothing, Optional Button2Action As Action = Nothing, Optional Button3Action As Action = Nothing) As Integer
+        '将弹窗列入队列
+        Dim Converter As New MyMsgBoxConverter With {.Type = MyMsgBoxType.Markdown, .Button1 = Button1, .Button2 = Button2, .Button3 = Button3, .Text = Caption, .IsWarn = IsWarn, .Title = Title, .HighLight = HighLight, .ForceWait = True, .Button1Action = Button1Action, .Button2Action = Button2Action, .Button3Action = Button3Action}
         WaitingMyMsgBox.Add(Converter)
         If RunInUi() Then
             '若为 UI 线程，立即执行弹窗刻， 避免快速（连点器）点击时多次弹窗
@@ -363,6 +423,8 @@ EndHint:
                         FrmMain.PanMsg.Children.Add(New MyMsgText(WaitingMyMsgBox(0)))
                     Case MyMsgBoxType.Login
                         FrmMain.PanMsg.Children.Add(New MyMsgLogin(WaitingMyMsgBox(0)))
+                    Case MyMsgBoxType.Markdown
+                        FrmMain.PanMsg.Children.Add(New MyMsgMarkdown(WaitingMyMsgBox(0)))
                 End Select
                 WaitingMyMsgBox.RemoveAt(0)
             Else

--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherAbout.xaml
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherAbout.xaml
@@ -437,6 +437,8 @@
                         <RowDefinition Height="60" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="60" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="60" />
                     </Grid.RowDefinitions>
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Java Launch Wrapper" TextWrapping="Wrap" FontWeight="Bold" />
                     <TextBlock Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" Text="Copyright © 2022 00ll00&#xa;Licensed under the MIT License." TextWrapping="Wrap" />
@@ -568,6 +570,13 @@ EventType="打开网页" EventData="https://github.com/OrgEleCho/EleCho.WpfSuite
                 EventType="打开网页" EventData="https://github.com/litedb-org/LiteDB" />
                     <local:MyButton Grid.Row="37" Grid.Column="3" MinWidth="140" Text="查看许可文档" Padding="13,0" Margin="0,7,20,18" HorizontalAlignment="Left"
 EventType="打开网页" EventData="https://github.com/litedb-org/LiteDB/blob/master/LICENSE" />
+
+                    <TextBlock Grid.Row="38" Grid.Column="0" Text="Markdig.Wpf" TextWrapping="Wrap" FontWeight="Bold" />
+                    <TextBlock Grid.Row="38" Grid.Column="2" Grid.ColumnSpan="2" Text="Copyright © 2016-2021 Nicolas Musset" TextWrapping="Wrap" />
+                    <local:MyButton Grid.Row="39" Grid.Column="2" MinWidth="140" Text="查看来源网站" Padding="13,0" Margin="0,7,20,18" HorizontalAlignment="Left"
+                EventType="打开网页" EventData="https://github.com/Kryptos-FR/markdig.wpf" />
+                    <local:MyButton Grid.Row="39" Grid.Column="3" MinWidth="140" Text="查看许可文档" Padding="13,0" Margin="0,7,20,18" HorizontalAlignment="Left"
+EventType="打开网页" EventData="https://github.com/Kryptos-FR/markdig.wpf/blob/main/LICENSE.md" />
                 </Grid>
             </local:MyCard>
         </StackPanel>

--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherFeedback.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherFeedback.xaml.vb
@@ -102,7 +102,7 @@
             Dim commonInfo = $"{item.User} | {item.Time} | 类型: {item.Type}"
 
             Dim clickHandler As Action = Sub()
-                                             Select Case MyMsgBox(
+                                             Select Case MyMsgBoxMarkdown(
                                                  $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                                                  $"状态：{item.Tags} | 类型：{item.Type}" & vbCrLf & vbCrLf &
                                                  $"{item.Content}",
@@ -127,7 +127,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -155,7 +155,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -183,7 +183,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -211,7 +211,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -239,7 +239,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -267,7 +267,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -295,7 +295,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -323,7 +323,7 @@
 
                 AddHandler li.Click,
             Sub(sender As Object, e As RoutedEventArgs)
-                Select Case MyMsgBox(
+                Select Case MyMsgBoxMarkdown(
                     $"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）" & vbCrLf &
                     $"类型：{item.Type}" & vbCrLf & vbCrLf &
                     $"{item.Content}",
@@ -339,7 +339,7 @@
             ele.Info = item.User & " | " & item.Time
             ele.Tags = StatusDesc
             AddHandler ele.Click, Sub()
-                                      Select Case MyMsgBox($"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）{vbCrLf}状态：{StatusDesc}{vbCrLf}{vbCrLf}{item.Content}",
+                                      Select Case MyMsgBoxMarkdown($"提交者：{item.User}（{GetTimeSpanString(item.Time - DateTime.Now, False)}）{vbCrLf}状态：{StatusDesc}{vbCrLf}{vbCrLf}{item.Content}",
                                                "#" & item.ID & " " & item.Title,
                                                Button2:="查看详情")
                                           Case 2

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -284,6 +284,9 @@
       <DependentUpon>MyExtraTextButton.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\MyImage.vb" />
+    <Compile Include="Controls\MyMsg\MyMsgMarkdown.xaml.vb">
+      <DependentUpon>MyMsgMarkdown.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\MyPageRight.vb" />
     <Compile Include="Controls\MyPageLeft.vb" />
     <Compile Include="Controls\MyIconTextButton.xaml.vb">
@@ -583,6 +586,10 @@
     <Page Include="Controls\MyMsg\MyMsgSelect.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\MyMsg\MyMsgMarkdown.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Controls\MyMsg\MyMsgText.xaml">
       <SubType>Designer</SubType>
@@ -911,6 +918,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Resources\Markdown.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Import Include="Microsoft.VisualBasic" />
@@ -1157,6 +1168,9 @@
     </PackageReference>
     <PackageReference Include="LiteDB">
       <Version>5.0.21</Version>
+    </PackageReference>
+    <PackageReference Include="Markdig.Wpf">
+      <Version>0.5.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
       <Version>4.72.1</Version>

--- a/Plain Craft Launcher 2/Resources/Markdown.xaml
+++ b/Plain Craft Launcher 2/Resources/Markdown.xaml
@@ -8,7 +8,9 @@
         <Setter Property="FontSize" Value="15" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="LineStackingStrategy" Value="BlockLineHeight" />
-        <Setter Property="ContextMenuService.IsEnabled" Value="False"/>
+        <Setter Property="VirtualizingPanel.IsVirtualizing" Value="True"/>
+        <Setter Property="VirtualizingPanel.UseLayoutRounding" Value="True"/>
+        <Setter Property="VirtualizingPanel.VirtualizationMode" Value="Recycling"/>
     </Style>
 
     <!-- 紧凑段落样式 -->
@@ -25,7 +27,7 @@
 
     <!-- 代码块样式 -->
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.CodeBlockStyleKey}">
-        <Setter Property="Background" Value="{DynamicResource ColorBrush8}" />
+        <Setter Property="Background" Value="{DynamicResource ColorBrush6}" />
         <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
         <Setter Property="Margin" Value="0,6,0,6" />
         <Setter Property="Padding" Value="8,6,8,6" />
@@ -33,7 +35,7 @@
 
     <!-- 行内代码样式 -->
     <Style TargetType="{x:Type Run}" x:Key="{x:Static markdig:Styles.CodeStyleKey}">
-        <Setter Property="Background" Value="{DynamicResource ColorBrush8}" />
+        <Setter Property="Background" Value="{DynamicResource ColorBrush6}" />
         <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
     </Style>
 
@@ -52,27 +54,25 @@
 
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading3StyleKey}">
         <Setter Property="FontSize" Value="18" />
-        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Margin" Value="0,8,0,4" />
     </Style>
 
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading4StyleKey}">
         <Setter Property="FontSize" Value="16" />
-        <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="TextDecorations" Value="Underline" />
+        <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Margin" Value="0,6,0,4" />
     </Style>
 
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading5StyleKey}">
         <Setter Property="FontSize" Value="14" />
-        <Setter Property="FontWeight" Value="Bold" />
-        <Setter Property="FontStyle" Value="Italic" />
+        <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Margin" Value="0,4,0,4" />
     </Style>
 
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading6StyleKey}">
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="Foreground" Value="{DynamicResource ColorBrushGray5}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Margin" Value="0,4,0,4" />
     </Style>
 
@@ -90,6 +90,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ColorBrushGray5}" />
         <Setter Property="BorderThickness" Value="2,0,0,0" />
         <Setter Property="Foreground" Value="{DynamicResource ColorBrushGray2}" />
+        <Setter Property="Background" Value="{DynamicResource ColorBrushGray7}"/>
         <Setter Property="Padding" Value="8,2,0,2" />
         <Setter Property="Margin" Value="0,4,0,4" />
     </Style>
@@ -110,7 +111,11 @@
 
     <Style TargetType="{x:Type TableRow}" x:Key="{x:Static markdig:Styles.TableHeaderStyleKey}">
         <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="Background" Value="{DynamicResource ColorBrush8}"/>
+        <Setter Property="Background" Value="{DynamicResource ColorBrushGray6}"/>
+    </Style>
+
+    <Style TargetType="{x:Type CheckBox}" x:Key="{x:Static markdig:Styles.TaskListStyleKey}">
+        <Setter Property="Margin" Value="0,0,0,-2" />
     </Style>
 
     <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.SubscriptStyleKey}">
@@ -121,12 +126,13 @@
     </Style>
     <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.StrikeThroughStyleKey}">
         <Setter Property="TextBlock.TextDecorations" Value="Strikethrough" />
+        <Setter Property="Foreground" Value="{DynamicResource ColorBrushGray4}"/>
     </Style>
     <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.InsertedStyleKey}">
         <Setter Property="TextBlock.TextDecorations" Value="Underline" />
     </Style>
     <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.MarkedStyleKey}">
-        <Setter Property="Background" Value="{DynamicResource ColorBrush4}"/>
+        <Setter Property="Background" Value="{DynamicResource ColorBrush5}"/>
     </Style>
 
     <!-- MarkdownViewer模板优化 -->
@@ -135,8 +141,10 @@
             <Setter.Value>
                 <ControlTemplate TargetType="markdig:MarkdownViewer">
                     <FlowDocumentScrollViewer 
-            Document="{TemplateBinding Document}"
-            ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                        Document="{TemplateBinding Document}"
+                        ScrollViewer.VerticalScrollBarVisibility="Auto"
+                        ContextMenu="{x:Null}"
+                        SelectionBrush="{DynamicResource ColorBrush6}"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/Plain Craft Launcher 2/Resources/Markdown.xaml
+++ b/Plain Craft Launcher 2/Resources/Markdown.xaml
@@ -1,0 +1,122 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf">
+
+    <!-- 基础文档样式 -->
+    <Style TargetType="{x:Type FlowDocument}" x:Key="{x:Static markdig:Styles.DocumentStyleKey}">
+        <Setter Property="FontFamily" Value="Segoe UI, Microsoft YaHei UI, Meiryo UI, sans-serif" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="LineStackingStrategy" Value="BlockLineHeight" />
+    </Style>
+
+    <!-- 紧凑段落样式 -->
+    <Style TargetType="{x:Type Paragraph}">
+        <Setter Property="Margin" Value="0,4,0,4" />
+        <Setter Property="TextIndent" Value="0" />
+    </Style>
+
+    <!-- 列表样式 -->
+    <Style TargetType="{x:Type List}">
+        <Setter Property="Margin" Value="24,2,0,2" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+
+    <!-- 代码块样式 -->
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.CodeBlockStyleKey}">
+        <Setter Property="Background" Value="#FFF5F5F5" />
+        <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
+        <Setter Property="Margin" Value="0,6,0,6" />
+        <Setter Property="Padding" Value="8,6,8,6" />
+    </Style>
+
+    <!-- 行内代码样式 -->
+    <Style TargetType="{x:Type Run}" x:Key="{x:Static markdig:Styles.CodeStyleKey}">
+        <Setter Property="Background" Value="#FFF5F5F5" />
+        <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
+    </Style>
+
+    <!-- 标题样式优化 -->
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading1StyleKey}">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Margin" Value="0,12,0,8" />
+    </Style>
+
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading2StyleKey}">
+        <Setter Property="FontSize" Value="20" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Margin" Value="0,10,0,6" />
+    </Style>
+
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading3StyleKey}">
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="Margin" Value="0,8,0,4" />
+    </Style>
+
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading4StyleKey}">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="TextDecorations" Value="Underline" />
+        <Setter Property="Margin" Value="0,6,0,4" />
+    </Style>
+
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading5StyleKey}">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="FontStyle" Value="Italic" />
+        <Setter Property="Margin" Value="0,4,0,4" />
+    </Style>
+
+    <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading6StyleKey}">
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Foreground" Value="#FF666666" />
+        <Setter Property="Margin" Value="0,4,0,4" />
+    </Style>
+
+    <!-- 引用块样式 -->
+    <Style TargetType="{x:Type Section}" x:Key="{x:Static markdig:Styles.QuoteBlockStyleKey}">
+        <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+        <Setter Property="BorderThickness" Value="2,0,0,0" />
+        <Setter Property="Foreground" Value="#FF555555" />
+        <Setter Property="Padding" Value="8,2,0,2" />
+        <Setter Property="Margin" Value="0,4,0,4" />
+    </Style>
+
+    <!-- 表格样式优化 -->
+    <Style TargetType="{x:Type Table}" x:Key="{x:Static markdig:Styles.TableStyleKey}">
+        <Setter Property="BorderBrush" Value="#FFAAAAAA"/>
+        <Setter Property="BorderThickness" Value="0,0,1,1"/>
+        <Setter Property="CellSpacing" Value="0"/>
+        <Setter Property="Margin" Value="0,6,0,6"/>
+    </Style>
+
+    <Style TargetType="{x:Type TableCell}" x:Key="{x:Static markdig:Styles.TableCellStyleKey}">
+        <Setter Property="BorderBrush" Value="#FFAAAAAA"/>
+        <Setter Property="BorderThickness" Value="1,1,0,0"/>
+        <Setter Property="Padding" Value="4,2"/>
+    </Style>
+
+    <Style TargetType="{x:Type TableRow}" x:Key="{x:Static markdig:Styles.TableHeaderStyleKey}">
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Background" Value="#FFF0F0F0"/>
+    </Style>
+
+    <!-- 其他样式保持 -->
+    <!-- ... 保持原有的Hyperlink, Image, CheckBox等样式 ... -->
+
+    <!-- MarkdownViewer模板优化 -->
+    <Style TargetType="markdig:MarkdownViewer">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="markdig:MarkdownViewer">
+                    <FlowDocumentScrollViewer 
+            Document="{TemplateBinding Document}"
+            ScrollViewer.VerticalScrollBarVisibility="Auto"
+            Padding="8"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/Plain Craft Launcher 2/Resources/Markdown.xaml
+++ b/Plain Craft Launcher 2/Resources/Markdown.xaml
@@ -5,9 +5,10 @@
     <!-- 基础文档样式 -->
     <Style TargetType="{x:Type FlowDocument}" x:Key="{x:Static markdig:Styles.DocumentStyleKey}">
         <Setter Property="FontFamily" Value="Segoe UI, Microsoft YaHei UI, Meiryo UI, sans-serif" />
-        <Setter Property="FontSize" Value="14" />
+        <Setter Property="FontSize" Value="15" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="LineStackingStrategy" Value="BlockLineHeight" />
+        <Setter Property="ContextMenuService.IsEnabled" Value="False"/>
     </Style>
 
     <!-- 紧凑段落样式 -->
@@ -24,7 +25,7 @@
 
     <!-- 代码块样式 -->
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.CodeBlockStyleKey}">
-        <Setter Property="Background" Value="#FFF5F5F5" />
+        <Setter Property="Background" Value="{DynamicResource ColorBrush8}" />
         <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
         <Setter Property="Margin" Value="0,6,0,6" />
         <Setter Property="Padding" Value="8,6,8,6" />
@@ -32,7 +33,7 @@
 
     <!-- 行内代码样式 -->
     <Style TargetType="{x:Type Run}" x:Key="{x:Static markdig:Styles.CodeStyleKey}">
-        <Setter Property="Background" Value="#FFF5F5F5" />
+        <Setter Property="Background" Value="{DynamicResource ColorBrush8}" />
         <Setter Property="FontFamily" Value="Consolas, Courier New, monospace" />
     </Style>
 
@@ -71,40 +72,62 @@
 
     <Style TargetType="{x:Type Paragraph}" x:Key="{x:Static markdig:Styles.Heading6StyleKey}">
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="Foreground" Value="#FF666666" />
+        <Setter Property="Foreground" Value="{DynamicResource ColorBrushGray5}" />
         <Setter Property="Margin" Value="0,4,0,4" />
+    </Style>
+
+    <Style TargetType="{x:Type Hyperlink}" x:Key="{x:Static markdig:Styles.HyperlinkStyleKey}">
+        <Setter Property="Foreground" Value="{DynamicResource ColorBrush4}"/>
+    </Style>
+
+    <Style TargetType="{x:Type Line}" x:Key="{x:Static markdig:Styles.ThematicBreakStyleKey}">
+        <Setter Property="Stretch" Value="Fill" />
+        <Setter Property="Stroke" Value="{DynamicResource ColorBrush5}" />
     </Style>
 
     <!-- 引用块样式 -->
     <Style TargetType="{x:Type Section}" x:Key="{x:Static markdig:Styles.QuoteBlockStyleKey}">
-        <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ColorBrushGray5}" />
         <Setter Property="BorderThickness" Value="2,0,0,0" />
-        <Setter Property="Foreground" Value="#FF555555" />
+        <Setter Property="Foreground" Value="{DynamicResource ColorBrushGray2}" />
         <Setter Property="Padding" Value="8,2,0,2" />
         <Setter Property="Margin" Value="0,4,0,4" />
     </Style>
 
     <!-- 表格样式优化 -->
     <Style TargetType="{x:Type Table}" x:Key="{x:Static markdig:Styles.TableStyleKey}">
-        <Setter Property="BorderBrush" Value="#FFAAAAAA"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ColorBrushGray3}"/>
         <Setter Property="BorderThickness" Value="0,0,1,1"/>
         <Setter Property="CellSpacing" Value="0"/>
         <Setter Property="Margin" Value="0,6,0,6"/>
     </Style>
 
     <Style TargetType="{x:Type TableCell}" x:Key="{x:Static markdig:Styles.TableCellStyleKey}">
-        <Setter Property="BorderBrush" Value="#FFAAAAAA"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ColorBrushGray3}"/>
         <Setter Property="BorderThickness" Value="1,1,0,0"/>
         <Setter Property="Padding" Value="4,2"/>
     </Style>
 
     <Style TargetType="{x:Type TableRow}" x:Key="{x:Static markdig:Styles.TableHeaderStyleKey}">
         <Setter Property="FontWeight" Value="SemiBold"/>
-        <Setter Property="Background" Value="#FFF0F0F0"/>
+        <Setter Property="Background" Value="{DynamicResource ColorBrush8}"/>
     </Style>
 
-    <!-- 其他样式保持 -->
-    <!-- ... 保持原有的Hyperlink, Image, CheckBox等样式 ... -->
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.SubscriptStyleKey}">
+        <Setter Property="Typography.Variants" Value="Subscript" />
+    </Style>
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.SuperscriptStyleKey}">
+        <Setter Property="Typography.Variants" Value="Superscript" />
+    </Style>
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.StrikeThroughStyleKey}">
+        <Setter Property="TextBlock.TextDecorations" Value="Strikethrough" />
+    </Style>
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.InsertedStyleKey}">
+        <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+    </Style>
+    <Style TargetType="{x:Type Span}" x:Key="{x:Static markdig:Styles.MarkedStyleKey}">
+        <Setter Property="Background" Value="{DynamicResource ColorBrush4}"/>
+    </Style>
 
     <!-- MarkdownViewer模板优化 -->
     <Style TargetType="markdig:MarkdownViewer">
@@ -113,8 +136,7 @@
                 <ControlTemplate TargetType="markdig:MarkdownViewer">
                     <FlowDocumentScrollViewer 
             Document="{TemplateBinding Document}"
-            ScrollViewer.VerticalScrollBarVisibility="Auto"
-            Padding="8"/>
+            ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
有一些 UI 问题还没优化

~~今天为了实现 Markdown 懂了下这个 MsgBox，发现实现有点 uhhh~~

Close https://github.com/PCL-Community/PCL2-CE/issues/903

# Markdig.WPF 渲染测试文档

这是一个用于测试 Markdig.WPF 渲染能力的综合 Markdown 文档，包含各种常见元素和复杂结构。

## 文本样式测试

- **粗体文本**
- *斜体文本*
- ***粗斜体文本***
- ~~删除线文本~~
- `行内代码`
- <u>下划线文本</u>
- H~2~O (下标)
- x^2^ (上标)
- 高亮文本 ==标记重要内容==

## 标题层级测试

### 三级标题
#### 四级标题
##### 五级标题
###### 六级标题

## 列表测试

### 无序列表
- 列表项 1
- 列表项 2
  - 嵌套列表项 A
  - 嵌套列表项 B
    - 更深嵌套项
- 列表项 3

### 有序列表
1. 第一项
2. 第二项
   1. 嵌套有序项 A
   2. 嵌套有序项 B
3. 第三项

### 任务列表
- [x] 已完成任务
- [ ] 未完成任务
- [ ] 另一个未完成任务

## 代码块测试

```csharp
// C# 代码示例
public class Program
{
    public static void Main()
    {
        Console.WriteLine("Hello, Markdig!");
        var result = Calculate(5, 3);
    }
    
    private static int Calculate(int a, int b) 
    {
        return a * b + 10;
    }
}
```

```python
# Python 代码示例
def fibonacci(n):
    a, b = 0, 1
    for _ in range(n):
        yield a
        a, b = b, a + b

print(list(fibonacci(10)))
```

## 表格测试

| 功能        | 状态      | 备注        |
|-------------|-----------|-------------|
| 标题渲染    | ✔️ 支持   | 6级标题     |
| 代码块      | ✔️ 支持   | 语法高亮    |
| 表格        | ✔️ 支持   | 基本格式    |
| 任务列表    | ✔️ 支持   |             |
| 数学公式    | ❌ 不支持  | 需扩展      |

## 引用与分隔线

> 这是一个引用块。它应该具有特殊的样式和缩进，以区别于普通文本。
> 
> 多行引用示例：
> 第二行引用内容

---

## 链接与图片测试

### 外部链接
- [Markdig GitHub 仓库](https://github.com/lunet-io/markdig)
- [WPF 文档](https://docs.microsoft.com/en-us/dotnet/desktop/wpf/)

### 图片
![示例图片](https://picsum.photos/600/200)

### 带标题图片
![编程艺术](https://picsum.photos/600/200 "编程是一门艺术")

## 复杂结构测试

### 组合元素
1. **混合列表项**
   - 包含`行内代码`
   - 包含*斜体文本*
   - 包含[链接示例](#)
   
> 引用中的列表：
> - 引用列表项 1
> - 引用列表项 2
>   - 嵌套引用列表
