### PR TITLE
fix(instance): 下载实例时有可能空引用

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -1915,7 +1915,7 @@ Public Class PageDownloadInstall
         Dim request As New McInstallRequest With {
             .TargetInstanceName = instanceName,
             .TargetInstanceFolder = $"{McFolderSelected}versions\{instanceName}\",
-            .MinecraftJson = _vanillaData("url").ToString(),
+            .MinecraftJson = _vanillaData?("url").ToString(),
             .MinecraftName = _vanillaName,
             .OptiFineEntry = SelectedOptiFine,
             .ForgeEntry = SelectedForge,


### PR DESCRIPTION
Closes #2499 
应该只有这里会 nre
（在 #2133 改了 instance-install 没想到这里还有）
（这两个页面几乎一样为什么不是一个）