### PR TITLE
feat: 加入用户环境依赖检查

### DIFF
--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -19,22 +19,20 @@ public sealed partial class DependencyCheckService
         Context.Info("开始环境检查……");
 
         if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
-            await _CheckAndAsk("Microsoft.D3DMappingLayers", " OpenGL 兼容包", "9nqpsl29bfff")
+            await _CheckAndAsk("Microsoft.D3DMappingLayers", "OpenGL 兼容包", "9nqpsl29bfff")
                 .ConfigureAwait(false);
 
-        await _CheckAndAsk("Microsoft.WebpImageExtension", " WebP 组件包", "9pg2dk419drg")
+        await _CheckAndAsk("Microsoft.WebpImageExtension", "WebP 组件包", "9pg2dk419drg")
             .ConfigureAwait(false);
-
-        Context.DeclareStopped();
     }
 
     private static async Task _CheckAndAsk(string packageId, string packageName, string storeId)
     {
         if (!await _CheckPakcageAsync(packageId))
         {
-            Context.Info($"检测到包 {packageId} 缺失，请求用户安装");
+            Context.Info($"检测到依赖缺失 (package-id = {packageId})");
             var selection = MsgBoxWrapper.Show(
-                $"当前系统缺失{packageName}，点击确定打开微软应用商店安装",
+                $"当前系统环境缺失软件运行所需依赖“{packageName}”\n\n点击确定打开微软应用商店安装",
                 buttons: ["确定", "稍后"]);
             if (selection == 1) _LaunchMsStore(storeId);
         }

--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
-namespace PCL.Core.Tools;
+namespace PCL.Core.App.Tools;
 
 [LifecycleScope("dependency-check", "依赖检查")]
 [LifecycleService(LifecycleState.Running)]

--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -28,7 +28,7 @@ public sealed partial class DependencyCheckService
 
     private static async Task _CheckAndAsk(string packageId, string packageName, string storeId)
     {
-        if (!await _CheckPakcageAsync(packageId))
+        if (!await _CheckPackageAsync(packageId))
         {
             Context.Info($"检测到依赖缺失 (package-id = {packageId})");
             var selection = MsgBoxWrapper.Show(
@@ -50,7 +50,7 @@ public sealed partial class DependencyCheckService
         ps.Start();
     }
 
-    private static async Task<bool> _CheckPakcageAsync(string id)
+    private static async Task<bool> _CheckPackageAsync(string id)
     {
         var command = $"Get-AppxPackage -Name *{id}* | ConvertTo-Json";
 
@@ -84,7 +84,7 @@ public sealed partial class DependencyCheckService
             var hasPack = false;
             foreach (var node in jnode.AsArray())
             {
-                if (CheckPackSuit(jnode, id))
+                if (node != null && CheckPackSuit(node, id))
                 {
                     hasPack = true;
                     break;

--- a/PCL.Core/Tools/DependencyCheckService.cs
+++ b/PCL.Core/Tools/DependencyCheckService.cs
@@ -1,0 +1,111 @@
+using PCL.Core.App.IoC;
+using PCL.Core.UI;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace PCL.Core.Tools;
+
+[LifecycleScope("dependency-check", "依赖检查")]
+[LifecycleService(LifecycleState.Running)]
+public sealed partial class DependencyCheckService
+{
+    [LifecycleStart]
+    private static async Task _Start()
+    {
+        Context.Info("开始环境检查……");
+
+        if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
+            await _CheckAndAsk("Microsoft.D3DMappingLayers", " OpenGL 兼容包", "9nqpsl29bfff")
+                .ConfigureAwait(false);
+
+        await _CheckAndAsk("Microsoft.WebpImageExtension", " WebP 组件包", "9pg2dk419drg")
+            .ConfigureAwait(false);
+
+        Context.DeclareStopped();
+    }
+
+    private static async Task _CheckAndAsk(string packageId, string packageName, string storeId)
+    {
+        if (!await _CheckPakcageAsync(packageId))
+        {
+            Context.Info($"检测到包 {packageId} 缺失，请求用户安装");
+            var selection = MsgBoxWrapper.Show(
+                $"当前系统缺失{packageName}，点击确定打开微软应用商店安装",
+                buttons: ["确定", "稍后"]);
+            if (selection == 1) _LaunchMsStore(storeId);
+        }
+    }
+
+    private static void _LaunchMsStore(string id)
+    {
+        Context.Info($"正在打开微软应用商店 (id = {id})");
+        var psi = new ProcessStartInfo()
+        {
+            FileName = $"ms-windows-store://pdp?launch=true&hl=zh-cn&gl=cn&referrer=storeforweb&productid={id}&mode=full",
+            UseShellExecute = true
+        };
+        using var ps = new Process() { StartInfo = psi };
+        ps.Start();
+    }
+
+    private static async Task<bool> _CheckPakcageAsync(string id)
+    {
+        var command = $"Get-AppxPackage -Name *{id}* | ConvertTo-Json";
+
+        var psi = new ProcessStartInfo()
+        {
+            FileName = "powershell.exe",
+            Arguments = $"-NoProfile -Command \"{command}\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var ps = new Process() { StartInfo = psi };
+        ps.Start();
+
+        JsonNode? jnode;
+        try
+        {
+            // ConvertTo-Json 结构不一定可靠，不太能 Serialize
+            jnode = await JsonNode.ParseAsync(ps.StandardOutput.BaseStream);
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (jnode == null) return false;
+        if (jnode.GetValueKind().Equals(JsonValueKind.Array))
+        {
+            var hasPack = false;
+            foreach (var node in jnode.AsArray())
+            {
+                if (CheckPackSuit(jnode, id))
+                {
+                    hasPack = true;
+                    break;
+                }
+
+            }
+
+            return hasPack;
+        }
+        else
+        {
+            return CheckPackSuit(jnode, id);
+        }
+
+        // 检查当前的 JsonNode 下是否是符合的包
+        static bool CheckPackSuit(JsonNode jnode, string id)
+        {
+            var findedPackName = jnode["Name"]?.GetValue<string>();
+            return findedPackName != null && findedPackName.Contains(id);
+        }
+    }
+}


### PR DESCRIPTION
Close https://github.com/PCL-Community/PCL-CE/issues/387

## Summary by Sourcery

添加一个启动依赖检查服务，用于验证所需的 Windows 运行时组件是否已安装，并通过 Microsoft Store 提示引导用户安装缺失的包。

新功能：
- 引入环境依赖检查，在应用启动时运行，检查用于图形和图像支持所需的特定 Windows 软件包是否存在。
- 当未检测到所需组件时，提示用户从 Microsoft Store 安装缺失的依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a startup dependency check service that verifies required Windows runtime components are installed and guides users to install missing packages via Microsoft Store prompts.

New Features:
- Introduce an environment dependency check that runs on app startup and inspects the presence of specific Windows packages needed for graphics and image support.
- Prompt users to install missing dependencies from Microsoft Store when required components are not detected.

</details>