### PR TITLE
feat(custom): 添加了自定义主页的专门页面

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -1009,6 +1009,10 @@ Public Class FormMain
         ''' 主页市场，这是一个副页面。
         ''' </summary>
         HomePageMarket = 13
+        ''' <summary>
+        ''' 主页管理，这是一个副页面。
+        ''' </summary>
+        SetupCustom = 14
     End Enum
     ''' <summary>
     ''' 次要页面种类。其数值必须与 StackPanel 中的下标一致。
@@ -1027,6 +1031,7 @@ Public Class FormMain
         SetupUI = 1
         SetupSystem = 2
         SetupLink = 3
+        SetupCustom = 4
         LinkLobby = 1
         LinkSetup = 4
         LinkHelp = 5
@@ -1075,6 +1080,8 @@ Public Class FormMain
                 Return $"存档管理 - {GetFolderNameFromPath(Stack.Additional)}"
             Case PageType.HomePageMarket
                 Return "主页市场"
+            Case PageType.SetupCustom
+                Return "主页管理"
             Case Else
                 Return ""
         End Select
@@ -1333,7 +1340,10 @@ Public Class FormMain
                     PageChangeAnim(FrmInstanceSavesLeft, FrmInstanceSavesLeft.PageGet(SubType))
                 Case PageType.HomePageMarket '主页市场
                     FrmHomepageMarket = If(FrmHomepageMarket, New PageHomePageMarket)
-                    PageChangeAnim(New MyPageLeft, FrmHomepageMarket)
+                    PageChangeAnim(New MyPageLeft, FrmHomePageMarket)
+                Case PageType.SetupCustom '主页管理
+                    FrmSetupCustom = If(FrmSetupCustom, New PageSetupCustom)
+                    PageChangeAnim(New MyPageLeft, FrmSetupCustom)
             End Select
 #End Region
 

--- a/Plain Craft Launcher 2/Modules/Base/ModSetup.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModSetup.vb
@@ -247,43 +247,6 @@ Public Class ModSetup
         End Try
     End Sub
 
-    '主页
-    Public Sub UiCustomType(Value As Integer)
-        If FrmSetupUI Is Nothing Then Return
-        Select Case Value
-            Case 0 '无
-                FrmSetupUI.PanCustomPreset.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomLocal.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomNet.Visibility = Visibility.Collapsed
-                FrmSetupUI.HintCustom.Visibility = Visibility.Collapsed
-                FrmSetupUI.HintCustomWarn.Visibility = Visibility.Collapsed
-            Case 1 '本地
-                FrmSetupUI.PanCustomPreset.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomLocal.Visibility = Visibility.Visible
-                FrmSetupUI.PanCustomNet.Visibility = Visibility.Collapsed
-                FrmSetupUI.HintCustom.Visibility = Visibility.Visible
-                FrmSetupUI.HintCustomWarn.Visibility = If(Setup.Get("HintCustomWarn"), Visibility.Collapsed, Visibility.Visible)
-                FrmSetupUI.HintCustom.Text = $"从 PCL 文件夹下的 Custom.xaml 读取主页内容。{vbCrLf}你可以手动编辑该文件，向主页添加文本、图片、常用网站、快捷启动等功能。"
-                FrmSetupUI.HintCustom.EventType = ""
-                FrmSetupUI.HintCustom.EventData = ""
-            Case 2 '联网
-                FrmSetupUI.PanCustomPreset.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomLocal.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomNet.Visibility = Visibility.Visible
-                FrmSetupUI.HintCustom.Visibility = Visibility.Visible
-                FrmSetupUI.HintCustomWarn.Visibility = If(Setup.Get("HintCustomWarn"), Visibility.Collapsed, Visibility.Visible)
-                FrmSetupUI.HintCustom.Text = $"从指定网址联网获取主页内容。服主也可以用于动态更新服务器公告。{vbCrLf}如果你制作了稳定运行的联网主页，可以点击这条提示投稿，若合格即可加入预设！"
-                FrmSetupUI.HintCustom.EventType = "打开网页"
-                FrmSetupUI.HintCustom.EventData = "https://github.com/Meloong-Git/PCL/discussions/2528"
-            Case 3 '预设
-                FrmSetupUI.PanCustomPreset.Visibility = Visibility.Visible
-                FrmSetupUI.PanCustomLocal.Visibility = Visibility.Collapsed
-                FrmSetupUI.PanCustomNet.Visibility = Visibility.Collapsed
-                FrmSetupUI.HintCustom.Visibility = Visibility.Collapsed
-                FrmSetupUI.HintCustomWarn.Visibility = Visibility.Collapsed
-        End Select
-        FrmSetupUI.CardCustom.TriggerForceResize()
-    End Sub
     '颜色模式
     Public Sub UiDarkMode(Value As Integer)
         If Value = 0 Then

--- a/Plain Craft Launcher 2/Modules/ModMain.vb
+++ b/Plain Craft Launcher 2/Modules/ModMain.vb
@@ -491,7 +491,8 @@ EndHint:
     Public FrmSetupUI As PageSetupUI
     Public FrmSetupSystem As PageSetupSystem
     Public FrmSetupJava As PageSetupJava
-    Public FrmHomePageMarket As PageHomePageMarket
+    Public FrmHomePageMarket As PageHomepageMarket
+    Public FrmSetupCustom As PageSetupCustom
 
     '其他页面声明
     Public FrmOtherLeft As PageOtherLeft

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupCustom.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupCustom.xaml
@@ -1,0 +1,79 @@
+﻿<local:MyPageRight
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:PCL"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    mc:Ignorable="d" x:Class="PageSetupCustom"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    PanScroll="{Binding ElementName=PanBack}">
+    <local:MyScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
+        <StackPanel x:Name="PanMain" Margin="25,10">
+            <local:MyCard Margin="0,0,0,15" Title="主页" x:Name="CardCustom">
+                <StackPanel Margin="25,40,25,15">
+                    <Grid Margin="-1,0,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="1*" />
+                        </Grid.ColumnDefinitions>
+                        <local:MyRadioBox Text="空白" x:Name="RadioCustomType0" Height="22" Tag="UiCustomType/0" Grid.Column="0" />
+                        <local:MyRadioBox Text="读取本地文件" x:Name="RadioCustomType1" Height="22" Tag="UiCustomType/1" Grid.Column="1" />
+                        <local:MyRadioBox Text="联网更新" x:Name="RadioCustomType2" Height="22" Tag="UiCustomType/2" Grid.Column="2" />
+                    </Grid>
+                    <local:MyHint Margin="0,15,0,-4" Text="如果出现这条文字，请立即反馈！请立即反馈！请立即反馈并提供截图！" Theme="Red" x:Name="HintCustom" Visibility="Collapsed"/>
+                    <local:MyHint Margin="0,15,0,6" Text="请谨慎使用陌生人提供的主页，恶意代码可能会造成损害！" Theme="Yellow" x:Name="HintCustomWarn" 
+                                  CanClose="True" RelativeSetup="HintCustomWarn" />
+                    <Grid Height="35" x:Name="PanCustomLocal" Visibility="Collapsed" Margin="0,10,0,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
+                        </Grid.ColumnDefinitions>
+                        <local:MyButton x:Name="BtnCustomRefresh" Grid.Column="0" MinWidth="140" Text="刷新主页" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight" />
+                        <local:MyButton x:Name="BtnCustomFile" Grid.Column="1" MinWidth="140" Text="生成教学文件" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" />
+                        <local:MyButton x:Name="BtnCustomTutorial" Grid.Column="2" MinWidth="140" Text="查看教程" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" />
+                    </Grid>
+                    <Grid x:Name="PanCustomNet" Visibility="Collapsed" Margin="0,10,0,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="下载地址" Margin="0,0,25,0" />
+                        <local:MyTextBox x:Name="TextCustomNet" Tag="UiCustomNet" Grid.Column="1" MaxHeight="28">
+                            <local:MyTextBox.ValidateRules>
+                                <local:ValidateNullable />
+                                <local:ValidateHttp />
+                            </local:MyTextBox.ValidateRules>
+                        </local:MyTextBox>
+                    </Grid>
+                    <Grid x:Name="PanCustomPreset" Visibility="Collapsed" Margin="0,12,10,5" Height="28">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="主页预设" Margin="0,0,25,0" />
+                        <local:MyComboBox x:Name="ComboCustomPreset" Grid.ColumnSpan="2" Tag="UiCustomPreset" Grid.Column="1">
+                            <local:MyComboBoxItem Content="你知道吗？" IsSelected="True" />
+                            <local:MyComboBoxItem Content="回声洞" />
+                            <local:MyComboBoxItem Content="Minecraft 新闻（作者：最亮的信标）" />
+                            <local:MyComboBoxItem Content="简单主页（作者：MFn233）" />
+                            <local:MyComboBoxItem Content="每日整合包推荐（作者：wkea）" />
+                            <local:MyComboBoxItem Content="Minecraft 皮肤推荐（作者：wkea）" />
+                            <local:MyComboBoxItem Content="OpenBMCLAPI 仪表盘 Lite（作者：Silverteal、Mxmilu666）" />
+                            <local:MyComboBoxItem Content="PCL 主页市场（作者：凌云）" />
+                            <local:MyComboBoxItem Content="PCL 新闻速报（作者：Joker2184）" />
+                            <local:MyComboBoxItem Content="PCL 新功能说明书（作者：WForst-Breeze）" />
+                            <local:MyComboBoxItem Content="OpenMCIM 仪表盘（作者：SALTWOOD）" Visibility="Collapsed" />
+                            <local:MyComboBoxItem Content="杂志主页（作者：CreeperIsASpy）" />
+                            <local:MyComboBoxItem Content="PCL GitHub 仪表盘（作者：Deep-Dark-Forest）" />
+                        </local:MyComboBox>
+                    </Grid>
+                </StackPanel>
+            </local:MyCard>
+            <local:MyCard>
+                <StackPanel x:Name="HomepagesPan">
+                </StackPanel>
+            </local:MyCard>
+        </StackPanel>
+    </local:MyScrollViewer>
+</local:MyPageRight>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupCustom.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupCustom.xaml.vb
@@ -1,0 +1,178 @@
+﻿Imports System.Net.Http
+Imports Microsoft.Windows.Themes
+Imports Newtonsoft.Json.Linq
+
+Public Class PageSetupCustom
+
+    Private Shadows IsLoaded As Boolean = False
+
+    Private Sub PageSetupCustom_Loaded(sender As Object, e As RoutedEventArgs) Handles Me.Loaded
+
+        '重复加载部分
+        PanBack.ScrollToHome()
+
+
+        AniControlEnabled += 1
+        Reload() '#4826，在每次进入页面时都刷新一下
+        AniControlEnabled -= 1
+
+        LoadHomepages()
+
+        '非重复加载部分
+        If IsLoaded Then Return
+        IsLoaded = True
+
+
+    End Sub
+    Private Sub Reload()
+        Try
+            CType(FindName("RadioCustomType" & Setup.Load("UiCustomType", forceReload:=True)), MyRadioBox).Checked = True
+            TextCustomNet.Text = Setup.Get("UiCustomNet")
+
+        Catch ex As NullReferenceException
+            Log(ex, "主页设置项存在异常，已被自动重置", LogLevel.Msgbox)
+            Reset()
+        Catch ex As Exception
+            Log(ex, "重载主页设置时出错", LogLevel.Feedback)
+        End Try
+    End Sub
+
+    '初始化
+    Public Sub Reset()
+        Try
+            Setup.Reset("UiCustomType")
+            Setup.Reset("UiCustomNet")
+
+            Log("[Setup] 已初始化主页设置！")
+            Hint("已初始化主页设置", HintType.Finish, False)
+        Catch ex As Exception
+            Log(ex, "初始化主页设置失败", LogLevel.Msgbox)
+        End Try
+
+        Reload()
+    End Sub
+
+    '将控件改变路由到设置改变
+    '有些暂时没用到，先留着吧，谁知道呢……
+    'Private Shared Sub SliderChange(sender As MySlider, e As Object) Handles Nothing
+    '   If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Value)
+    'End Sub
+    'Private Shared Sub ComboChange(sender As MyComboBox, e As Object) Handles Nothing
+    '    If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.SelectedIndex)
+    'End Sub
+    'Private Shared Sub CheckBoxChange(sender As MyCheckBox, e As Object) Handles Nothing
+    '   If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Checked)
+    'End Sub
+    Private Shared Sub TextBoxChange(sender As MyTextBox, e As Object) Handles TextCustomNet.ValidatedTextChanged
+        If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Text)
+    End Sub
+    Private Shared Sub RadioBoxChange(sender As MyRadioBox, e As Object) Handles RadioCustomType0.Check, RadioCustomType1.Check, RadioCustomType2.Check
+        If AniControlEnabled = 0 Then Setup.Set(sender.Tag.ToString.Split("/")(0), sender.Tag.ToString.Split("/")(1))
+        UiCustomType(sender.Tag.ToString.Split("/")(1))
+    End Sub
+    Private Sub PresetSelectedFromCard(sender As MyListItem, e As Object)
+        RadioCustomType2.SetChecked(True, True)
+        If AniControlEnabled = 0 Then Setup.Set("UiCustomNet", sender.Tag.ToString)
+        TextCustomNet.Text = sender.Tag.ToString
+        FrmLaunchRight.ForceRefresh()
+    End Sub
+
+
+    '主页
+    Private Sub BtnCustomFile_Click(sender As Object, e As EventArgs) Handles BtnCustomFile.Click
+        Try
+            If File.Exists(ExePath & "PCL\Custom.xaml") Then
+                If MyMsgBox("当前已存在布局文件，继续生成教学文件将会覆盖现有布局文件！", "覆盖确认", "继续", "取消", IsWarn:=True) = 2 Then Return
+            End If
+            WriteFile(ExePath & "PCL\Custom.xaml", GetResourceStream("Resources/Custom.xml"))
+            Hint("教学文件已生成！", HintType.Finish)
+            OpenExplorer(ExePath & "PCL\Custom.xaml")
+        Catch ex As Exception
+            Log(ex, "生成教学文件失败", LogLevel.Feedback)
+        End Try
+    End Sub
+    Private Sub BtnCustomRefresh_Click() Handles BtnCustomRefresh.Click
+        FrmLaunchRight.ForceRefresh()
+        Hint("已刷新主页！", HintType.Finish)
+    End Sub
+    Private Sub BtnCustomTutorial_Click(sender As Object, e As EventArgs) Handles BtnCustomTutorial.Click
+        MyMsgBox("1. 点击 生成教学文件 按钮，这会在 PCL 文件夹下生成 Custom.xaml 布局文件。" & vbCrLf &
+                 "2. 使用记事本等工具打开这个文件并进行修改，修改完记得保存。" & vbCrLf &
+                 "3. 点击 刷新主页 按钮，查看主页现在长啥样了。" & vbCrLf &
+                 vbCrLf &
+                 "你可以在生成教学文件后直接刷新主页，对照着进行修改，更有助于理解。" & vbCrLf &
+                 "直接将主页文件拖进 PCL 窗口也可以快捷加载。", "主页自定义教程")
+    End Sub
+
+    '主页
+    Private Shared Sub UiCustomType(value As Integer)
+        Select Case value
+            Case 0 '无
+                FrmSetupCustom.PanCustomLocal.Visibility = Visibility.Collapsed
+                FrmSetupCustom.PanCustomNet.Visibility = Visibility.Collapsed
+                FrmSetupCustom.HintCustom.Visibility = Visibility.Collapsed
+                FrmSetupCustom.HintCustomWarn.Visibility = Visibility.Collapsed
+            Case 1 '本地
+                FrmSetupCustom.PanCustomLocal.Visibility = Visibility.Visible
+                FrmSetupCustom.PanCustomNet.Visibility = Visibility.Collapsed
+                FrmSetupCustom.HintCustom.Visibility = Visibility.Visible
+                FrmSetupCustom.HintCustom.Theme = MyHint.Themes.Blue
+                FrmSetupCustom.HintCustomWarn.Visibility = If(Setup.Get("HintCustomWarn"), Visibility.Collapsed, Visibility.Visible)
+                FrmSetupCustom.HintCustom.Text = $"从 PCL 文件夹下的 Custom.xaml 读取主页内容。{vbCrLf}你可以手动编辑该文件，向主页添加文本、图片、常用网站、快捷启动等功能。"
+                FrmSetupCustom.HintCustom.EventType = ""
+                FrmSetupCustom.HintCustom.EventData = ""
+            Case 2 '联网
+                FrmSetupCustom.PanCustomLocal.Visibility = Visibility.Collapsed
+                FrmSetupCustom.PanCustomNet.Visibility = Visibility.Visible
+                FrmSetupCustom.HintCustom.Visibility = Visibility.Visible
+                FrmSetupCustom.HintCustom.Theme = MyHint.Themes.Blue
+                FrmSetupCustom.HintCustomWarn.Visibility = If(Setup.Get("HintCustomWarn"), Visibility.Collapsed, Visibility.Visible)
+                FrmSetupCustom.HintCustom.Text = $"从指定网址联网获取主页内容。服主也可以用于动态更新服务器公告。{vbCrLf}如果你制作了稳定运行的联网主页，可以点击这条提示投稿，若合格即可加入预设！"
+                FrmSetupCustom.HintCustom.EventType = "打开网页"
+                FrmSetupCustom.HintCustom.EventData = "https://github.com/Hex-Dragon/PCL2/discussions/2528"
+        End Select
+        FrmSetupCustom.CardCustom.TriggerForceResize()
+    End Sub
+    Private Async Sub LoadHomepages()
+        Dim url As String = "http://pclhomeplazaoss.lingyunawa.top:26995/d/Homepages/HomepageList/homepages.json"
+
+        Using httpClient As New HttpClient()
+            ' 获取字节数组而不是字符串
+            Dim responseBytes() As Byte = Await httpClient.GetByteArrayAsync(url)
+
+            ' 使用 GBK 编码解码
+            Dim gbkEncoding As Encoding = Encoding.GetEncoding("GBK")
+            Dim jsonString As String = gbkEncoding.GetString(responseBytes)
+            Dim jsonObj As JObject = JObject.Parse(jsonString)
+            Dim homepages As JObject = jsonObj("homepages")
+
+
+            Dispatcher.Invoke(Sub()
+                                  HomepagesPan.Children.Clear()
+                                  Dim index As Integer = 1
+
+                                  For Each homepage As JProperty In homepages.Properties()
+                                      Dim item As JObject = homepage.Value
+                                      Dim isPreset As Boolean = item("preset").ToObject(Of Boolean)()
+                                      ' 设置图标（直接使用固定路径）
+                                      Dim listItem As New MyListItem With {
+                                          .Margin = New Thickness(10, 8, 10, 8),
+                                          .ToolTip = "预设主页",
+                                          .Title = item("alias").ToString(),
+                                          .Info = item("desc").ToString(),
+                                          .Type = MyListItem.CheckType.Clickable,
+                                          .Logo = "pack://application:,,,/images/Blocks/RedstoneLampOn.png",
+                                          .Tag = item("link")
+                                      }
+
+                                      ' 添加点击事件处理
+                                      AddHandler listItem.Click, AddressOf PresetSelectedFromCard
+
+                                      HomepagesPan.Children.Add(listItem)
+                                      index += 1
+                                  Next
+                              End Sub)
+        End Using
+    End Sub
+
+End Class

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml
@@ -20,6 +20,14 @@
                 </x:Array>
             </local:MyListItem.Buttons>
         </local:MyListItem>
+        <local:MyListItem x:Name="ItemCustom" IsScaleAnimationEnabled="False" Tag="4" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="主页管理" 
+                          Logo="M17.5 16.5v2q0 .2.15.35T18 19t.35-.15t.15-.35v-2h2q.2 0 .35-.15T21 16t-.15-.35t-.35-.15h-2v-2q0-.2-.15-.35T18 13t-.35.15t-.15.35v2h-2q-.2 0-.35.15T15 16t.15.35t.35.15zM18 21q-2.075 0-3.537-1.463T13 16t1.463-3.537T18 11t3.538 1.463T23 16t-1.463 3.538T18 21M4 17V8q0-.475.213-.9t.587-.7l6-4.5q.275-.2.575-.3T12 1.5t.625.1t.575.3l6.05 4.55q.175.125.263.325t.087.425q0 .425-.288.713T18.6 8.2q-.175 0-.325-.05T18 8l-6-4.5L6 8v9h4q.425 0 .713.288T11 18t-.288.713T10 19H6q-.825 0-1.412-.587T4 17m8-6.75" Type="RadioBox">
+            <local:MyListItem.Buttons>
+                <x:Array Type="{x:Type local:MyIconButton}">
+                    <local:MyIconButton Tag="4" ToolTip="初始化本页设置" ToolTipService.Placement="Right" ToolTipService.InitialShowDelay="200" ToolTipService.VerticalOffset="-1" Click="Reset" Logo="M530 0c287 0 521 229 521 511s-233 511-521 511c-233 0-436-151-500-368a63 63 0 0 1 44-79 65 65 0 0 1 80 43c48 162 200 276 375 276 215 0 390-171 390-383s-174-383-390-383c-103 0-199 39-270 106l21-5a63 63 0 0 1 33 123l-157 42a65 65 0 0 1-90-42l-49-183a65 65 0 1 1 126-33l6 26A524 524 0 0 1 530 0z" LogoScale="0.9" />
+                </x:Array>
+            </local:MyListItem.Buttons>
+        </local:MyListItem>
         <local:MyListItem x:Name="ItemSystem" IsScaleAnimationEnabled="False" Tag="2" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="其他" Type="RadioBox"
                           Logo="M511 995a128 128 0 0 1-57-13L70 791a126 126 0 0 1-70-113V311a126 126 0 0 1 15-60V248c1-2 3-5 5-8a127 127 0 0 1 49-42L454 13a128 128 0 0 1 112 0l383 190a126 126 0 0 1 72 113v360a126 126 0 0 1-70 115L568 984c-17 7-37 11-57 11z m42-470v370l360-178c14-7 23-21 23-38v-335L554 524zM85 330v347a42 42 0 0 0 23 38l360 178V523L85 330zM135 260l375 189 137-65L286 188 135 260z m245-118l363 197 150-71-365-180a42 42 0 0 0-37 0l-111 53z">
             <local:MyListItem.Buttons>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml.vb
@@ -8,6 +8,7 @@ Public Class PageSetupLeft
         If ItemLaunch.Checked AndAlso Setup.Get("UiHiddenSetupLaunch") Then IsHiddenPage = True
         If ItemUI.Checked AndAlso Setup.Get("UiHiddenSetupUi") Then IsHiddenPage = True
         If ItemSystem.Checked AndAlso Setup.Get("UiHiddenSetupSystem") Then IsHiddenPage = True
+        If ItemCustom.Checked AndAlso Setup.Get("UiHiddenSetupSystem") Then IsHiddenPage = True
         If PageSetupUI.HiddenForceShow Then IsHiddenPage = False
         '若页面错误，或尚未加载，则继续
         If IsLoad AndAlso Not IsHiddenPage Then Return
@@ -22,6 +23,8 @@ Public Class PageSetupLeft
             ItemUI.SetChecked(True, False, False)
         ElseIf Not Setup.Get("UiHiddenSetupSystem") Then
             ItemSystem.SetChecked(True, False, False)
+        ElseIf Not Setup.Get("UiHiddenSetupCustom") Then
+            ItemCustom.SetChecked(True, False, False)
         Else
             ItemLaunch.SetChecked(True, False, False)
         End If
@@ -45,6 +48,8 @@ Public Class PageSetupLeft
             PageID = FormMain.PageSubType.SetupUI
         ElseIf Not Setup.Get("UiHiddenSetupSystem") Then
             PageID = FormMain.PageSubType.SetupSystem
+        ElseIf Not Setup.Get("UiHiddenSetupCustom") Then
+            PageID = FormMain.PageSubType.SetupCustom
         Else
             PageID = FormMain.PageSubType.SetupLaunch
         End If
@@ -53,7 +58,7 @@ Public Class PageSetupLeft
     ''' <summary>
     ''' 勾选事件改变页面。
     ''' </summary>
-    Private Sub PageCheck(sender As MyListItem, e As EventArgs) Handles ItemLaunch.Check, ItemSystem.Check, ItemUI.Check
+    Private Sub PageCheck(sender As MyListItem, e As EventArgs) Handles ItemLaunch.Check, ItemSystem.Check, ItemUI.Check, ItemCustom.Check
         '尚未初始化控件属性时，sender.Tag 为 Nothing，会跳过切换，且由于 PageID 默认为 0 而切换到第一个页面
         '若使用 IsLoaded，则会导致模拟点击不被执行（模拟点击切换页面时，控件的 IsLoaded 为 False）
         If sender.Tag IsNot Nothing Then PageChange(Val(sender.Tag))
@@ -74,6 +79,9 @@ Public Class PageSetupLeft
             Case FormMain.PageSubType.SetupSystem
                 If FrmSetupSystem Is Nothing Then FrmSetupSystem = New PageSetupSystem
                 Return FrmSetupSystem
+            Case FormMain.PageSubType.SetupCustom
+                If FrmSetupCustom Is Nothing Then FrmSetupCustom = New PageSetupCustom
+                Return FrmSetupCustom
             Case Else
                 Throw New Exception("未知的设置子页面种类：" & ID)
         End Select
@@ -98,6 +106,9 @@ Public Class PageSetupLeft
                 Case FormMain.PageSubType.SetupSystem
                     If IsNothing(FrmSetupSystem) Then FrmSetupSystem = New PageSetupSystem
                     PageChangeRun(FrmSetupSystem)
+                Case FormMain.PageSubType.SetupCustom
+                    If IsNothing(FrmSetupCustom) Then FrmSetupCustom = New PageSetupCustom
+                    PageChangeRun(FrmSetupCustom)
                 Case Else
                     Throw New Exception("未知的设置子页面种类：" & ID)
             End Select
@@ -149,6 +160,12 @@ Public Class PageSetupLeft
                     If IsNothing(FrmSetupSystem) Then FrmSetupSystem = New PageSetupSystem
                     FrmSetupSystem.Reset()
                     ItemSystem.Checked = True
+                End If
+            Case FormMain.PageSubType.SetupCustom
+                If MyMsgBox("是否要初始化 主页管理 页面的所有设置？该操作不可撤销。", "初始化确认",, "取消", IsWarn:=True) = 1 Then
+                    If IsNothing(FrmSetupCustom) Then FrmSetupCustom = New PageSetupCustom
+                    FrmSetupCustom.Reset()
+                    ItemCustom.Checked = True
                 End If
         End Select
     End Sub

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -267,80 +267,6 @@
                     </Grid>
                 </StackPanel>
             </local:MyCard>
-            <local:MyCard Margin="0,0,0,15" Title="主页" x:Name="CardCustom">
-                <StackPanel Margin="25,40,25,15">
-                    <Grid Margin="-1,0,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="1*" />
-                            <ColumnDefinition Width="0.2*" />
-                        </Grid.ColumnDefinitions>
-                        <local:MyRadioBox Text="空白" x:Name="RadioCustomType0" Height="22" Tag="UiCustomType/0" Grid.Column="0" />
-                        <local:MyRadioBox Text="预设" x:Name="RadioCustomType3" Height="22" Tag="UiCustomType/3" Grid.Column="1" />
-                        <local:MyRadioBox Text="读取本地文件" x:Name="RadioCustomType1" Height="22" Tag="UiCustomType/1" Grid.Column="2" />
-                        <local:MyRadioBox Text="联网更新" x:Name="RadioCustomType2" Height="22" Tag="UiCustomType/2" Grid.Column="3" />
-                    </Grid>
-                    <local:MyHint Margin="0,15,0,-4" Text="内容见 ModSetup" Theme="Blue" x:Name="HintCustom" />
-                    <local:MyHint Margin="0,15,0,6" Text="请谨慎使用陌生人提供的主页，恶意代码可能会造成损害！" Theme="Yellow" x:Name="HintCustomWarn" 
-                                  CanClose="True" RelativeSetup="HintCustomWarn" />
-                    <Grid Height="35" x:Name="PanCustomLocal" Visibility="Collapsed" Margin="0,10,0,5">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
-                        </Grid.ColumnDefinitions>
-                        <local:MyButton x:Name="BtnCustomRefresh" Grid.Column="0" MinWidth="140" Text="刷新主页" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" ColorType="Highlight" />
-                        <local:MyButton x:Name="BtnCustomFile" Grid.Column="1" MinWidth="140" Text="生成教学文件" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" />
-                        <local:MyButton x:Name="BtnCustomTutorial" Grid.Column="2" MinWidth="140" Text="查看教程" Padding="13,0" Margin="0,0,20,0" HorizontalAlignment="Left" />
-                    </Grid>
-                    <Grid x:Name="PanCustomNet" Visibility="Collapsed" Margin="0,10,0,5">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="下载地址" Margin="0,0,25,0" />
-                        <local:MyTextBox x:Name="TextCustomNet" Tag="UiCustomNet" Grid.Column="1" MaxHeight="28">
-                            <local:MyTextBox.ValidateRules>
-                                <local:ValidateNullable />
-                                <local:ValidateHttp />
-                            </local:MyTextBox.ValidateRules>
-                        </local:MyTextBox>
-                    </Grid>
-                    <Grid x:Name="PanCustomPreset" Visibility="Collapsed" Margin="0,12,10,5" Height="28">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="主页预设" Margin="0,0,25,0" />
-                        <local:MyComboBox x:Name="ComboCustomPreset" Grid.ColumnSpan="2" Tag="UiCustomPreset" Grid.Column="1">
-                            <local:MyComboBoxItem Content="你知道吗？" IsSelected="True" />
-                            <local:MyComboBoxItem Content="回声洞" />
-                            <local:MyComboBoxItem Content="Minecraft 新闻（作者：最亮的信标）" />
-                            <local:MyComboBoxItem Content="简单主页（作者：MFn233）" />
-                            <local:MyComboBoxItem Content="每日整合包推荐（作者：wkea）" />
-                            <local:MyComboBoxItem Content="Minecraft 皮肤推荐（作者：wkea）" />
-                            <local:MyComboBoxItem Content="OpenBMCLAPI 仪表盘 Lite（作者：Silverteal、Mxmilu666）" />
-                            <local:MyComboBoxItem Content="PCL 主页市场（作者：凌云）" />
-                            <local:MyComboBoxItem Content="PCL 新闻速报（作者：Joker2184）" />
-                            <local:MyComboBoxItem Content="PCL 新功能说明书（作者：WForst-Breeze）" />
-                            <local:MyComboBoxItem Content="OpenMCIM 仪表盘（作者：SALTWOOD）" Visibility="Collapsed" />
-                            <local:MyComboBoxItem Content="杂志主页（作者：CreeperIsASpy）" />
-                            <local:MyComboBoxItem Content="PCL GitHub 仪表盘（作者：Deep-Dark-Forest）" />
-                            <local:MyComboBoxItem Content="PCL CE 公告栏" />
-                        </local:MyComboBox>
-                    </Grid>
-                    <Grid Grid.Row="14">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
-                        <TextBlock VerticalAlignment="Center" Grid.Column="0" Margin="0,10,0,0" HorizontalAlignment="Left" Text="获取更多主页"/>
-                        <local:MyIconTextButton x:Name="BtnGotoHomepageMarket" Grid.Column="1" Margin="10,10,0,0" HorizontalAlignment="Left" Text="前往主页市场" Logo="M857.856 0H55.296a53.248 53.248 0 0 0-51.2 53.248V230.4a51.2 51.2 0 0 0 102.4 0V106.496h708.352a102.4 102.4 0 0 1 102.4 102.4v606.464a102.4 102.4 0 0 1-102.4 102.4H105.984v-120.32a51.2 51.2 0 0 0-102.4 0V972.8a53.248 53.248 0 0 0 51.2 51.2h803.072A166.4 166.4 0 0 0 1024 858.368v-691.2A166.4 166.4 0 0 0 857.856 0z M91.136 512a57.344 57.344 0 0 0 57.088 57.088h380.672l-103.68 103.68a53.248 53.248 0 0 0 75.264 75.264l198.144-198.4a52.992 52.992 0 0 0 0-75.264l-198.4-198.4a53.248 53.248 0 1 0-75.264 75.264l103.68 103.68H148.224A57.344 57.344 0 0 0 91.136 512z"/>
-                    </Grid>
-                </StackPanel>
-            </local:MyCard>
             <local:MyCard x:Name="CardSwitch" Margin="0,0,0,15" Title="功能隐藏">
                 <StackPanel Margin="25,38,15,15">
                     <TextBlock Margin="0,1,0,1" Text="你可以隐藏不需要的页面或关闭特定功能。在任意界面按 F12 可以暂时显示被隐藏的功能。" TextWrapping="Wrap" />
@@ -373,6 +299,7 @@
                         <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="2" Grid.Column="2" Text="启动" x:Name="CheckHiddenSetupLaunch" Tag="UiHiddenSetupLaunch" />
                         <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="2" Grid.Column="3" Text="个性化" x:Name="CheckHiddenSetupUI" Tag="UiHiddenSetupUi" />
                         <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="2" Grid.Column="4" Text="其他" x:Name="CheckHiddenSetupSystem" Tag="UiHiddenSetupSystem" />
+                        <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="2" Grid.Column="4" Text="主页管理" x:Name="CheckHiddenSetupCustom" Tag="UiHiddenSetupCustom" />
                         <TextBlock Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Left" Text="更多 子页面" />
                         <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="3" Grid.Column="2" Text="帮助" x:Name="CheckHiddenOtherHelp" Tag="UiHiddenOtherHelp" />
                         <local:MyCheckBox Height="22" VerticalAlignment="Center" Grid.Row="3" Grid.Column="3" Text="关于与鸣谢" x:Name="CheckHiddenOtherAbout" Tag="UiHiddenOtherAbout" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.vb
@@ -130,14 +130,6 @@ Public Class PageSetupUI
             SliderMusicVolume.Value = Setup.Get("UiMusicVolume")
             MusicRefreshUI()
 
-            '主页
-            Try
-                ComboCustomPreset.SelectedIndex = Setup.Get("UiCustomPreset")
-            Catch
-                Setup.Reset("UiCustomPreset")
-            End Try
-            CType(FindName("RadioCustomType" & Setup.Load("UiCustomType", ForceReload:=True)), MyRadioBox).Checked = True
-            TextCustomNet.Text = Setup.Get("UiCustomNet")
 
             '功能隐藏
             CheckHiddenPageDownload.Checked = Setup.Get("UiHiddenPageDownload")
@@ -203,9 +195,6 @@ Public Class PageSetupUI
             Setup.Reset("UiMusicRandom")
             Setup.Reset("UiMusicSMTC")
             Setup.Reset("UiMusicAuto")
-            Setup.Reset("UiCustomType")
-            Setup.Reset("UiCustomPreset")
-            Setup.Reset("UiCustomNet")
             Setup.Reset("UiHiddenPageDownload")
             Setup.Reset("UiHiddenPageLink")
             Setup.Reset("UiHiddenPageSetup")
@@ -245,16 +234,16 @@ Public Class PageSetupUI
     Private Shared Sub SliderChange(sender As MySlider, e As Object) Handles SliderBackgroundOpacity.Change, SliderBlurValue.Change, SliderBlurSamplingRate.Change, SliderBackgroundBlur.Change, SliderLauncherOpacity.Change, SliderMusicVolume.Change ', SliderLauncherHue.Change, SliderLauncherLight.Change, SliderLauncherSat.Change, SliderLauncherDelta.Change
         If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Value)
     End Sub
-    Private Shared Sub ComboChange(sender As MyComboBox, e As Object) Handles ComboDarkMode.SelectionChanged, ComboBackgroundSuit.SelectionChanged, ComboCustomPreset.SelectionChanged, ComboBlurType.SelectionChanged
+    Private Shared Sub ComboChange(sender As MyComboBox, e As Object) Handles ComboDarkMode.SelectionChanged, ComboBackgroundSuit.SelectionChanged, ComboBlurType.SelectionChanged
         If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.SelectedIndex)
     End Sub
     Private Shared Sub CheckBoxChange(sender As MyCheckBox, e As Object) Handles CheckLockWindowSize.Change, CheckBlur.Change, CheckMusicStop.Change, CheckMusicRandom.Change, CheckMusicAuto.Change, CheckBackgroundColorful.Change, CheckLogoLeft.Change, CheckLauncherLogo.Change, CheckHiddenFunctionHidden.Change, CheckHiddenFunctionSelect.Change, CheckHiddenFunctionModUpdate.Change, CheckHiddenPageDownload.Change, CheckHiddenPageLink.Change, CheckHiddenPageOther.Change, CheckHiddenPageSetup.Change, CheckHiddenSetupLaunch.Change, CheckHiddenSetupSystem.Change, CheckHiddenSetupUI.Change, CheckHiddenOtherAbout.Change, CheckHiddenOtherFeedback.Change, CheckHiddenOtherVote.Change, CheckHiddenOtherHelp.Change, CheckHiddenOtherTest.Change, CheckMusicStart.Change, CheckMusicSMTC.Change, CheckHiddenVersionEdit.Change, CheckHiddenVersionExport.Change, CheckHiddenVersionSave.Change, CheckHiddenVersionScreenshot.Change, CheckHiddenVersionMod.Change, CheckHiddenVersionResourcePack.Change, CheckHiddenVersionShader.Change, CheckHiddenVersionSchematic.Change, CheckHiddenVersionServer.Change, CheckAutoPauseVideo.Change
         If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Checked)
     End Sub
-    Private Shared Sub TextBoxChange(sender As MyTextBox, e As Object) Handles TextLogoText.ValidatedTextChanged, TextCustomNet.ValidatedTextChanged
+    Private Shared Sub TextBoxChange(sender As MyTextBox, e As Object) Handles TextLogoText.ValidatedTextChanged
         If AniControlEnabled = 0 Then Setup.Set(sender.Tag, sender.Text)
     End Sub
-    Private Shared Sub RadioBoxChange(sender As MyRadioBox, e As Object) Handles RadioLogoType0.Check, RadioLogoType1.Check, RadioLogoType2.Check, RadioLogoType3.Check, RadioLauncherTheme0.Check, RadioLauncherTheme1.Check, RadioLauncherTheme2.Check, RadioLauncherTheme3.Check, RadioLauncherTheme4.Check, RadioLauncherTheme5.Check, RadioLauncherTheme6.Check, RadioLauncherTheme7.Check, RadioLauncherTheme8.Check, RadioLauncherTheme9.Check, RadioLauncherTheme10.Check, RadioLauncherTheme11.Check, RadioLauncherTheme12.Check, RadioLauncherTheme13.Check, RadioLauncherTheme14.Check, RadioCustomType0.Check, RadioCustomType1.Check, RadioCustomType2.Check, RadioCustomType3.Check
+    Private Shared Sub RadioBoxChange(sender As MyRadioBox, e As Object) Handles RadioLogoType0.Check, RadioLogoType1.Check, RadioLogoType2.Check, RadioLogoType3.Check, RadioLauncherTheme0.Check, RadioLauncherTheme1.Check, RadioLauncherTheme2.Check, RadioLauncherTheme3.Check, RadioLauncherTheme4.Check, RadioLauncherTheme5.Check, RadioLauncherTheme6.Check, RadioLauncherTheme7.Check, RadioLauncherTheme8.Check, RadioLauncherTheme9.Check, RadioLauncherTheme10.Check, RadioLauncherTheme11.Check, RadioLauncherTheme12.Check, RadioLauncherTheme13.Check, RadioLauncherTheme14.Check
         Dim gotCfg = sender.Tag.ToString.Split("/")
         If AniControlEnabled = 0 Then Setup.Set(gotCfg(0), Integer.Parse(gotCfg(1)))
     End Sub
@@ -515,32 +504,6 @@ Refresh:
     Private Sub CheckMusicStop_Change() Handles CheckMusicStop.Change
         If AniControlEnabled <> 0 Then Return
         If CheckMusicStop.Checked Then CheckMusicStart.Checked = False
-    End Sub
-
-    '主页
-    Private Sub BtnCustomFile_Click(sender As Object, e As EventArgs) Handles BtnCustomFile.Click
-        Try
-            If File.Exists(ExePath & "PCL\Custom.xaml") Then
-                If MyMsgBox("当前已存在布局文件，继续生成教学文件将会覆盖现有布局文件！", "覆盖确认", "继续", "取消", IsWarn:=True) = 2 Then Return
-            End If
-            WriteFile(ExePath & "PCL\Custom.xaml", GetResourceStream("Resources/Custom.xml"))
-            Hint("教学文件已生成！", HintType.Finish)
-            OpenExplorer(ExePath & "PCL\Custom.xaml")
-        Catch ex As Exception
-            Log(ex, "生成教学文件失败", LogLevel.Feedback)
-        End Try
-    End Sub
-    Private Sub BtnCustomRefresh_Click() Handles BtnCustomRefresh.Click
-        FrmLaunchRight.ForceRefresh()
-        Hint("已刷新主页！", HintType.Finish)
-    End Sub
-    Private Sub BtnCustomTutorial_Click(sender As Object, e As EventArgs) Handles BtnCustomTutorial.Click
-        MyMsgBox("1. 点击 生成教学文件 按钮，这会在 PCL 文件夹下生成 Custom.xaml 布局文件。" & vbCrLf &
-                 "2. 使用记事本等工具打开这个文件并进行修改，修改完记得保存。" & vbCrLf &
-                 "3. 点击 刷新主页 按钮，查看主页现在长啥样了。" & vbCrLf &
-                 vbCrLf &
-                 "你可以在生成教学文件后直接刷新主页，对照着进行修改，更有助于理解。" & vbCrLf &
-                 "直接将主页文件拖进 PCL 窗口也可以快捷加载。", "主页自定义教程")
     End Sub
 
     '主题
@@ -823,8 +786,5 @@ Refresh:
         SliderBackgroundBlur.GetHintText = Function(v) v & " 像素"
         SliderBlurValue.GetHintText = Function(v) v & " 像素"
         SliderBlurSamplingRate.GetHintText = Function(v) v & "%"
-    End Sub
-    Private Sub BtnHomepageMarket_Click(sender As Object, e As EventArgs) Handles BtnGotoHomepageMarket.Click
-        FrmMain.PageChange(New FormMain.PageStackData With {.Page = FormMain.PageType.HomepageMarket})
     End Sub
 End Class

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -111,4 +111,9 @@
     <Resource Include="Images\**" />
     <Resource Include="Resources\**" />
   </ItemGroup>
+  <ItemGroup>
+    <Page Update="Pages\PageSetup\PageSetupCustom.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
添加了自定义主页的专门页面（close #333 ）。
完全移除了预设选项，全部采用联网更新模式。所谓的预设转型为 HomepageList 中的列表（也实现了热更新）。
增加了新页面 SetupCustom，名为“主页管理”。这个页面可以完成之前个性化页面中的所有主页设置功能，且更加全面的介绍了各个主页的功能。
Checklist：
- [ ] 完全移除其他页面的主页功能残余，将 HomePageMarket 的功能完全移除，主页市场重新成为主页，其原来功能被 HomepageList 代替。
- [ ] 给下面的卡片增加分类，分离 preset 为 true 的“预设”主页和 preset 为 false 的“社区”主页（此社区非彼社区）。

预览图：
<details><summary>Details</summary>
<p>

<img width="1049" height="914" alt="image" src="https://github.com/user-attachments/assets/79aeee38-b259-4ce0-a95b-38c35091260a" />

</p>
</details> 