### PR TITLE
fix(feedback): 更正检查更新失败的行为

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -2891,9 +2891,14 @@ NextElement:
         OpenWebsite("https://github.com/PCL-Community/PCL2-CE/issues/")
     End Sub
     Public Function CanFeedback(ShowHint As Boolean) As Boolean
-        If Not IsVerisonLatest() Then
+        Dim stat As VersionStatus = GetVersionStatus()
+        If stat <> VersionStatus.Latest Then
             If ShowHint Then
-                If MyMsgBox($"你的 PCL 不是最新版，因此无法提交反馈。{vbCrLf}请在更新后，确认该问题在最新版中依然存在，然后再提交反馈。", "无法提交反馈", "更新", "取消") = 1 Then
+                If MyMsgBox(
+                    If(stat = VersionStatus.NotLatest,
+                    $"你的 PCL 不是最新版，因此无法提交反馈。{vbCrLf}请在更新后，确认该问题在最新版中依然存在，然后再提交反馈。",
+                    $"你的 PCL 检查更新失败，因此无法提交反馈。{vbCrLf}请连接到互联网，在检查更新后，确认该问题在最新版中依然存在，然后再提交反馈。"),
+                    "无法提交反馈", If(stat = VersionStatus.NotLatest, "更新", "重新检查更新"), "取消") = 1 Then
                     UpdateCheckByButton()
                 End If
             End If

--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -711,20 +711,25 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
                            End Try
                        End Sub)
     End Sub
-    Public Function IsVerisonLatest() As Boolean
+    Public Enum VersionStatus
+        Latest
+        NotLatest
+        Unknown
+    End Enum
+    Public Function GetVersionStatus() As VersionStatus
         Try
-            Return RemoteServer.IsLatest(
+            Return If(RemoteServer.IsLatest(
             If(IsUpdBetaChannel, UpdateChannel.beta, UpdateChannel.stable),
             If(IsArm64System, UpdateArch.arm64, UpdateArch.x64),
             SemVer.Parse(VersionBaseName),
-            VersionCode)
+            VersionCode), VersionStatus.Latest, VersionStatus.NotLatest)
         Catch ex As Exception
             Log(ex, "无法获取最新版本信息，请检查网络连接", LogLevel.Hint)
-            Return False
+            Return VersionStatus.Unknown
         End Try
     End Function
     Public Sub NoticeUserUpdate(Optional Silent As Boolean = False)
-        If Not IsVerisonLatest() Then
+        If GetVersionStatus() <> VersionStatus.Latest Then
             Dim latest As VersionDataModel = Nothing
             Dim checkUpdateEx As Exception = Nothing
             RunInNewThread(
@@ -906,7 +911,7 @@ PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的
         Dim AnnouncementDesire = Setup.Get("SystemSystemActivity")
         Select Case UpdateDesire
             Case 0
-                If Not IsVerisonLatest() Then
+                If GetVersionStatus() <> VersionStatus.Latest Then
                     UpdateStart(True) '静默更新
                 End If
             Case 1

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupSystem.xaml.vb
@@ -257,7 +257,7 @@ Class PageSetupSystem
     ''' </summary>
     Public Shared Function IsLauncherNewest() As Boolean?
         Try
-            Return IsVerisonLatest()
+            Return GetVersionStatus() = VersionStatus.Latest
         Catch ex As Exception
             Log(ex, "确认启动器更新失败", LogLevel.Feedback)
             Return Nothing


### PR DESCRIPTION
Close #1964

真的超级无敌抱歉，上高中之后越来越忙了，就没登过 GitHub。

现在，检查更新失败的弹窗内容如图。

<details>
<summary>图</summary>
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/fb04ef71-6d84-44f8-8739-8e5429d8c181" />
</details>

之前龙猫拼错的 `IsVerisonLatest` （返回值 `Boolean`）被修改为 `GetVersionStatus`，返回一个 `VersionStatus` 枚举。所有引用到此方法的代码全部做了相应调整。不知道是否可行？

感谢！