### PR TITLE
feat(update): 新的更新通道 `Nightly`

### DIFF
--- a/.github/workflows/release-nightly_publish.yml
+++ b/.github/workflows/release-nightly_publish.yml
@@ -1,0 +1,123 @@
+name: Publish (Nightly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # 每天午夜 UTC 时间运行
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - configuration: Beta # Nightly 构建使用 Beta 配置
+            architecture: x64
+          - configuration: Beta
+            architecture: ARM64
+      fail-fast: false
+
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      configuration: ${{ matrix.configuration }}
+      architecture: ${{ matrix.architecture }}
+    secrets: inherit
+
+  create_json_and_release:
+    name: Create nightly.json and Publish
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # 需要写权限来创建/更新 Release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 获取所有历史记录以供 git-cliff 使用
+
+      - name: Download x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: PCL2_CE_Beta_x64
+          path: ./artifact/x64
+
+      - name: Download ARM64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: PCL2_CE_Beta_ARM64
+          path: ./artifact/arm64
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@git-cliff
+
+      - name: Generate changelog for unreleased changes
+        run: |
+          # 为自上次标记以来的所有提交生成更新日志
+          git-cliff --unreleased --strip all > nightly_changelog.md
+
+      - name: Prepare release assets and nightly.json
+        id: prepare_assets
+        run: |
+          # 准备可执行文件
+          EXE_X64="./artifact/x64/Plain Craft Launcher 2.exe"
+          EXE_ARM64="./artifact/arm64/Plain Craft Launcher 2.exe"
+
+          # 计算 .exe 文件的 SHA256 哈希值
+          SHA256_X64=$(sha256sum "$EXE_X64" | awk '{print $1}')
+          SHA256_ARM64=$(sha256sum "$EXE_ARM64" | awk '{print $1}')
+          echo "SHA256 for x64 exe: $SHA256_X64"
+          echo "SHA256 for ARM64 exe: $SHA256_ARM64"
+
+          # 将 .exe 文件打包成 .zip 压缩包
+          ZIP_X64="PCL2_CE_Nightly_x64.zip"
+          ZIP_ARM64="PCL2_CE_Nightly_ARM64.zip"
+          zip -j "$ZIP_X64" "$EXE_X64"
+          zip -j "$ZIP_ARM64" "$EXE_ARM64"
+          echo "Created $ZIP_X64 and $ZIP_ARM64"
+
+          # 获取版本信息
+          VERSION_NAME=$(git describe --tags --always)
+          VERSION_CODE=$(date +'%Y%m%d')
+
+          # 读取更新日志并为 JSON 转义
+          CHANGELOG=$(cat nightly_changelog.md | awk '{printf "%s\\n", $0}' | sed 's/"/\\"/g')
+
+          # 构建 nightly.json 文件
+          cat <<EOF > nightly.json
+          {
+            "version": "${VERSION_NAME}",
+            "version_code": ${VERSION_CODE},
+            "changelog": "${CHANGELOG}",
+            "assets": [
+              {
+                "arch": "x64",
+                "download_url": "https://github.com/${{ github.repository }}/releases/download/nightly/${ZIP_X64}",
+                "sha256": "${SHA256_X64}"
+              },
+              {
+                "arch": "arm64",
+                "download_url": "https://github.com/${{ github.repository }}/releases/download/nightly/${ZIP_ARM64}",
+                "sha256": "${SHA256_ARM64}"
+              }
+            ]
+          }
+          EOF
+
+          echo "Generated nightly.json:"
+          cat nightly.json
+
+      - name: Publish to Nightly Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: "Nightly Build"
+          body_path: nightly_changelog.md
+          prerelease: true
+          # 这将覆盖 'nightly' release 中的现有文件
+          files: |
+            ./PCL2_CE_Nightly_x64.zip
+            ./PCL2_CE_Nightly_ARM64.zip
+            ./nightly.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -683,6 +683,7 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
     Public IsCheckingUpdates As Boolean = False
     Public IsUpdateWaitingRestart As Boolean = False
     Public RemoteServer As New UpdatesWrapperModel({
+        New UpdatesGitHubModel() With {.SourceName = "GitHub Nightly"},
         New UpdatesMirrorChyanModel(),
         New UpdatesRandomModel({
                 New UpdatesMinioModel("https://s3.pysio.online/pcl2-ce/", "Pysio"),
@@ -690,13 +691,20 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
             }),
         New UpdatesMinioModel("https://github.com/PCL-Community/PCL2_CE_Server/raw/main/", "GitHub")
     })
-    Public ReadOnly Property IsUpdBetaChannel
-        Get
-            If VersionBaseName.Contains("beta") Then Return True
-            Return Setup.Get("SystemSystemUpdateBranch") = 1
-        End Get
-    End Property
 
+    Public Function GetCurrentUpdateChannel() As UpdateChannel
+        If VersionBaseName.Contains("nightly") Then Return UpdateChannel.nightly
+        If VersionBaseName.Contains("beta") Then Return UpdateChannel.beta
+        Select Case CType(Setup.Get("SystemSystemUpdateBranch"), Integer)
+            Case 1
+                Return UpdateChannel.beta
+            Case 2
+                Return UpdateChannel.nightly
+            Case Else
+                Return UpdateChannel.stable
+        End Select
+    End Function
+    
     Public Sub UpdateCheckByButton()
         If IsCheckingUpdates Then
             Hint("正在检查更新中，请稍后再试……")
@@ -715,7 +723,7 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
     Public Function IsVerisonLatest() As Boolean
         Try
             Return RemoteServer.IsLatest(
-            If(IsUpdBetaChannel, UpdateChannel.beta, UpdateChannel.stable),
+            GetCurrentUpdateChannel(),
             If(IsArm64System, UpdateArch.arm64, UpdateArch.x64),
             SemVer.Parse(VersionBaseName),
             VersionCode)
@@ -725,15 +733,26 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
         End Try
     End Function
     Public Sub NoticeUserUpdate(Optional Silent As Boolean = False)
+        Dim channel = GetCurrentUpdateChannel()
+        If channel = UpdateChannel.nightly Then
+            If Not IsVerisonLatest() Then
+                Dim latest = RemoteServer.GetLatestVersion(channel, If(IsArm64System, UpdateArch.arm64, UpdateArch.x64))
+                If MyMsgBoxMarkdown($"启动器有新版本可用（{VersionBaseName} -> {latest.VersionName}）。由于你选择了 Nightly 更新通道，需要立即更新才能继续使用。{vbCrLf}{vbCrLf}{latest.Changelog}", "启动器更新", "更新", "或者更新", ForceWait:=True) = 1 Or 2 Then
+                    UpdateStart(False)
+                End If
+            Else
+                If Not Silent Then Hint("启动器已是最新版 " + VersionBaseName + "，无须更新啦！", HintType.Finish)
+            End If
+            Return
+        End If
+
         If Not IsVerisonLatest() Then
             Dim latest As VersionDataModel = Nothing
             Dim checkUpdateEx As Exception = Nothing
             RunInNewThread(
                 Sub()
                     Try
-                        latest = RemoteServer.GetLatestVersion(
-                            If(IsUpdBetaChannel, UpdateChannel.beta, UpdateChannel.stable),
-                            If(IsArm64System, UpdateArch.arm64, UpdateArch.x64))
+                        latest = RemoteServer.GetLatestVersion(channel, If(IsArm64System, UpdateArch.arm64, UpdateArch.x64))
                     Catch ex As Exception
                         checkUpdateEx = ex
                     End Try
@@ -760,16 +779,12 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
         Dim DlTargetPath As String = ExePath + "PCL\Plain Craft Launcher Community Edition.exe"
         RunInNewThread(Sub()
                            Try
-                               Dim version = RemoteServer.GetLatestVersion(
-                               If(IsUpdBetaChannel, UpdateChannel.beta, UpdateChannel.stable),
-                               If(IsArm64System, UpdateArch.arm64, UpdateArch.x64))
+                               Dim channel = GetCurrentUpdateChannel()
+                               Dim version = RemoteServer.GetLatestVersion(channel, If(IsArm64System, UpdateArch.arm64, UpdateArch.x64))
                                WriteFile($"{PathTemp}CEUpdateLog.md", version.Changelog)
                                '构造步骤加载器
                                Dim Loaders As New List(Of LoaderBase)
-                               '下载
-                               Loaders.AddRange(RemoteServer.GetDownloadLoader(
-                                                If(IsUpdBetaChannel, UpdateChannel.beta, UpdateChannel.stable),
-                                                If(IsArm64System, UpdateArch.arm64, UpdateArch.x64), DlTargetPath))
+                               Loaders.AddRange(RemoteServer.GetDownloadLoader(channel, If(IsArm64System, UpdateArch.arm64, UpdateArch.x64), DlTargetPath))
                                Loaders.Add(New LoaderTask(Of Integer, Integer)("校验更新", Sub()
                                                                                            Dim curHash = GetFileSHA256(DlTargetPath)
                                                                                            If curHash <> version.SHA256 Then
@@ -906,12 +921,14 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
         Dim UpdateDesire = Setup.Get("SystemSystemUpdate")
         Dim AnnouncementDesire = Setup.Get("SystemSystemActivity")
         Select Case UpdateDesire
-            Case 0
-                If Not IsVerisonLatest() Then
+            Case 0, 1
+                If GetCurrentUpdateChannel() = UpdateChannel.nightly Then
+                    NoticeUserUpdate(True) ' Nightly 通道强制检查更新
+                ElseIf UpdateDesire = 0 AndAlso Not IsVerisonLatest() Then
                     UpdateStart(True) '静默更新
+                ElseIf UpdateDesire = 1 Then
+                    NoticeUserUpdate(True)
                 End If
-            Case 1
-                NoticeUserUpdate(True)
             Case 2, 3
                 Exit Sub
         End Select

--- a/Plain Craft Launcher 2/Modules/Updates/EnumUpdateChannel.vb
+++ b/Plain Craft Launcher 2/Modules/Updates/EnumUpdateChannel.vb
@@ -1,6 +1,7 @@
 ﻿Public Enum UpdateChannel
     stable
     beta
+    nightly
 End Enum
 
 Public Enum UpdateArch

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesGitHubModel.vb
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesGitHubModel.vb
@@ -1,0 +1,100 @@
+Imports System.IO.Compression
+Imports Newtonsoft.Json
+Imports PCL.Core.Utils
+
+Public Class UpdatesGitHubModel
+    Implements IUpdateSource
+
+    Private Const NightlyJsonUrl As String = "https://github.com/PCL-Community/PCL2-CE/releases/download/nightly/nightly.json"
+    ' Private Const NightlyJsonUrl As String = "https://r2.230225.xyz/nightly.json"
+    Private _nightlyInfo As NightlyJsonModel
+
+    Public Property SourceName As String Implements IUpdateSource.SourceName
+
+    Public Function IsAvailable() As Boolean Implements IUpdateSource.IsAvailable
+        Return True ' Assume network is available
+    End Function
+
+    Public Function RefreshCache() As Boolean Implements IUpdateSource.RefreshCache
+        Try
+            Dim jsonContent = NetGetCodeByRequestRetry(NightlyJsonUrl)
+            _nightlyInfo = JsonConvert.DeserializeObject(Of NightlyJsonModel)(jsonContent)
+            Return _nightlyInfo IsNot Nothing
+        Catch ex As Exception
+            Log(ex, "[Update] Failed to fetch nightly.json from GitHub")
+            Return False
+        End Try
+    End Function
+
+    Public Function GetLatestVersion(channel As UpdateChannel, arch As UpdateArch) As VersionDataModel Implements IUpdateSource.GetLatestVersion
+        If channel <> UpdateChannel.nightly Then Throw New NotSupportedException("UpdatesGitHubModel only supports the Nightly channel.")
+        If _nightlyInfo Is Nothing AndAlso Not RefreshCache() Then Throw New Exception("Failed to get nightly update info.")
+
+        Dim asset = GetAssetForArch(arch)
+
+        Return New VersionDataModel With {
+            .VersionName = _nightlyInfo.version,
+            .VersionCode = _nightlyInfo.version_code,
+            .SHA256 = asset.sha256,
+            .Source = SourceName,
+            .Changelog = _nightlyInfo.changelog
+        }
+    End Function
+
+    Public Function IsLatest(channel As UpdateChannel, arch As UpdateArch, currentVersion As SemVer, currentVersionCode As Integer) As Boolean Implements IUpdateSource.IsLatest
+        If channel <> UpdateChannel.nightly Then Throw New NotSupportedException("UpdatesGitHubModel only supports the Nightly channel.")
+        If _nightlyInfo Is Nothing AndAlso Not RefreshCache() Then Return True ' If we can't get info, assume we're latest to avoid errors
+
+        Return currentVersionCode >= _nightlyInfo.version_code
+    End Function
+
+    Public Function GetAnnouncementList() As VersionAnnouncementDataModel Implements IUpdateSource.GetAnnouncementList
+        Throw New Exception("GitHub Nightly 无公告系统")
+    End Function
+
+    Public Function GetDownloadLoader(channel As UpdateChannel, arch As UpdateArch, output As String) As List(Of LoaderBase) Implements IUpdateSource.GetDownloadLoader
+        If channel <> UpdateChannel.nightly Then Throw New NotSupportedException("UpdatesGitHubModel only supports the Nightly channel.")
+        If _nightlyInfo Is Nothing AndAlso Not RefreshCache() Then Throw New Exception("Failed to get nightly update info for download.")
+
+        Dim asset = GetAssetForArch(arch)
+        Dim downloadUrl = asset.download_url
+        Dim tempPath = IO.Path.Combine(PathTemp, "Cache", "Update", "Download", $"{asset.sha256}.zip")
+
+        Dim loaders As New List(Of LoaderBase)
+        ' 1. 下载更新包
+        loaders.Add(New LoaderDownload("下载更新", New List(Of NetFile) From {New NetFile({downloadUrl}, tempPath)}))
+
+        ' 2. 解压更新包，将 .exe 文件提取到 ModSecret 指定的 output 路径
+        loaders.Add(New LoaderTask(Of String, Integer)("提取文件", Sub()
+                                                                   Using fs As New IO.FileStream(tempPath, IO.FileMode.Open, IO.FileAccess.Read, IO.FileShare.Read)
+                                                                       Using zip As New ZipArchive(fs)
+                                                                           Dim entry = zip.Entries.FirstOrDefault(Function(x) x.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                                                                           If entry Is Nothing Then Throw New Exception("在下载的更新包中找不到可执行文件。")
+                                                                           entry.ExtractToFile(output, True)
+                                                                       End Using
+                                                                   End Using
+                                                               End Sub))
+        Return loaders
+    End Function
+
+    Private Function GetAssetForArch(arch As UpdateArch) As NightlyAsset
+        Dim archName = If(arch = UpdateArch.arm64, "arm64", "x64")
+        Dim asset = _nightlyInfo.assets.FirstOrDefault(Function(a) a.arch.Equals(archName, StringComparison.OrdinalIgnoreCase))
+        If asset Is Nothing Then Throw New Exception($"Nightly build for architecture {archName} not found.")
+        Return asset
+    End Function
+
+End Class
+
+Public Class NightlyJsonModel
+    Public Property version As String
+    Public Property version_code As Integer
+    Public Property changelog As String
+    Public Property assets As List(Of NightlyAsset)
+End Class
+
+Public Class NightlyAsset
+    Public Property arch As String
+    Public Property download_url As String
+    Public Property sha256 As String
+End Class

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml
@@ -38,15 +38,19 @@
                         </local:MyComboBox>
                         <TextBlock Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Left" Text="最大线程数" Margin="0,0,25,0" />
                         <local:MySlider x:Name="SliderDownloadThread" Grid.Row="4" Tag="ToolDownloadThread" MaxValue="255" Value="63" Grid.Column="1"
-                                        ToolTip="线程数越多，限速的文件下载越快，但过高的线程数可能会造成下载时非常严重的卡顿。&#xa;一般而言，64 线程已可以保证足够的下载速度。" />
+                                        ToolTip="线程数越多，限速的文件下载越快，但过高的线程数可能会造成下载时非常严重的卡顿。
+一般而言，64 线程已可以保证足够的下载速度。" />
                         <TextBlock VerticalAlignment="Center" Grid.Row="5" HorizontalAlignment="Left" Text="速度限制" Margin="0,0,25,0" />
                         <local:MySlider x:Name="SliderDownloadSpeed" Grid.Row="5" Tag="ToolDownloadSpeed" MaxValue="42" Value="42" Grid.Column="1"
                                         ToolTip="设置下载的速度上限，以避免在下载时导致其他需要联网的程序卡死" />
                         <TextBlock VerticalAlignment="Top" Grid.Row="6" HorizontalAlignment="Left" Text="目标文件夹" Margin="0,5,25,5" />
-                        <TextBlock Margin="0,5" HorizontalAlignment="Left" Text="请在 启动 → 实例选择 → 文件夹列表 中更改下载目标文件夹。&#xa;在某个文件夹或游戏实例上右键，即可选择打开对应文件夹。" Grid.Row="6" Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
+                        <TextBlock Margin="0,5" HorizontalAlignment="Left" Text="请在 启动 → 实例选择 → 文件夹列表 中更改下载目标文件夹。
+在某个文件夹或游戏实例上右键，即可选择打开对应文件夹。" Grid.Row="6" Grid.Column="1" VerticalAlignment="Center" Opacity="0.5" />
                         <TextBlock Margin="0,5" Grid.Row="7" Text="安装行为" />
                         <local:MyCheckBox Grid.Row="7" Grid.Column="1" Text="安装新实例后自动选定该实例" x:Name="CheckDownloadAutoSelectVersion" Tag="ToolDownloadAutoSelectVersion" />
-                        <local:MyCheckBox Grid.Row="7" Grid.Column="1" Margin="230,0,0,0" Text="升级部分版本的 Authlib" x:Name="CheckFixAuthlib" Tag="ToolFixAuthlib" ToolTip="部分 MC 版本（如 1.16.5）存在 Bug，可能导致使用离线验证时多人游戏被禁用。&#xa;PCL 可尝试升级这些版本的 Authlib 支持库以解决问题。&#xa;此设置仅对新安装的实例有效。"/>
+                        <local:MyCheckBox Grid.Row="7" Grid.Column="1" Margin="230,0,0,0" Text="升级部分版本的 Authlib" x:Name="CheckFixAuthlib" Tag="ToolFixAuthlib" ToolTip="部分 MC 版本（如 1.16.5）存在 Bug，可能导致使用离线验证时多人游戏被禁用。
+PCL 可尝试升级这些版本的 Authlib 支持库以解决问题。
+此设置仅对新安装的实例有效。"/>
                     </Grid>
                 </StackPanel>
             </local:MyCard>
@@ -144,9 +148,10 @@
                     </local:MyComboBox>
                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="启动器更新通道" Margin="0,0,25,0" Grid.Row="2"/>
                     <local:MyComboBox x:Name="ComboSystemUpdateBranch" Tag="SystemSystemUpdateBranch" Grid.Column="1" Grid.Row="2" 
-                        ToolTip="PCL 社区版提供了两种更新通道：&#xa;Slow Ring：较为稳定，功能通常已经过测试。&#xa;Fast Ring：更新较快，但可能包含未经充分测试的功能，可能不稳定。&#xa;&#xa;Fast Ring 仅推荐具有一定基础知识和能力的用户使用，且不适合用于制作整合包。&#xa;在升级到 Fast Ring 版本后，只能手动重新下载启动器来切换回 Slow Ring。&#xa;&#xa;如果你不知道你在干什么，请选择 Slow Ring。">
+                        ToolTip="PCL 社区版提供了三种更新通道：&#xa;Slow Ring：较为稳定，功能通常已经过测试。&#xa;Fast Ring：更新较快，但可能包含未经充分测试的功能，可能不稳定。&#xa;Nightly：每日构建，包含 dev 分支的最新更改，仅供测试使用，极不稳定。&#xa;&#xa;Fast Ring 和 Nightly 仅推荐具有一定基础知识和能力的用户使用，且不适合用于制作整合包。&#xa;在升级到 Fast Ring 或 Nightly 版本后，只能手动重新下载启动器来切换回 Slow Ring。&#xa;&#xa;如果你不知道你在干什么，请选择 Slow Ring。">
                         <local:MyComboBoxItem Content="Slow Ring" />
                         <local:MyComboBoxItem Content="Fast Ring" />
+                        <local:MyComboBoxItem Content="Nightly" />
                     </local:MyComboBox>
                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="启动器公告" Margin="0,0,25,0" Grid.Row="4" />
                     <local:MyComboBox x:Name="ComboSystemActivity" Tag="SystemSystemActivity" Grid.Column="1" Grid.Row="4">
@@ -155,7 +160,9 @@
                         <local:MyComboBoxItem Content="关闭所有公告" />
                     </local:MyComboBox>
                     <TextBlock Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Left" Text="缓存文件夹" Margin="0,0,25,0" />
-                    <local:MyTextBox x:Name="TextSystemCache" Grid.Row="6" Grid.ColumnSpan="2" Tag="SystemSystemCache" Grid.Column="1" ToolTip="PCL 的下载、皮肤等缓存文件的存储位置。&#xa;不推荐路径中带有空格。&#xa;留空即为默认值，重启 PCL 后生效。" HintText="默认">
+                    <local:MyTextBox x:Name="TextSystemCache" Grid.Row="6" Grid.ColumnSpan="2" Tag="SystemSystemCache" Grid.Column="1" ToolTip="PCL 的下载、皮肤等缓存文件的存储位置。
+不推荐路径中带有空格。
+留空即为默认值，重启 PCL 后生效。" HintText="默认">
                         <local:MyTextBox.ValidateRules>
                             <local:ValidateNullable />
                             <local:ValidateFolderPath UseMinecraftCharCheck="False" />
@@ -169,7 +176,11 @@
                                     ToolTip="实时日志功能中最大显示行数，超过该值会自动删除旧的日志。" />
                     <local:MyCheckBox Grid.Row="12" Text="禁用硬件加速" x:Name="CheckSystemDisableHardwareAcceleration" Tag="SystemDisableHardwareAcceleration"/>
                     <local:MyCheckBox Grid.Row="12" Grid.Column="1" Text="参与 PCL CE 软硬件调查" x:Name="CheckSystemTelemetry" Tag="SystemTelemetry" 
-                                      ToolTip="这是一项与 Steam 硬件调查类似的计划，参与调查可以帮助我们更好的进行规划和开发，且我们会不定期发布该调查的统计结果。&#xa;如果选择参与调查，我们将会收集以下信息：&#xa;启动器版本信息与识别码，使用的 Windows 系统版本与架构，已安装的物理内存大小，NAT 与 IPv6 支持情况，是否使用过官方版 PCL、HMCL 或 BakaXL&#xa;&#xa;这些数据均不与你关联，我们也绝不会向第三方出售数据。不参与调查不会影响你使用其他功能。"/>
+                                      ToolTip="这是一项与 Steam 硬件调查类似的计划，参与调查可以帮助我们更好的进行规划和开发，且我们会不定期发布该调查的统计结果。
+如果选择参与调查，我们将会收集以下信息：
+启动器版本信息与识别码，使用的 Windows 系统版本与架构，已安装的物理内存大小，NAT 与 IPv6 支持情况，是否使用过官方版 PCL、HMCL 或 BakaXL
+
+这些数据均不与你关联，我们也绝不会向第三方出售数据。不参与调查不会影响你使用其他功能。"/>
                     <Grid Grid.Row="13" Grid.ColumnSpan="5" Margin="0,8,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
@@ -178,9 +189,9 @@
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="35"/>
-                            <RowDefinition Height="7"/>
-                            <RowDefinition Height="35"/>
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="7" />
+                            <RowDefinition Height="35" />
                         </Grid.RowDefinitions>
                         <local:MyButton Grid.Column="0" x:Name="BtnSystemUpdate" MinWidth="100" Text="检查更新" Padding="13,0" Margin="0,0,20,0" />
                         <local:MyButton Grid.Column="1" x:Name="BtnSystemMirrorChyanKey" MinWidth="100" Text="设置 Mirror 酱 CDK" Padding="13,0" Margin="0,0,20,0" ToolTip="设置用于 Mirror 酱服务器请求的 CDK"/>
@@ -247,7 +258,8 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <local:MyHint Text="请勿填写不信任的代理地址" Grid.Row="0" Grid.ColumnSpan="5" Theme="Yellow"/>
-                        <local:MyTextBox x:Name="TextSystemHttpProxy" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="5" Tag="SystemHttpProxy" HintText="比如 http://127.0.0.1:1080/" ToolTip="不正确的代理服务器地址会导致无法连接网络，因使用代理导致的网络问题不予处理。&#xa;请勿填写不信任的代理服务器地址，这可能会导致你的账号信息泄露，甚至账号被盗。"/>
+                        <local:MyTextBox x:Name="TextSystemHttpProxy" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="5" Tag="SystemHttpProxy" HintText="比如 http://127.0.0.1:1080/" ToolTip="不正确的代理服务器地址会导致无法连接网络，因使用代理导致的网络问题不予处理。
+请勿填写不信任的代理服务器地址，这可能会导致你的账号信息泄露，甚至账号被盗。"/>
                         <TextBlock Grid.Column="0" Grid.Row="4" Text="账号" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0,5,0"/>
                         <local:MyTextBox Grid.Column="1" Grid.Row="4" HintText="如有" Tag="SystemHttpProxyCustomUsername" x:Name="TextSystemHttpProxyCustomUsername" Margin="0,0,5,0"/>
                         <TextBlock Grid.Column="2" Grid.Row="4" Text="密码" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,0,5,0"/>
@@ -273,9 +285,12 @@
                             <ColumnDefinition />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
-                        <local:MyCheckBox Grid.Column="0" Text="禁止在下载时从其他文件夹复制文件" Height="22" x:Name="CheckDebugSkipCopy" Tag="SystemDebugSkipCopy" ToolTip="在下载时不直接复制其他 MC 文件夹中已经存在的相同文件，而是重新下载文件。&#xa;只建议在测试下载速度时开启。" />
-                        <local:MyCheckBox Grid.Column="1" Text="调试模式" Height="22" x:Name="CheckDebugMode" Tag="SystemDebugMode" ToolTip="显示调试信息与更多错误信息。&#xa;这会导致启动器性能略有下降，若无特殊需要不建议开启。" />
-                        <local:MyCheckBox Grid.Column="2" Text="添加延迟" Height="22" x:Name="CheckDebugDelay" Tag="SystemDebugDelay" ToolTip="在各个环节添加随机的延迟，拖慢加载速度，以测试部分功能是否正常运行。&#xa;这会严重影响启动器运行，若无特殊需要不建议开启。" />
+                        <local:MyCheckBox Grid.Column="0" Text="禁止在下载时从其他文件夹复制文件" Height="22" x:Name="CheckDebugSkipCopy" Tag="SystemDebugSkipCopy" ToolTip="在下载时不直接复制其他 MC 文件夹中已经存在的相同文件，而是重新下载文件。
+只建议在测试下载速度时开启。" />
+                        <local:MyCheckBox Grid.Column="1" Text="调试模式" Height="22" x:Name="CheckDebugMode" Tag="SystemDebugMode" ToolTip="显示调试信息与更多错误信息。
+这会导致启动器性能略有下降，若无特殊需要不建议开启。" />
+                        <local:MyCheckBox Grid.Column="2" Text="添加延迟" Height="22" x:Name="CheckDebugDelay" Tag="SystemDebugDelay" ToolTip="在各个环节添加随机的延迟，拖慢加载速度，以测试部分功能是否正常运行。
+这会严重影响启动器运行，若无特殊需要不建议开启。" />
                     </Grid>
                 </StackPanel>
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
@@ -49,7 +49,7 @@ Class PageSetupSystem
         ComboSystemUpdate.SelectedIndex = Setup.Get("SystemSystemUpdate")
         Dim branch As Integer = Setup.Get("SystemSystemUpdateBranch")
         ComboSystemUpdateBranch.SelectedIndex = branch
-        If branch = 1 Then
+        If branch = 1 OrElse branch = 2 OrElse VersionBaseName.Contains("nightly") Then
             ComboSystemUpdateBranch.IsEnabled = False
         Else
             ComboSystemUpdateBranch.IsEnabled = True
@@ -221,15 +221,40 @@ Class PageSetupSystem
     End Sub
     Private Sub ComboSystemUpdateBranch_SelectionChanged(sender As Object, e As SelectionChangedEventArgs) Handles ComboSystemUpdateBranch.SelectionChanged
         If AniControlEnabled <> 0 Then Exit Sub
-        If ComboSystemUpdateBranch.SelectedIndex <> 1 Then Exit Sub
-        If MyMsgBox("你正在切换启动器更新通道到 Fast Ring。" & vbCrLf &
-                    "Fast Ring 可以提供下个版本更新内容的预览，但可能会包含未经充分测试的功能，稳定性欠佳。" & vbCrLf & vbCrLf &
-                    "在升级到 Fast Ring 版本后，只能手动重新下载启动器来切换回 Slow Ring。" & vbCrLf &
-                    "该选项仅推荐具有一定基础知识和能力的用户选择。如果你正在制作整合包，请使用 Slow Ring！", "继续之前...", "我已知晓", "取消", IsWarn:=True) = 2 Then
-            ComboSystemUpdateBranch.SelectedItem = e.RemovedItems(0)
-        Else
-            UpdateCheckByButton()
-        End If
+        Select Case ComboSystemUpdateBranch.SelectedIndex
+            Case 1
+                If MyMsgBox("你正在切换启动器更新通道到 Fast Ring。" & vbCrLf &
+                            "Fast Ring 可以提供下个版本更新内容的预览，但可能会包含未经充分测试的功能，稳定性欠佳。" & vbCrLf & vbCrLf &
+                            "在升级到 Fast Ring 版本后，只能手动重新下载启动器来切换回 Slow Ring。" & vbCrLf &
+                            "该选项仅推荐具有一定基础知识和能力的用户选择。如果你正在制作整合包，请使用 Slow Ring！", "继续之前...", "我已知晓", "取消", IsWarn:=True) = 2 Then
+                    ComboSystemUpdateBranch.SelectedItem = e.RemovedItems(0)
+                Else
+                    UpdateCheckByButton()
+                End If
+            Case 2
+                If MyMsgBox("你正在切换启动器更新通道到 Nightly。" & vbCrLf &
+                            "该通道可第一时间获取基于最新代码构建的开发版本，但可能极不稳定，甚至直接无法启动。" & vbCrLf & vbCrLf &
+                            "在升级到 Nightly 版本后，只能手动重新下载启动器来切换回 Slow Ring。" & vbCrLf &
+                            "该选项仅推荐高级用户选择。如果你正在制作整合包，请使用 Slow Ring！", "继续之前...", "我已知晓", "取消", IsWarn:=True) = 2 Then
+                    ComboSystemUpdateBranch.SelectedItem = e.RemovedItems(0)
+                    Return
+                End If
+                Dim ret = MyMsgBoxInput("最终确认", "你确定要切换到 Nightly 通道吗？" & vbCrLf &
+                                        "Nightly 版本可能存在严重问题，甚至无法启动！" & vbCrLf &
+                                        "在升级到 Nightly 版本后，将无法切换回其他任何更新通道，只能手动重新下载启动器来切换回 Slow Ring 或 Fast Ring。" & vbCrLf & vbCrLf &
+                                        "该选项仅推荐高级用户选择。如果你正在制作整合包，请使用 Slow Ring！" & vbCrLf &
+                                        "请输入 '我确认切换到此分支并已知晓风险' 以确认切换到 Nightly 通道。", Button1 := "提交", Button2 := "取消", IsWarn:=True)
+                If ret Is Nothing Then 
+                    ComboSystemUpdateBranch.SelectedItem = e.RemovedItems(0)
+                    Return
+                End If
+                If ret = "我确认切换到此分支并已知晓风险" Then
+                    UpdateCheckByButton()
+                Else
+                    Hint("你输入了错误的内容...")
+                    ComboSystemUpdateBranch.SelectedItem = e.RemovedItems(0)
+                End If
+        End Select
     End Sub
     Private Sub BtnSystemUpdate_Click(sender As Object, e As EventArgs) Handles BtnSystemUpdate.Click
         UpdateCheckByButton()


### PR DESCRIPTION
引入了新的更新通道 `Nightly`，该通道的目的是为部分高级用户提供包含 dev 分支的最新更改供测试使用。

Nightly 通道每晚自动构建，包含过去 24 小时内的所有更改，但稳定性极差，因此在代码中对用户操作进行了两次确认。为了确保启动器的 Bug 得到及时修复，Nightly 通道强制更新（确定按钮：“更新”；取消按钮：“或者更新”均触发更新）。其余锁定逻辑与 Fast Ring 一致。

由于我没有 Visual Basic .NET 开发经验，本 PR 大部分代码由 Rider 上的 Gemini Code Assist 编写。