### PR TITLE
fix(telemetry): 修复数据调查由于错误的异步处理可能发送失败

### DIFF
--- a/PCL.Core/App/TelemetryService.cs
+++ b/PCL.Core/App/TelemetryService.cs
@@ -4,22 +4,21 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using Microsoft.Win32;
 using PCL.Core.Net;
+using PCL.Core.Net.Dns;
 using PCL.Core.Net.Http.Client;
 using PCL.Core.Utils.OS;
 using STUN.Client;
 
 namespace PCL.Core.App;
 
+[LifecycleScope("Telemetry", "遥测")]
 [LifecycleService(LifecycleState.Running)]
-public class TelemetryService : GeneralService
+public partial class TelemetryService : GeneralService
 {
-    private static LifecycleContext? _context;
-    private static LifecycleContext Context => _context!;
-    private TelemetryService() : base("Telemetry", "遥测") { _context = Lifecycle.GetContext(this); }
 
     // ReSharper disable UnusedAutoPropertyAccessor.Local
 
@@ -36,22 +35,37 @@ public class TelemetryService : GeneralService
         [JsonPropertyName("UsedHMCL")] public required bool UsedHmcl { get; set; }
         [JsonPropertyName("UsedBakaXL")] public required bool UsedBakaXl { get; set; }
         public required ulong Memory { get; set; }
-        public required string NatMapBehaviour { get; set; }
-        public required string NatFilterBehaviour { get; set; }
+        public required string? NatMapBehaviour { get; set; }
+        public required string? NatFilterBehaviour { get; set; }
         [JsonPropertyName("IPv6Status")] public required string Ipv6Status { get; set; }
     }
 
-    // ReSharper restore UnusedAutoPropertyAccessor.Local
+    private const string STUN_SERVER_ADDR = "stun.miwifi.com";
 
-    public override void Start()
+    // ReSharper restore UnusedAutoPropertyAccessor.Local
+    [LifecycleStart]
+    private static async Task _StartAsync()
     {
         if (!Config.System.Telemetry) return;
         var telemetryKey = EnvironmentInterop.GetSecret("TELEMETRY_KEY");
         if (string.IsNullOrWhiteSpace(telemetryKey)) return;
         var appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var natTest = new StunClient5389UDP(new IPEndPoint(Dns.GetHostAddresses("stun.miwifi.com").First(), 3478),
-            new IPEndPoint(IPAddress.Any, 0));
-        natTest.QueryAsync().GetAwaiter().GetResult();
+
+        // stun test
+        StunClient5389UDP? natTest = default;
+        var miWifiIps = await DnsQuery.Instance.QueryForIpAsync(STUN_SERVER_ADDR).ConfigureAwait(false);
+        try
+        {
+            miWifiIps ??= await Dns.GetHostAddressesAsync(STUN_SERVER_ADDR).ConfigureAwait(false);
+        } catch(Exception) { /* Ignore dns error */ }
+        
+        if (miWifiIps != null && miWifiIps.Length != 0)
+        {
+            natTest = new StunClient5389UDP(new IPEndPoint(miWifiIps.First(), 3478),
+                new IPEndPoint(IPAddress.Any, 0));
+            await natTest.QueryAsync().ConfigureAwait(false);
+        }
+
         var telemetry = new TelemetryDeviceEnvironment
         {
             Tag = "Telemetry",
@@ -73,14 +87,14 @@ public class TelemetryService : GeneralService
             UsedHmcl = Directory.Exists(Path.Combine(appDataFolder, ".hmcl")),
             UsedBakaXl = Directory.Exists(Path.Combine(appDataFolder, "BakaXL")),
             Memory = KernelInterop.GetPhysicalMemoryBytes().Total,
-            NatMapBehaviour = natTest.State.MappingBehavior.ToString(),
-            NatFilterBehaviour = natTest.State.FilteringBehavior.ToString(),
+            NatMapBehaviour = natTest?.State.MappingBehavior.ToString(),
+            NatFilterBehaviour = natTest?.State.FilteringBehavior.ToString(),
             Ipv6Status = NetworkInterfaceUtils.GetIPv6Status().ToString()
         };
-        using var response = HttpRequestBuilder
+        using var response = await HttpRequestBuilder
             .Create("https://pcl2ce.pysio.online/post", HttpMethod.Post)
             .WithAuthentication(telemetryKey).WithJsonContent(telemetry)
-            .SendAsync().Result;
+            .SendAsync().ConfigureAwait(false);
         if (response.IsSuccess)
             Context.Info("已发送设备环境调查数据");
         else

--- a/PCL.Core/App/TelemetryService.cs
+++ b/PCL.Core/App/TelemetryService.cs
@@ -17,7 +17,7 @@ namespace PCL.Core.App;
 
 [LifecycleScope("Telemetry", "遥测")]
 [LifecycleService(LifecycleState.Running)]
-public partial class TelemetryService : GeneralService
+public sealed partial class TelemetryService
 {
 
     // ReSharper disable UnusedAutoPropertyAccessor.Local


### PR DESCRIPTION
~~哦，我的上帝呀，你们瞧瞧这段代码写的，真是太糟糕了，我指的是，像隔壁玛丽奶奶烤焦的苹果派一样糟糕——外表硬得能当砖头，内里还冒着绝望的黑烟。
看在上帝的份上，我真想脱下我的皮鞋，轻轻踢一踢那位在同步方法里写 `.Result` 的先生的屁股，蠢货！您难道没听见 `SynchronizationContext` 在角落里低声啜泣吗？
您在大庭广众之下调用 `.Result`，污蔑异步编程的优雅，你所说的“这样写很简单”都是令人愤慨的谎言，我是绝对不会，同意的！
您怎么总是支支吾吾地说“反正跑起来了”？我没法摸透您究竟是个什么样的人——是勇敢的探险家，还是那个把线程池拖进死锁沼泽的迷路羔羊？~~