### PR TITLE
imp(ioc): add some command line features to scope generator

### DIFF
--- a/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
+++ b/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
@@ -122,13 +122,17 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
                     if (awaitable) return null;
                     var command = attr.ConstructorArguments[0].Value!.ToString();
                     var paraArray = method.Parameters;
-                    var hasCommandModelArg = paraArray.Length > 0 && paraArray[0].Type.GetSimplifiedTypeName() == "PCL.Core.App.Cli.CommandLine";
+                    var skip = 0;
+                    var hasCommandModelArg = paraArray.Length > 0
+                        && paraArray[0].Type.GetSimplifiedTypeName() == "PCL.Core.App.Cli.CommandLine";
+                    if (hasCommandModelArg) skip++;
                     var hasIsCallbackArgIndex = hasCommandModelArg ? 1 : 0;
                     var hasIsCallbackArg = paraArray.Length > hasIsCallbackArgIndex
                         && paraArray[hasIsCallbackArgIndex].Type.SpecialType == SpecialType.System_Boolean
                         && paraArray[hasIsCallbackArgIndex].Name == "isCallback";
+                    if (hasIsCallbackArg) skip++;
                     var splitArgs = (
-                        from para in hasCommandModelArg ? paraArray.Skip(1) : paraArray
+                        from para in paraArray.Skip(skip)
                         let name = para.Name
                         let typeName = para.Type.GetFullyQualifiedName()
                         let hasDefaultValue = para.HasExplicitDefaultValue

--- a/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
+++ b/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
@@ -244,7 +244,8 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
         {
             var actionParamModel = argModel.HasCommandModelArg ? "model" : "_";
             var actionParamIsCallback = argModel.HasIsCallbackArg ? "isCallback" : "_";
-            yield return $"StartupService.TryHandleCommand({argModel.Command.ToLiteral()}, ({actionParamModel}, {actionParamIsCallback}) => {{";
+            yield return $"Essentials.StartupService.TryHandleCommand(" +
+                $"{argModel.Command.ToLiteral()}, ({actionParamModel}, {actionParamIsCallback}) => {{";
             var argTexts = new List<string>();
             if (argModel.HasCommandModelArg) argTexts.Add(actionParamModel);
             if (argModel.HasIsCallbackArg) argTexts.Add(actionParamIsCallback);

--- a/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
+++ b/PCL.Core.SourceGenerators/LifecycleScopeGenerator.cs
@@ -11,13 +11,14 @@ namespace PCL.Core.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public class LifecycleScopeGenerator : IIncrementalGenerator
 {
-    private const string LifecycleNamespace = "PCL.Core.App.IoC";
-    private const string ScopeAttributeType = $"{LifecycleNamespace}.LifecycleScopeAttribute";
+    private const string AppNamespace = "PCL.Core.App";
+    private const string IocNamespace = $"{AppNamespace}.IoC";
+    private const string ScopeAttributeType = $"{IocNamespace}.LifecycleScopeAttribute";
 
-    private const string StartMethodAttributeType = $"{LifecycleNamespace}.LifecycleStartAttribute";
-    private const string StopMethodAttributeType = $"{LifecycleNamespace}.LifecycleStopAttribute";
-    private const string CommandHandlerMethodAttributeType = $"{LifecycleNamespace}.LifecycleCommandHandlerAttribute";
-    private const string DependencyInjectionMethodAttributeType = $"{LifecycleNamespace}.LifecycleDependencyInjectionAttribute";
+    private const string StartMethodAttributeType = $"{IocNamespace}.LifecycleStartAttribute";
+    private const string StopMethodAttributeType = $"{IocNamespace}.LifecycleStopAttribute";
+    private const string CommandHandlerMethodAttributeType = $"{IocNamespace}.LifecycleCommandHandlerAttribute";
+    private const string DependencyInjectionMethodAttributeType = $"{IocNamespace}.LifecycleDependencyInjectionAttribute";
 
     private static readonly HashSet<string> _MethodAttributeTypes = [
         StartMethodAttributeType, StopMethodAttributeType,
@@ -37,6 +38,7 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
     private record CommandHandlerMethodModel(
         string Command,
         bool HasCommandModelArg,
+        bool HasIsCallbackArg,
         (string Name, string TypeName, bool hasDefaultValue, object? DefaultValue)[] SplitArgs
     ) : ScopeMethodModel;
 
@@ -121,6 +123,10 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
                     var command = attr.ConstructorArguments[0].Value!.ToString();
                     var paraArray = method.Parameters;
                     var hasCommandModelArg = paraArray.Length > 0 && paraArray[0].Type.GetSimplifiedTypeName() == "PCL.Core.App.Cli.CommandLine";
+                    var hasIsCallbackArgIndex = hasCommandModelArg ? 1 : 0;
+                    var hasIsCallbackArg = paraArray.Length > hasIsCallbackArgIndex
+                        && paraArray[hasIsCallbackArgIndex].Type.SpecialType == SpecialType.System_Boolean
+                        && paraArray[hasIsCallbackArgIndex].Name == "isCallback";
                     var splitArgs = (
                         from para in hasCommandModelArg ? paraArray.Skip(1) : paraArray
                         let name = para.Name
@@ -128,7 +134,7 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
                         let hasDefaultValue = para.HasExplicitDefaultValue
                         select (name, typeName, hasDefaultValue, hasDefaultValue ? para.ExplicitDefaultValue : null)
                     ).ToArray();
-                    return new CommandHandlerMethodModel(command, hasCommandModelArg, splitArgs)
+                    return new CommandHandlerMethodModel(command, hasCommandModelArg, hasIsCallbackArg, splitArgs)
                     {
                         MethodName = methodName,
                         Awaitable = false
@@ -169,7 +175,8 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
         sb.AppendLine();
         sb.AppendLine("using System;");
         sb.AppendLine("using System.Threading.Tasks;");
-        sb.AppendLine($"using {LifecycleNamespace};");
+        sb.AppendLine($"using {AppNamespace};");
+        sb.AppendLine($"using {IocNamespace};");
         sb.AppendLine();
         sb.AppendLine("#nullable enable");
         sb.AppendLine();
@@ -231,9 +238,12 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
         }
         else if (model is CommandHandlerMethodModel argModel)
         {
-            yield return $"StartupService.TryHandleCommand({argModel.Command.ToLiteral()}, (model, _) => {{";
+            var actionParamModel = argModel.HasCommandModelArg ? "model" : "_";
+            var actionParamIsCallback = argModel.HasIsCallbackArg ? "isCallback" : "_";
+            yield return $"StartupService.TryHandleCommand({argModel.Command.ToLiteral()}, ({actionParamModel}, {actionParamIsCallback}) => {{";
             var argTexts = new List<string>();
-            if (argModel.HasCommandModelArg) argTexts.Add("model");
+            if (argModel.HasCommandModelArg) argTexts.Add(actionParamModel);
+            if (argModel.HasIsCallbackArg) argTexts.Add(actionParamIsCallback);
             foreach (var (name, typeName, hasDefaultValue, defaultValue) in argModel.SplitArgs)
             {
                 var existsText = "exists_" + name;
@@ -254,7 +264,7 @@ public class LifecycleScopeGenerator : IIncrementalGenerator
             if (awaitable) yield return $"{indentStr}Func<{diModel.ParameterType}, Task>";
             else yield return $"{indentStr}Action<{diModel.ParameterType}>";
             yield return $"{indentStr}    action = {diModel.MethodName};";
-            yield return $"{indentStr}var result = IoC.DependencyGroups.InvokeInjection(action, " +
+            yield return $"{indentStr}var result = DependencyGroups.InvokeInjection(action, " +
                          $"{diModel.Identifier.ToLiteral()}, " +
                          $"(AttributeTargets){diModel.Targets});";
             var logStr = diModel.Identifier + "@" + diModel.Targets;


### PR DESCRIPTION
如果还有什么问题丢 comment，一块做了

## Summary by Sourcery

扩展生命周期作用域源代码生成器，以支持更多命令处理程序参数，并与更新后的 IoC 命名空间保持一致。

新功能：
- 允许生命周期命令处理方法声明一个可选的布尔参数 `isCallback`，该参数会由生成的代码透传。

改进：
- 更新生成器常量和生成的 `using` 语句以使用新的 `PCL.Core.App` 和 `PCL.Core.App.IoC` 命名空间。
- 调整生成的依赖注入调用，改为直接调用 `DependencyGroups`，而不是通过 IoC 的静态访问入口进行调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the lifecycle scope source generator to support additional command handler parameters and align it with updated IoC namespaces.

New Features:
- Allow lifecycle command handler methods to declare an optional boolean isCallback parameter that is passed through by the generated code.

Enhancements:
- Update generator constants and generated usings to use the new PCL.Core.App and PCL.Core.App.IoC namespaces.
- Adjust generated dependency injection calls to invoke DependencyGroups directly instead of via the IoC static access point.

</details>