### PR TITLE
imp: remove MinWidth prop from PageToolsLeft

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
@@ -4,7 +4,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:PCL"
-      mc:Ignorable="d" MinWidth="150">
+      mc:Ignorable="d">
     <StackPanel Orientation="Vertical" x:Name="PanItem" Margin="0,12,0,0">
         
         <TextBlock Text="联机" Margin="13,6,5,4" Opacity="0.6" FontSize="12" />


### PR DESCRIPTION
不到谁加的，总感觉这页面 nav 莫名其妙多一块空白

## Summary by Sourcery

增强功能：
- 通过移除不必要的最小宽度约束，简化 PageToolsLeft 的布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify the PageToolsLeft layout by removing an unnecessary minimum width constraint.

</details>