### PR TITLE
imp(comp-detail): 资源下载页面使用双栏样式

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml
@@ -22,15 +22,32 @@
                     </StackPanel>
                 </StackPanel>
             </local:MyCard>
-            <StackPanel Grid.Row="1" Grid.RowSpan="2" Name="PanMain" Grid.IsSharedSizeScope="True">
-                <local:MyCard Margin="0,0,0,15" x:Name="CardFilter">
-                    <StackPanel>
-                        <StackPanel x:Name="PanInstanceFilter" Margin="10,10,0,5" Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left" />
-                        <StackPanel x:Name="PanModLoaderFilter" Margin="10,5,0,10" Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Left" />
-                    </StackPanel>
+            <Grid Grid.Row="1" x:Name="PanMain">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="1*" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="250" />
+                    <ColumnDefinition Width="1*" />
+                </Grid.ColumnDefinitions>
+                <local:MyCard Title="过滤器" Grid.Column="0" Margin="0,0,15,0" x:Name="CardFilter" VerticalAlignment="Top">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <StackPanel Margin="10,45,10,15">
+                            <TextBlock x:Name="PanInstanceFilterTag" Margin="4,0,0,8" Text="Minecraft 版本" />
+                            <WrapPanel x:Name="PanInstanceFilter" Margin="10,10,10,10" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                            <TextBlock x:Name="PanModLoaderFilterTag" Margin="4,8,0,8" Text="模组加载器" />
+                            <WrapPanel x:Name="PanModLoaderFilter" Margin="10,10,10,10" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                        </StackPanel>
+                    </Grid>
                 </local:MyCard>
-                <StackPanel Name="PanResults" />
-            </StackPanel>
+                
+                <StackPanel Grid.Column="1" Name="PanResults" />
+            </Grid>
             <local:MyCard Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" SnapsToDevicePixels="True" x:Name="PanLoad" UseAnimation="False" Margin="0,0,0,8">
                 <local:MyLoading Text="正在获取版本列表" Margin="20,20,20,17" x:Name="Load" HorizontalAlignment="Center" VerticalAlignment="Center" />
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.vb
@@ -118,25 +118,29 @@ GroupDone:
         'UI 化筛选器
         PanInstanceFilter.Children.Clear()
         PanModLoaderFilter.Children.Clear()
+        
+        'Hill 做的动态 Margin
         If Not _pageType = CompType.Mod Then
             PanInstanceFilter.Margin = New Thickness(10, 10, 0, 10)
             PanModLoaderFilter.Margin = New Thickness(0)
+        Else
+            PanInstanceFilter.Margin = New Thickness(10, 10, 0, 10)
+            PanModLoaderFilter.Margin = New Thickness(10, 10, 0, 10)
         End If
+        
         If instanceFilters.Count < 2 Then
             CardFilter.Visibility = Visibility.Collapsed
             _instanceFilter = Nothing
         Else
             CardFilter.Visibility = Visibility.Visible
-            '插入标签
+            
+            '显示标签
             If _pageType = CompType.Mod Then
-                Dim instanceTextBlock As New TextBlock With {
-                        .Text = "实例筛选：", .VerticalAlignment = VerticalAlignment.Center,
-                        .Margin = New Thickness(2, 0, 0, 0)}
-                PanInstanceFilter.Children.Add(instanceTextBlock)
-                Dim modLoaderTextBlock As New TextBlock With {
-                        .Text = "模组加载器筛选：", .VerticalAlignment = VerticalAlignment.Center,
-                        .Margin = New Thickness(2, 0, 0, 0)}
-                PanModLoaderFilter.Children.Add(modLoaderTextBlock)
+                PanModLoaderFilter.Visibility = Visibility.Visible
+                PanModLoaderFilterTag.Visibility = Visibility.Visible
+            Else
+                PanModLoaderFilter.Visibility = Visibility.Collapsed
+                PanModLoaderFilterTag.Visibility = Visibility.Collapsed
             End If
             
             instanceFilters.Insert(0, "全部")
@@ -194,8 +198,7 @@ GroupDone:
                 End If
             End If
             
-            '注意：在 Mod 下 index 0 是 TextBlock
-            Dim index As Integer = If(_pageType = CompType.Mod, 1, 0) 
+            Dim index As Integer = If(_pageType = CompType.Mod, 0, 0) 
             If instanceToCheck Is Nothing Then instanceToCheck = PanInstanceFilter.Children(index)
             If modLoaderToCheck Is Nothing And _pageType = CompType.Mod Then modLoaderToCheck = PanModLoaderFilter.Children(index)
             instanceToCheck.Checked = True


### PR DESCRIPTION
更改了资源下载页面的 UI 样式，从原本的单栏转向了双栏设计，并将过滤器的标签更改为了使用 XAML 绑定实现而非原本的 VB 内操作。

按照我最初的想法，左侧的过滤器卡片应该要实现类似 CSS 中 `position: sticky;` 的效果，但似乎 XAML 里实现这个效果非常困难，那就开摆吧。

VB 里有一些空行是我自己空的，感觉看着舒服点。

因为我自己也没什么 UI 设计灵感，欢迎提出意见和建议，我会抽时间修改。