### PR TITLE
fix: 修复 MyListItem 选中时的外观错误

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyListItem.xaml.vb
+++ b/Plain Craft Launcher 2/Controls/MyListItem.xaml.vb
@@ -509,7 +509,7 @@ Public Class MyListItem
                 If Checked Then
                     '由无变有
                     If Not IsNothing(RectCheck) Then
-                        Dim Delta = ActualHeight - RectCheck.ActualHeight - 12
+                        Dim Delta = 20
                         Anim.Add(AaHeight(RectCheck, Delta * 0.4, 200,, New AniEaseOutFluent(AniEasePower.Weak)))
                         Anim.Add(AaHeight(RectCheck, Delta * 0.6, 300,, New AniEaseOutBack(AniEasePower.Weak)))
                         Anim.Add(AaOpacity(RectCheck, 1 - RectCheck.Opacity, 30))


### PR DESCRIPTION
嗯反正就是原来的太丑了，想改  

这是原来的  
<img width="547" height="324" alt="db551a4e83a9517f206ef719b5a01633" src="https://github.com/user-attachments/assets/f5274a9f-fb95-4f08-a6c9-88ab60170acd" />

这是改完后的  
<img width="1054" height="597" alt="02539bc0d16709001ca30f2624013e53" src="https://github.com/user-attachments/assets/0f80055f-78bc-4738-aeb4-d566cd0a96ee" />
