### PR TITLE
fix(ModLaunch): 修复使用JAVA7及更早版本时，未设置永久代内存导致游戏频繁内存溢出崩溃的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1639,6 +1639,15 @@ LoginFinish:
         DataList.Insert(0, ArgumentJvm) '可变 JVM 参数
         DataList.Add("-Xmn" & Math.Floor(PageInstanceSetup.GetRam(McInstanceSelected, Not McLaunchJavaSelected.Installation.Is64Bit) * 1024 * 0.15) & "m")
         DataList.Add("-Xmx" & Math.Floor(PageInstanceSetup.GetRam(McInstanceSelected, Not McLaunchJavaSelected.Installation.Is64Bit) * 1024) & "m")
+        If McLaunchJavaSelected.Installation.MajorVersion <= 7 Then
+            If Not DataList.Any(Function(d) d.Contains("-XX:PermSize=") OrElse d.Contains("-XX:MaxPermSize=")) Then
+                DataList.Add("-XX:PermSize=128m")
+                DataList.Add("-XX:MaxPermSize=256m")
+                McLaunchLog("检测到 Java " & McLaunchJavaSelected.Installation.MajorVersion & "，已自动添加永久代内存参数")
+            Else
+                McLaunchLog("检测到 Java " & McLaunchJavaSelected.Installation.MajorVersion & "，用户已自定义永久代参数，跳过自动添加")
+            End If
+        End If
         DataList.Add("""-Djava.library.path=" & GetNativesFolder() & """")
         DataList.Add("-cp ${classpath}") '把支持库添加进启动参数表
 


### PR DESCRIPTION
Java 7 及更早版本使用永久代 (PermGen)​ 存储类元数据，其大小固定（默认约64-128MB），而往后的 Java 8 用元空间 (Metaspace)​ 替代了 PermGen，可自动扩展。

在使用Java7游玩1.6.4老版本怀旧时，频繁出现"java.lang.OutOfMemoryError: PermGen space"错误致客户端崩溃。

该PR永久修复了此问题，当检测到用户选择了老版本Java时，如果用户未指定这个参数，自动添加了PermGen参数，扩充预分配的内存额度。

在官方版提交完发现这里也有这个问题=v=

## Summary by Sourcery

在使用旧版 Java 启动 Minecraft 实例时，确保正确配置 JVM 内存设置，以防止与 PermGen 相关的崩溃。

Bug 修复：
- 当用户未显式设置时，对 Java 7 及更早版本自动配置 PermGen 内存选项，以避免在游戏启动过程中出现 `OutOfMemoryError: PermGen space`。

增强功能：
- 记录 PermGen 选项是被自动添加还是由于用户自定义设置而跳过，以便提供更完善的启动诊断信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure proper JVM memory configuration when launching Minecraft instances with older Java versions to prevent PermGen-related crashes.

Bug Fixes:
- Automatically configure PermGen memory options for Java 7 and earlier when not explicitly set by the user to avoid OutOfMemoryError: PermGen space during game launch.

Enhancements:
- Log whether PermGen options were auto-added or skipped due to user-defined settings for better launch diagnostics.

</details>