### PR TITLE
fix(SavesInfo): 修复1.4版本以下存档信息获取出错

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml
@@ -8,6 +8,7 @@
         <StackPanel Margin="25,10,25,10" x:Name="PanMain">
             <local:MyHint x:Name="Hintversion1_9" Theme="Yellow" Grid.Row="0" Visibility="Collapsed" Margin="0,5,0,0"/>
             <local:MyHint x:Name="Hintversion1_8" Theme="Yellow" Grid.Row="0" Visibility="Collapsed" Margin="0,5,0,0"/>
+            <local:MyHint x:Name="Hintversion1_3" Theme="Yellow" Grid.Row="0" Visibility="Collapsed" Margin="0,5,0,0"/>
             <local:MyCard Margin="0,15,0,0" Title="存档详细信息" x:Name="PanContent">
                 <Grid Margin="15,35,15,15" x:Name="PanList">
                     <Grid.RowDefinitions>


### PR DESCRIPTION
修复1.4版本以下存档信息获取出错

<img width="1095" height="689" alt="image" src="https://github.com/user-attachments/assets/5b063430-147b-4e8d-8f4a-718878402806" />

加入 1.3版本以下无法获取是否允许作弊的提示，删除未使用的 dayTimeTicks 变量导致1.4版本获取存档信息报错，顺便移除了一些多余判断