### PR TITLE
feat(search): 更精确的资源中文搜索

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -1775,14 +1775,16 @@ RetryDir:
     ''' <summary>
     ''' 获取多段文本加权后的相似度。
     ''' </summary>
-    Private Function SearchSimilarityWeighted(Source As List(Of KeyValuePair(Of String, Double)), Query As String) As Double
-        Dim TotalWeight As Double = 0
-        Dim Sum As Double = 0
-        For Each Pair In Source
-            Sum += SearchSimilarity(Pair.Key, Query) * Pair.Value
-            TotalWeight += Pair.Value
+    Private Function SearchSimilarityWeighted(source As List(Of SearchSource), query As String) As Double
+        Dim totalWeight As Double = 0
+        Dim sum As Double = 0
+        For Each Pair In source
+            If Pair.Aliases.Any Then
+                sum += Pair.Aliases.Max(Function(a) SearchSimilarity(a, query)) * Pair.Weight
+            End If
+            totalWeight += Pair.Weight
         Next
-        Return Sum / TotalWeight
+        Return sum / totalWeight
     End Function
     ''' <summary>
     ''' 用于搜索的项目。
@@ -1793,9 +1795,10 @@ RetryDir:
         ''' </summary>
         Public Item As T
         ''' <summary>
-        ''' 该项目用于搜索的源。
+        ''' 该项目用于搜索的文本源。
+        ''' 在搜索时，会对每个文本源单独加权，但单个文本源内的多个别名只取最高的一个的相似度。
         ''' </summary>
-        Public SearchSource As List(Of KeyValuePair(Of String, Double))
+        Public SearchSource As List(Of SearchSource)
         ''' <summary>
         ''' 相似度。
         ''' </summary>
@@ -1804,6 +1807,21 @@ RetryDir:
         ''' 是否完全匹配。
         ''' </summary>
         Public AbsoluteRight As Boolean
+    End Class
+    ''' <summary>
+    ''' 单个用于搜索的文本源。
+    ''' </summary>
+    Public Class SearchSource
+        Public Aliases As String()
+        Public Weight As Double
+        Public Sub New(aliases As String(), Optional weight As Double = 1)
+            Me.Aliases = aliases
+            Me.Weight = weight
+        End Sub
+        Public Sub New(text As String, Optional weight As Double = 1)
+            Me.Aliases = {text}
+            Me.Weight = weight
+        End Sub
     End Class
     ''' <summary>
     ''' 进行多段文本加权搜索，获取相似度较高的数项结果。
@@ -1832,7 +1850,12 @@ RetryDir:
             Entry.Similarity = SearchSimilarityWeighted(Entry.SearchSource, Query)
 
             ' Preprocess search source keys: remove spaces and convert to lowercase
-            Dim processedSources = Entry.SearchSource.Select(Function(s) s.Key.Replace(" ", "").ToLower()).ToList()
+            Dim processedSources = Entry.SearchSource.Select(Function(s) 
+                For i = LBound(s.Aliases) To UBound(s.Aliases)
+                    s.Aliases(i) = s.Aliases(i).Replace(" ", "").ToLower()
+                Next i
+                Return s.Aliases
+                End Function).ToList()
 
             ' Check if all query parts are matched exactly by at least one source
             Dim isAbsoluteRight As Boolean = True

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
@@ -1081,6 +1081,11 @@ NoSubtitle:
         ''' </summary>
         Public SearchText As String = Nothing
         ''' <summary>
+        ''' 在进行中文搜索时，CurseForge 的替代搜索文本。
+        ''' 由于 CurseForge API 在有任意关键词未匹配的时候就不显示结果，所以不能使用与 Modrinth 相同的算法。
+        ''' </summary>
+        Public CurseForgeAltSearchText As String = Nothing
+        ''' <summary>
         ''' 允许的来源。
         ''' </summary>
         Public Source As CompSourceType = CompSourceType.Any
@@ -1127,7 +1132,7 @@ NoSubtitle:
             End If
             If ModLoader <> CompLoaderType.Any Then Address.Append("&modLoaderType=").Append(CType(ModLoader, Integer).ToString())
             If Not String.IsNullOrEmpty(GameVersion) Then Address.Append("&gameVersion=").Append(GameVersion)
-            If Not String.IsNullOrEmpty(SearchText) Then Address.Append("&searchFilter=").Append(Net.WebUtility.UrlEncode(SearchText))
+            If Not String.IsNullOrEmpty(If(CurseForgeAltSearchText, SearchText)) Then Address.Append("&searchFilter=").Append(Net.WebUtility.UrlEncode(If(CurseForgeAltSearchText, SearchText)))
             If Storage.CurseForgeOffset > 0 Then Address.Append("&index=").Append(Storage.CurseForgeOffset)
             Select Case Sort
                 Case CompSortType.Relevance
@@ -1272,67 +1277,87 @@ NoSubtitle:
                     If searchItem.ChineseName.Contains("动态的树") Then Continue For
                     Dim entry As New SearchEntry(Of CompDatabaseEntry) With {
                         .Item = searchItem,
-                        .SearchSource = New List(Of KeyValuePair(Of String, Double)) From {
-                            New KeyValuePair(Of String, Double)(
-                                searchItem.ChineseName &
-                                If(searchItem.CurseForgeSlug, "") &
-                                If(searchItem.ModrinthSlug, ""),
-                                1.0
-                            )
-                        }
+                            .SearchSource = New List(Of SearchSource) From {
+                            New SearchSource(searchItem.ChineseName.BeforeFirst(" (").Split({"/"c}, StringSplitOptions.RemoveEmptyEntries), 1), '部分 Mod 有别名
+                            New SearchSource(searchItem.ChineseName.AfterFirst(" (") & If(searchItem.CurseForgeSlug, "") & If(searchItem.ModrinthSlug, ""), 0.5)
+                            }
                     }
                     SearchEntries.Add(entry)
                 Next
             End Using
             '获取搜索结果
-            Dim SearchResults = Search(SearchEntries, Request.SearchText, 3)
+            Dim SearchResults = Search(SearchEntries, Request.SearchText, 40, 0.2)
             If Not SearchResults.Any() Then Throw New Exception("无搜索结果，请尝试搜索英文名称")
-            Dim SearchResult As String = ""
-            For i = 0 To Math.Min(4, SearchResults.Count - 1) '就算全是准确的，也最多只要 5 个
-                If Not SearchResults(i).AbsoluteRight AndAlso i >= Math.Min(2, SearchResults.Count - 1) Then Exit For '把 3 个结果拼合以提高准确度
-                If SearchResults(i).Item.CurseForgeSlug IsNot Nothing Then SearchResult += SearchResults(i).Item.CurseForgeSlug.Replace("-", " ").Replace("/", " ") & " "
-                If SearchResults(i).Item.ModrinthSlug IsNot Nothing Then SearchResult += SearchResults(i).Item.ModrinthSlug.Replace("-", " ").Replace("/", " ") & " "
-                SearchResult += SearchResults(i).Item.ChineseName.AfterLast(" (").TrimEnd(") ").BeforeFirst(" - ").
-                    Replace(":", "").Replace("(", "").Replace(")", "").ToLower.Replace("/", " ") & " "
+            '提取可能的英文名
+            Dim ExtractWords =
+                    Function(Result As SearchEntry(Of CompDatabaseEntry)) As String()
+                        Dim Word As String = ""
+                        If Result.Item.CurseForgeSlug IsNot Nothing Then Word += Result.Item.CurseForgeSlug.Replace("-", " ").Replace("/", " ") & " "
+                        If Result.Item.ModrinthSlug IsNot Nothing Then Word += Result.Item.ModrinthSlug.Replace("-", " ").Replace("/", " ") & " "
+                        Word += Result.Item.ChineseName.AfterLast(" (").TrimEnd(") ").BeforeFirst(" - ").
+                    Replace(":", "").Replace("(", "").Replace(")", "").ToLower.Replace("/", " ").Replace("-", " ")
+                        Dim Words = Word.ToLower.Split(" ")
+                        Words = Words.Select(Function(w) w.TrimStart("{[(").TrimEnd("}])")).Where(
+                            Function(w)
+                                If w.Length <= 1 Then Return False '单字词
+                                If {"the", "of", "mod", "and"}.Contains(w) Then Return False '常见词
+                                If Val(w) > 0 Then Return False '数字
+                                If w.Split(" ").Count > 3 AndAlso w.Contains("ftb") Then Return False '神秘 FTB
+                                Return True
+                            End Function).Distinct.ToArray
+                        Return Words
+                    End Function
+            Dim WordWeights As New Dictionary(Of String, Double) '各个单词及其出现的权重
+            For Each Result In SearchResults
+                For Each Word In ExtractWords(Result)
+                    Dim Similarity = If(Result.SearchSource.Any(Function(s) s.Aliases.Contains(Request.SearchText)), 100000, Result.Similarity) '完全匹配为 100000
+                    If Not WordWeights.ContainsKey(Word) Then WordWeights.Add(Word, 0)
+                    WordWeights(Word) += Similarity
+                Next
             Next
-            Log("[Comp] 中文搜索原始关键词：" & SearchResult, LogLevel.Developer)
-            '去除常见连接词
-            Dim RealFilter As String = ""
-            For Each Word In SearchResult.Split(" ")
-                If {"the", "of", "a", "mod", "and"}.Contains(Word.ToLowerInvariant) OrElse Val(Word) > 0 Then Continue For
-                If SearchResult.Split(" ").Count > 3 AndAlso {"ftb"}.Contains(Word.ToLower) Then Continue For
-                RealFilter += Word.TrimStart("{[(").TrimEnd("}])") & " "
-            Next
-            Request.SearchText = RealFilter
-            Log("[Comp] 中文搜索最终关键词：" & RealFilter, LogLevel.Developer)
+            If Not WordWeights.Any() Then Throw New Exception("无搜索结果，请尝试搜索英文名称")
+            '根据权重选取英文单词
+            Dim SortedWords = WordWeights.OrderByDescending(Function(w) w.Value).ToList
+            If SortedWords.First.Value >= 100000 Then '如果有完全匹配的，就只选完全匹配的
+                Request.SearchText = SortedWords.Where(Function(w) w.Value >= 100000).Select(Function(w) w.Key).Join(" ")
+            Else '否则，CurseForge 选第一个结果，Modrinth 选前 5 个单词
+                Request.SearchText = SortedWords.Take(5).Select(Function(w) w.Key).Join(" ")
+                Request.CurseForgeAltSearchText = ExtractWords(SearchResults.First).Join(" ")
+                Log("[Comp] 中文搜索基础关键词（CurseForge）：" & Request.CurseForgeAltSearchText, LogLevel.Developer)
+            End If
+            Log("[Comp] 中文搜索基础关键词：" & Request.SearchText, LogLevel.Developer)
         End If
-
-        '驼峰英文请求关键字处理
-        Dim SpacedKeywords = RegexPatterns.EnglishSpacedKeywords.Replace(Request.SearchText, "$& ")
-        'Request.SearchText.RegexReplace("([A-Z]+|[a-z]+?)(?=[A-Z]+[a-z]+[a-z ]*)", "$& ")
-        Dim ConnectedKeywords = Request.SearchText.Replace(" ", "")
-        Dim AllPossibleKeywords = (SpacedKeywords & " " & If(IsChineseSearch, Request.SearchText, ConnectedKeywords & " " & RawFilter)).ToLower
 
         '最终处理关键字：分割、去重
-        Dim RightKeywords As New List(Of String)
-        For Each Keyword In AllPossibleKeywords.Split(" ")
-            Keyword = Keyword.Trim("["c, "]"c)
-            If Keyword = "" Then Continue For
-            If {"forge", "fabric", "for", "mod", "quilt"}.Contains(Keyword) Then '#208
-                Log("[Comp] 已跳过搜索关键词：" & Keyword, LogLevel.Developer)
-                Continue For
-            End If
-            RightKeywords.Add(Keyword)
-        Next
-        If RawFilter.Length > 0 AndAlso Not RightKeywords.Any() Then
-            Request.SearchText = RawFilter '全都被过滤掉了
-        Else
-            Request.SearchText = Join(RightKeywords.Distinct.ToList, " ").ToLower
-        End If
+        Dim processKeywords =
+                Sub(ByRef text As String)
+                    If text Is Nothing Then Return
+                    text = text.ToLowerInvariant
+                    Dim words As New List(Of String)
+                    For Each Keyword In text.Split(" ")
+                        Keyword = Keyword.Trim("["c, "]"c)
+                        If Keyword = "" Then Continue For
+                        If {"forge", "fabric", "for", "mod", "quilt"}.Contains(Keyword) Then '#208
+                            Log("[Comp] 已跳过搜索关键词：" & Keyword, LogLevel.Developer)
+                            Continue For
+                        End If
+                        words.Add(Keyword)
+                    Next
+                    If RawFilter.Length > 0 AndAlso Not words.Any() Then
+                        text = RawFilter '全都被过滤掉了
+                    Else
+                        text = Join(words.Distinct.ToList, " ")
+                    End If
+                    '例外项：OptiForge、OptiFabric（拆词后因为包含 Forge/Fabric 导致无法搜到实际的 Mod）
+                    If RawFilter.Replace(" ", "").ContainsF("optiforge", True) Then text = "optiforge"
+                    If RawFilter.Replace(" ", "").ContainsF("optifabric", True) Then text = "optifabric"
+                End Sub
 
-        '例外项：OptiForge、OptiFabric（拆词后因为包含 Forge/Fabric 导致无法搜到实际的 Mod）
-        If RawFilter.Replace(" ", "").ContainsF("optiforge", True) Then Request.SearchText = "optiforge"
-        If RawFilter.Replace(" ", "").ContainsF("optifabric", True) Then Request.SearchText = "optifabric"
+        If Request.CurseForgeAltSearchText IsNot Nothing Then
+            processKeywords(Request.CurseForgeAltSearchText)
+            Log("[Comp] 工程列表搜索最终文本（CurseForge）：" & Request.CurseForgeAltSearchText, LogLevel.Debug)
+        End If
+        processKeywords(Request.SearchText)
         Log("[Comp] 工程列表搜索最终文本：" & Request.SearchText, LogLevel.Debug)
         Task.Progress = 0.1
 
@@ -1477,7 +1502,7 @@ Retry:
                                                   Not Storage.Results.Any(Function(b) r.IsLike(b))).ToList
         '加入列表
         RealResults.AddRange(RawResults)
-        Log($"[Comp] 去重、筛选后累计新增结果 {RealResults.Count} 个")
+        Log($"[Comp] 去重、筛选后累计新增结果 {RealResults.Count} 个（目前已有结果 {Storage.Results.Count} 个）")
 
 #End Region
 
@@ -1523,16 +1548,19 @@ Retry:
             For Each Result As CompProject In RealResults
                 Scores.Add(Result, If(Result.WikiId > 0, 0.2, 0) +
                            Math.Log10(Math.Max(Result.DownloadCount, 1) * GetDownloadCountMult(Result)) / 9)
-                Entry.Add(New SearchEntry(Of CompProject) With {.Item = Result, .SearchSource = New List(Of KeyValuePair(Of String, Double)) From {
-                          New KeyValuePair(Of String, Double)(If(IsChineseSearch, Result.TranslatedName, Result.RawName), 1),
-                          New KeyValuePair(Of String, Double)(Result.Description, 0.05)}})
+                Entry.Add(New SearchEntry(Of CompProject) With {.Item = Result, .SearchSource = New List(Of SearchSource) From {
+                             New SearchSource(If(IsChineseSearch, Result.TranslatedName, Result.RawName).Split({"/"c}, StringSplitOptions.RemoveEmptyEntries), 1),
+                             New SearchSource(Result.Description, 0.05)}})
             Next
             Dim SearchResult = Search(Entry, RawFilter, 101, -1)
             For Each OneResult In SearchResult
-                Scores(OneResult.Item) += OneResult.Similarity / SearchResult(0).Similarity '最高 1 分的相似度分
+                Scores(OneResult.Item) +=
+                    If(OneResult.AbsoluteRight, 10, OneResult.Similarity) /
+                    If(SearchResult.First.AbsoluteRight, 10, SearchResult.First.Similarity) '最高 1 分的相似度分
             Next
         End If
         '根据排序分得出结果并添加
+        If Task.IsAborted Then Throw New ThreadInterruptedException 'Upstream #8246
         Storage.Results.AddRange(
             Scores.OrderByDescending(Function(s) s.Value).Select(Function(r) r.Key))
 
@@ -1727,7 +1755,10 @@ Retry:
                     End If
                     'GameVersions
                     Dim RawVersions As List(Of String) = Data("gameVersions").Select(Function(t) t.ToString.Trim.ToLower).ToList
-                    GameVersions = RawVersions.Where(Function(v) McInstanceInfo.IsFormatFit(v)).Select(Function(v) v.Replace("-snapshot", " 预览版")).ToList
+                    GameVersions = RawVersions.
+                        Where(Function(v) McInstanceInfo.IsFormatFit(v)).
+                        Select(Function(v) v.Replace("-snapshot", " 预览版")).
+                        Distinct.ToList
                     If GameVersions.Count > 1 Then
                         GameVersions = GameVersions.Sort(AddressOf CompareVersionGe).ToList
                         If Type = CompType.ModPack Then GameVersions = New List(Of String) From {GameVersions(0)} '整合包理应只 "支持" 一个版本
@@ -1794,7 +1825,8 @@ Retry:
                     'GameVersions
                     Dim RawVersions As List(Of String) = Data("game_versions").Select(Function(t) t.ToString.Trim.ToLower).ToList
                     GameVersions = RawVersions.Where(Function(v) v.Contains(".")).
-                        Select(Function(v) If(v.Contains("-"), v.BeforeFirst("-") & " 预览版", If(v.StartsWithF("b1."), "远古版本", v))).ToList
+                        Select(Function(v) If(v.Contains("-"), v.BeforeFirst("-") & " 预览版", If(v.StartsWithF("b1."), "远古版本", v))).
+                        Distinct.ToList
                     If GameVersions.Count > 1 Then
                         GameVersions = GameVersions.Sort(AddressOf CompareVersionGe).ToList
                         If Type = CompType.ModPack Then GameVersions = New List(Of String) From {GameVersions(0)} '整合包理应只 “支持” 一个版本
@@ -1932,7 +1964,7 @@ Retry:
                 ' 注意：若 pageSize=10000 失效，需考虑分页逻辑
                 ResultJsonArray = DlModRequest($"https://api.curseforge.com/v1/mods/{ProjectId}/files?pageSize=10000", IsJson:=True)("data")
             Else
-                ResultJsonArray = DlModRequest($"https://api.modrinth.com/v2/project/{ProjectId}/version", IsJson:=True)
+                ResultJsonArray = DlModRequest($"https://api.modrinth.com/v2/project/{ProjectId}/version?include_changelog=false", IsJson:=True)
             End If
 
             CompFilesCache(ProjectId) = ResultJsonArray.

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.vb
@@ -685,13 +685,13 @@ Public Class PageDownloadCompFavorites
             For Each Item As MyListItem In CompItemList
                 If TypeOf Item.Tag IsNot CompProject Then Continue For
                 Dim Entry As CompProject = Item.Tag
-                Dim SearchSource As New List(Of KeyValuePair(Of String, Double))
-                SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.RawName, 1))
+                Dim SearchSource As New List(Of SearchSource)
+                SearchSource.Add(New SearchSource(Entry.RawName, 1))
                 If Entry.Description IsNot Nothing AndAlso Entry.Description <> "" Then
-                    SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Description, 0.4))
+                    SearchSource.Add(New SearchSource(Entry.Description, 0.4))
                 End If
-                If Entry.TranslatedName <> Entry.RawName Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.TranslatedName, 1))
-                SearchSource.Add(New KeyValuePair(Of String, Double)(String.Join("", Entry.Tags), 0.2))
+                If Entry.TranslatedName <> Entry.RawName Then SearchSource.Add(New SearchSource(Entry.TranslatedName, 1))
+                SearchSource.Add(New SearchSource(String.Join("", Entry.Tags), 0.2))
                 QueryList.Add(New SearchEntry(Of MyListItem) With {.Item = Item, .SearchSource = SearchSource})
             Next
             '进行搜索

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.vb
@@ -2034,20 +2034,20 @@ Install:
         '构造请求
         Dim QueryList As New List(Of SearchEntry(Of LocalCompFile))
         For Each Entry As LocalCompFile In CompResourceListLoader.Output.AsReadOnly()
-            Dim SearchSource As New List(Of KeyValuePair(Of String, Double))
-            SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Name, 1))
-            SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.FileName, 1))
+            Dim SearchSource As New List(Of SearchSource)
+            SearchSource.Add(New SearchSource(Entry.Name, 1))
+            SearchSource.Add(New SearchSource(Entry.FileName, 1))
             If Entry.Version IsNot Nothing Then
-                SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Version, 0.2))
+                SearchSource.Add(New SearchSource(Entry.Version, 0.2))
             End If
             If Entry.Description IsNot Nothing AndAlso Entry.Description <> "" Then
-                SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Description, 0.4))
+                SearchSource.Add(New SearchSource(Entry.Description, 0.4))
             End If
             If Entry.Comp IsNot Nothing Then
-                If Entry.Comp.RawName <> Entry.Name Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.RawName, 1))
-                If Entry.Comp.TranslatedName <> Entry.Comp.RawName Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.TranslatedName, 1))
-                If Entry.Comp.Description <> Entry.Description Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.Description, 0.4))
-                SearchSource.Add(New KeyValuePair(Of String, Double)(String.Join("", Entry.Comp.Tags), 0.2))
+                If Entry.Comp.RawName <> Entry.Name Then SearchSource.Add(New SearchSource(Entry.Comp.RawName, 1))
+                If Entry.Comp.TranslatedName <> Entry.Comp.RawName Then SearchSource.Add(New SearchSource(Entry.Comp.TranslatedName, 1))
+                If Entry.Comp.Description <> Entry.Description Then SearchSource.Add(New SearchSource(Entry.Comp.Description, 0.4))
+                SearchSource.Add(New SearchSource(String.Join("", Entry.Comp.Tags), 0.2))
             End If
             QueryList.Add(New SearchEntry(Of LocalCompFile) With {.Item = Entry, .SearchSource = SearchSource})
         Next

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.vb
@@ -373,8 +373,8 @@ Public Class PageInstanceSaves
                 Dim queryList As New List(Of SearchEntry(Of String))
                 For Each saveFolder In saveFolders
                     Dim folderName = GetFolderNameFromPath(saveFolder)
-                    Dim searchSource As New List(Of KeyValuePair(Of String, Double))
-                    searchSource.Add(New KeyValuePair(Of String, Double)(folderName, 1))
+                    Dim searchSource As New List(Of SearchSource)
+                    searchSource.Add(New SearchSource(folderName, 1))
                     queryList.Add(New SearchEntry(Of String) With {.Item = saveFolder, .SearchSource = searchSource})
                 Next
                 _searchResult = Search(queryList, SearchBox.Text, MaxBlurCount:=6, MinBlurSimilarity:=0.35).Select(Function(r) r.Item).ToList()

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.vb
@@ -1180,20 +1180,20 @@ Public Class PageInstanceSavesDatapack
                 '构造请求
                 Dim QueryList As New List(Of SearchEntry(Of LocalCompFile))
                 For Each Entry As LocalCompFile In CompResourceListLoader.Output
-                    Dim SearchSource As New List(Of KeyValuePair(Of String, Double))
-                    SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Name, 1))
-                    SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.FileName, 1))
+                    Dim SearchSource As New List(Of SearchSource)
+                    SearchSource.Add(New SearchSource(Entry.Name, 1))
+                    SearchSource.Add(New SearchSource(Entry.FileName, 1))
                     If Entry.Version IsNot Nothing Then
-                        SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Version, 0.2))
+                        SearchSource.Add(New SearchSource(Entry.Version, 0.2))
                     End If
                     If Entry.Description IsNot Nothing AndAlso Entry.Description <> "" Then
-                        SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Description, 0.4))
+                        SearchSource.Add(New SearchSource(Entry.Description, 0.4))
                     End If
                     If Entry.Comp IsNot Nothing Then
-                        If Entry.Comp.RawName <> Entry.Name Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.RawName, 1))
-                        If Entry.Comp.TranslatedName <> Entry.Comp.RawName Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.TranslatedName, 1))
-                        If Entry.Comp.Description <> Entry.Description Then SearchSource.Add(New KeyValuePair(Of String, Double)(Entry.Comp.Description, 0.4))
-                        SearchSource.Add(New KeyValuePair(Of String, Double)(String.Join("", Entry.Comp.Tags), 0.2))
+                        If Entry.Comp.RawName <> Entry.Name Then SearchSource.Add(New SearchSource(Entry.Comp.RawName, 1))
+                        If Entry.Comp.TranslatedName <> Entry.Comp.RawName Then SearchSource.Add(New SearchSource(Entry.Comp.TranslatedName, 1))
+                        If Entry.Comp.Description <> Entry.Description Then SearchSource.Add(New SearchSource(Entry.Comp.Description, 0.4))
+                        SearchSource.Add(New SearchSource(String.Join("", Entry.Comp.Tags), 0.2))
                     End If
                     QueryList.Add(New SearchEntry(Of LocalCompFile) With {.Item = Entry, .SearchSource = SearchSource})
                 Next

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml.vb
@@ -145,12 +145,12 @@
                 If Not Entry.ShowInSearch OrElse (Val(VersionBranchCode) = 50 AndAlso Not Entry.ShowInPublic) Then Continue For
                 If Not Entry.ShowInSearch OrElse (Val(VersionBranchCode) <> 50 AndAlso Not Entry.ShowInSnapshot) Then Continue For
                 QueryList.Add(New SearchEntry(Of HelpEntry) With {
-                    .Item = Entry,
-                    .SearchSource = New List(Of KeyValuePair(Of String, Double)) From {
-                        New KeyValuePair(Of String, Double)(Entry.Title, 1),
-                        New KeyValuePair(Of String, Double)(Entry.Desc, 0.5),
-                        New KeyValuePair(Of String, Double)(Entry.Search, 1.5)
-                    }
+                                 .Item = Entry,
+                                 .SearchSource = New List(Of SearchSource) From {
+                                 New SearchSource(Entry.Title, 1),
+                                 New SearchSource(Entry.Desc, 0.5),
+                                 New SearchSource(Entry.Search, 1.5)
+                                 }
                 })
                 'New KeyValuePair(Of String, Double)(If(Entry.IsEvent, If(Entry.EventData, ""), Entry.XamlContent), 0.2)
             Next


### PR DESCRIPTION
部分代码来自主线 2.12.3 更新

## 来自 Sourcery 的总结

在改进相关元数据处理和日志记录的同时，提高中文资源搜索的准确性和搜索权重。

新功能：
- 为中文搜索引入备用的 CurseForge 搜索文本，以更好地匹配 CurseForge API 的行为。

缺陷修复：
- 防止在解析 CurseForge 和 Modrinth 版本列表时出现重复的 Minecraft 游戏版本。

改进优化：
- 优化中文搜索词的提取和权重分配，从中获取更准确的英文关键词，用于跨平台的 Mod 搜索。
- 将加权搜索来源模型进行泛化，以支持每个来源拥有多个别名，并更新所有调用方以使用新的抽象层。
- 调整项目评分机制，更好地奖励精确匹配，并对相似度贡献进行归一化处理。
- 改进关键词后处理逻辑，包括对 OptiForge 和 OptiFabric 的特殊处理，以及更健壮的噪音词过滤。
- 在去重日志中增加当前结果数量信息，便于调试。
- 跳过下载不必要的 Modrinth 更新日志数据，以减小请求负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Chinese resource search accuracy and search weighting while refining related metadata handling and logging.

New Features:
- Introduce an alternative CurseForge search text specifically for Chinese searches to better align with CurseForge API behavior.

Bug Fixes:
- Prevent duplicate Minecraft game versions from appearing in parsed CurseForge and Modrinth version lists.

Enhancements:
- Refine Chinese search term extraction and weighting to derive more accurate English keywords for Mod search across platforms.
- Generalize the weighted search source model to support multiple aliases per source and update all callers to use the new abstraction.
- Adjust project scoring to better reward exact matches and normalize similarity contributions.
- Improve keyword post-processing, including special handling for OptiForge and OptiFabric, and more robust filtering of noisy terms.
- Enrich de-duplication logs with current result counts for easier debugging.
- Skip downloading unnecessary Modrinth changelog data to reduce request payloads.

</details>