### PR TITLE
imp(PageLoginMs): 隐藏不可用的返回按钮

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginMs.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginMs.xaml.vb
@@ -4,7 +4,7 @@
     End Sub
     Private Sub BtnLogin_Click(sender As Object, e As EventArgs) Handles BtnLogin.Click
         BtnLogin.IsEnabled = False
-        BtnBack.IsEnabled = False
+        BtnBack.Visibility = Visibility.Collapsed
         BtnLogin.Text = "0%"
         RunInNewThread(
         Sub()
@@ -38,7 +38,7 @@
                 RunInUi(
                 Sub()
                     BtnLogin.IsEnabled = True
-                    BtnBack.IsEnabled = True
+                    BtnBack.Visibility = Visibility.Visible
                     BtnLogin.Text = "登录"
                 End Sub)
             End Try


### PR DESCRIPTION
我觉得吧，既然这个返回按钮登录加载时就用不了了，那不如直接隐藏，否则看着和可以用一样，有误导性