### PR TITLE
fix: 修复 Shell 打开路径行为

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModEvent.vb
+++ b/Plain Craft Launcher 2/Modules/ModEvent.vb
@@ -45,7 +45,8 @@
                                 Dim Info As New ProcessStartInfo With {
                                     .Arguments = If(Data.Length >= 2, Data(1), ""),
                                     .FileName = Location,
-                                    .WorkingDirectory = ShortenPath(WorkingDir)
+                                    .WorkingDirectory = ShortenPath(WorkingDir),
+                                    .UseShellExecute = True
                                 }
                                 Process.Start(Info)
                             End If

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceScreenshot.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceScreenshot.xaml.vb
@@ -1,5 +1,6 @@
 ﻿
 Imports Microsoft.VisualBasic.FileIO
+Imports PCL.Core.App
 
 Public Class PageInstanceScreenshot
     Implements IRefreshable
@@ -124,7 +125,7 @@ Public Class PageInstanceScreenshot
                 image.Cursor = Cursors.Hand
                 AddHandler image.MouseLeftButtonDown, Sub(sender, e)
                     Try
-                        Process.Start(i) ' 使用系统默认程序打开
+                        Basics.OpenPath(i) ' 使用系统默认程序打开
                     Catch ex As Exception
                         Log(ex, "打开截图失败！", LogLevel.Hint)
                     End Try

--- a/Plain Craft Launcher 2/Pages/PageOther/PageOtherTest.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageOther/PageOtherTest.xaml.vb
@@ -399,7 +399,7 @@ Public Class PageOtherTest
         Try
             Dim text As String = TextDownloadFolder.Text
             Directory.CreateDirectory(text)
-            Process.Start(text)
+            Basics.OpenPath(text)
         Catch ex As Exception
             Log(ex, "打开下载文件夹失败", ModBase.LogLevel.Debug, "出现错误")
         End Try

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
@@ -1,4 +1,6 @@
-﻿Class PageSetupSystem
+﻿Imports PCL.Core.App
+
+Class PageSetupSystem
 
     Private Shadows IsLoaded As Boolean = False
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
@@ -1,6 +1,4 @@
-﻿Imports PCL.Core.App
-
-Class PageSetupSystem
+﻿Class PageSetupSystem
 
     Private Shadows IsLoaded As Boolean = False
 


### PR DESCRIPTION
把一些应该 `UseShellExecute = True` 然而没用的地方换成了 Core 的 `Basics.OpenPath` 引用