### PR TITLE
fix(constant) typo: misspelled `mcimirror` as `mcimirrmr`

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -1398,7 +1398,7 @@
                 Return NetGetCodeByRequestOnce(Source.Key, Encode:=Encoding.UTF8, Timeout:=Source.Value * 1000, IsJson:=IsJson, UseBrowserUserAgent:=True)
             Catch ex As Exception
                 ' 镜像源可能随机爆炸，忽略就好
-                If Not ex.Message.ContainsF("mcimirrmr") Then
+                If Not ex.Message.ContainsF("mcimirror") Then
                     Exs += ex.Message + vbCrLf
                 End If
             End Try


### PR DESCRIPTION
as title