### PR TITLE
fix(authlib): 第三方登录使用拖拽设置服务器下无法选择其他角色登录

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -643,6 +643,7 @@ Public Class FormMain
                             Return
                         End If
                         If MyMsgBox($"是否要创建新的第三方验证档案？{vbCrLf}验证服务器地址：{AuthlibServer}", "创建新的第三方验证档案", "确定", "取消") = 2 Then Exit Sub
+                        SelectedProfile = Nothing
                         RunInUi(Sub()
                                     PageLoginAuth.DraggedAuthServer = AuthlibServer
                                     FrmLaunchLeft.RefreshPage(True, McLoginType.Auth)


### PR DESCRIPTION
Resolve #1323 