### PR TITLE
fix(PageDownloadCompFavorites): #1023 修复编辑备注时空值导致的问题  修改备注编辑逻辑，当输入为空时不再覆盖原有备注，并正确显示当前备注内容

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
@@ -225,8 +225,11 @@
         AddHandler Btn_EditNote.Click, Sub(sender As Object, e As EventArgs)
                                            CurrentFavTarget.Notes.TryGetValue(CompId, Notes)
                                            Dim DesiredNote = MyMsgBoxInput("修改备注", DefaultInput:=Notes)
-                                           CurrentFavTarget.Notes(CompId) = DesiredNote
-                                           NoteItem.Text = If(String.IsNullOrWhiteSpace(DesiredNote), "", $" ({DesiredNote})")
+                                           If Not String.IsNullOrWhiteSpace(DesiredNote) Then
+                                               CurrentFavTarget.Notes(CompId) = DesiredNote
+                                           End If
+                                           CurrentFavTarget.Notes.TryGetValue(CompId, Notes)
+                                           NoteItem.Text = If(String.IsNullOrWhiteSpace(Notes), "", $" ({Notes})")
                                            CompFavorites.Save()
                                        End Sub
         '删除按钮


### PR DESCRIPTION
…mpFavorites.xaml.vb