### PR TITLE
feat: 禁止 "禁用 SSL 证书校验"

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -173,7 +173,6 @@ WaitRetry:
             Setup.Load("SystemHttpProxyCustomUsername")
             Setup.Load("SystemHttpProxyType")
             Setup.Load("ToolDownloadThread")
-            Setup.Load("ToolDownloadCert")
             Setup.Load("ToolDownloadSpeed")
             Setup.Load("UiFont")
             If SetupService.IsUnset(SetupEntries.System.UpdateBranch) Then

--- a/Plain Craft Launcher 2/Modules/Base/ModSetup.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModSetup.vb
@@ -130,22 +130,6 @@ Public Class ModSetup
     Public Sub ToolDownloadThread(Value As Integer)
         NetTaskThreadLimit = Value + 1
     End Sub
-    Public Sub ToolDownloadCert(Value As Boolean)
-        ServicePointManager.ServerCertificateValidationCallback =
-        Function(Sender, Certificate, Chain, Failure)
-            Dim Request As HttpWebRequest = TryCast(Sender, HttpWebRequest)
-            If Failure = Net.Security.SslPolicyErrors.None Then Return True '已通过验证
-            '基于 #3018 和 #5879，只在访问正版登录 API 时跳过证书验证
-            Log($"[System] 未通过 SSL 证书验证（{Failure}），提供的证书为 {Certificate?.Subject}，URL：{Request?.Address}", LogLevel.Debug)
-            If Request Is Nothing Then
-                Return Not Value
-            ElseIf Request.Address.Host.Contains("xboxlive") OrElse Request.Address.Host.Contains("minecraftservices") Then
-                Return Not Value '根据设置决定是否忽略错误
-            Else
-                Return False
-            End If
-        End Function
-    End Sub
     Public Sub ToolDownloadSpeed(Value As Integer)
         If Value <= 14 Then
             NetTaskSpeedLimitHigh = (Value + 1) * 0.1 * 1024 * 1024L

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
@@ -444,7 +444,7 @@ PreFin:
             LabServerAuthServerSecurityCL.Visibility = Visibility.Collapsed
             LabServerAuthServerSecurityVerify.Visibility = Visibility.Collapsed
             ' 如果开头为 http:// 给予警告
-        ElseIf TextServerAuthServer.Text.StartsWithF("https://") AndAlso Setup.Get("ToolDownloadCert") = "False" Then
+        ElseIf TextServerAuthServer.Text.StartsWithF("https://") Then
             LabServerAuthServerSecurity.Visibility = Visibility.Collapsed
             LabServerAuthServerSecurityVerify.Visibility = Visibility.Visible
             LabServerAuthServerSecurityCL.Visibility = Visibility.Visible

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
@@ -217,15 +217,10 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="28" />
                         <RowDefinition Height="9" />
-                        <RowDefinition Height="28" />
-                        <RowDefinition Height="9" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <local:MyCheckBox Margin="0,2,0,4" Text="验证 SSL 证书" Grid.Row="0" Height="22" Grid.Column="0" Grid.ColumnSpan="2"
-                                    x:Name="CheckDownloadCert" Tag="ToolDownloadCert"
-                                    ToolTip="开启验证会提高安全性、降低盗号风险（见 #2767），但也可能导致正版登录失败（见 #3018）。" />
-                    <TextBlock Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Left" Text="HTTP 代理" Margin="0,0,25,0" />
-                    <Grid Grid.Row="2" Grid.Column="1">
+                    <TextBlock Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Left" Text="HTTP 代理" Margin="0,0,25,0" />
+                    <Grid Grid.Row="0" Grid.Column="1">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="1*" />
                             <ColumnDefinition Width="1*" />
@@ -236,7 +231,7 @@
                         <local:MyRadioBox Text="使用系统代理" x:Name="RadioHttpProxyType1" Height="22" Tag="SystemHttpProxyType/1" Grid.Column="1" />
                         <local:MyRadioBox Text="自定义代理" x:Name="RadioHttpProxyType2" Height="22" Tag="SystemHttpProxyType/2" Grid.Column="2" />
                     </Grid>
-                    <Grid Grid.Row="4" Grid.Column="1" x:Name="HttpProxyCustom" Visibility="{Binding ElementName=RadioHttpProxyType2,Path=Checked,Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid Grid.Row="2" Grid.Column="1" x:Name="HttpProxyCustom" Visibility="{Binding ElementName=RadioHttpProxyType2,Path=Checked,Converter={StaticResource BooleanToVisibilityConverter}}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="28"/>
                             <RowDefinition Height="9"/>
@@ -252,12 +247,12 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <local:MyHint Text="请勿填写不信任的代理地址" Grid.Row="0" Grid.ColumnSpan="5" Theme="Yellow"/>
-                        <local:MyTextBox x:Name="TextSystemHttpProxy" Grid.Row="2" Grid.ColumnSpan="5" Tag="SystemHttpProxy" HintText="比如 http://127.0.0.1:1080/" ToolTip="不正确的代理服务器地址会导致无法连接网络，因使用代理导致的网络问题不予处理。&#xa;请勿填写不信任的代理服务器地址，这可能会导致你的账号信息泄露，甚至账号被盗。"/>
+                        <local:MyTextBox x:Name="TextSystemHttpProxy" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="5" Tag="SystemHttpProxy" HintText="比如 http://127.0.0.1:1080/" ToolTip="不正确的代理服务器地址会导致无法连接网络，因使用代理导致的网络问题不予处理。&#xa;请勿填写不信任的代理服务器地址，这可能会导致你的账号信息泄露，甚至账号被盗。"/>
                         <TextBlock Grid.Column="0" Grid.Row="4" Text="账号" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0,5,0"/>
                         <local:MyTextBox Grid.Column="1" Grid.Row="4" HintText="如有" Tag="SystemHttpProxyCustomUsername" x:Name="TextSystemHttpProxyCustomUsername" Margin="0,0,5,0"/>
                         <TextBlock Grid.Column="2" Grid.Row="4" Text="密码" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0,5,0"/>
                         <local:MyTextBox Grid.Column="3" Grid.Row="4" HintText="如有" Tag="SystemHttpProxyCustomPassword" x:Name="TextSystemHttpProxyCustomPassword" Margin="0,0,5,0"/>
-                        <local:MyButton Text="应用代理信息" TextPadding="3" Grid.Row="4" Grid.Column="5" x:Name="BtnApplyHttpProxy"/>
+                        <local:MyButton Text="应用代理信息" TextPadding="3" Grid.Row="4" Grid.Column="4" x:Name="BtnApplyHttpProxy"/>
                     </Grid>
                 </Grid>
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
@@ -68,8 +68,6 @@ Class PageSetupSystem
         CheckSystemTelemetry.Checked = Setup.Get("SystemTelemetry")
 
         '网络
-        CheckDownloadCert.Checked = Setup.Get("ToolDownloadCert")
-
         TextSystemHttpProxy.Text = Setup.Get("SystemHttpProxy")
         TextSystemHttpProxyCustomUsername.Text = Setup.Get("SystemHttpProxyCustomUsername")
         TextSystemHttpProxyCustomPassword.Text = Setup.Get("SystemHttpProxyCustomPassword")
@@ -112,7 +110,6 @@ Class PageSetupSystem
             Setup.Reset("SystemHttpProxyType")
             Setup.Reset("SystemHttpProxyCustomUsername")
             Setup.Reset("SystemHttpProxyCustomPassword")
-            Setup.Reset("ToolDownloadCert")
             Setup.Reset("SystemUseDefaultProxy")
             Setup.Reset("UiAniFPS")
 
@@ -126,7 +123,7 @@ Class PageSetupSystem
     End Sub
 
     '将控件改变路由到设置改变
-    Private Shared Sub CheckBoxChange(sender As MyCheckBox, e As Object) Handles CheckDebugMode.Change, CheckDebugDelay.Change, CheckDebugSkipCopy.Change, CheckUpdateRelease.Change, CheckUpdateSnapshot.Change, CheckHelpChinese.Change, CheckDownloadIgnoreQuilt.Change, CheckDownloadCert.Change, CheckDownloadClipboard.Change, CheckSystemDisableHardwareAcceleration.Change, CheckDownloadAutoSelectVersion.Change, CheckSystemTelemetry.Change, CheckFixAuthlib.Change
+    Private Shared Sub CheckBoxChange(sender As MyCheckBox, e As Object) Handles CheckDebugMode.Change, CheckDebugDelay.Change, CheckDebugSkipCopy.Change, CheckUpdateRelease.Change, CheckUpdateSnapshot.Change, CheckHelpChinese.Change, CheckDownloadIgnoreQuilt.Change, CheckDownloadClipboard.Change, CheckSystemDisableHardwareAcceleration.Change, CheckDownloadAutoSelectVersion.Change, CheckSystemTelemetry.Change, CheckFixAuthlib.Change
         If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Checked)
     End Sub
     Private Shared Sub SliderChange(sender As MySlider, e As Object) Handles SliderDebugAnim.Change, SliderDownloadThread.Change, SliderDownloadSpeed.Change, SliderAniFPS.Change, SliderMaxLog.Change


### PR DESCRIPTION
增强安全性。

如果用户遇到了安全通信建立失败的问题应该优化自己的网络环境而不是禁用 SSL 证书校验