### PR TITLE
fix(install): 修复 26.1 无法列表 NeoForge 的问题

### DIFF
--- a/PCL.Core/Utils/RegexPatterns.cs
+++ b/PCL.Core/Utils/RegexPatterns.cs
@@ -219,6 +219,17 @@ public static partial class RegexPatterns
 
     #endregion
 
+    #region Minecraft 下载信息
+
+    /// <summary>
+    /// 匹配 NeoForge 版本列表 JSON 中的版本号
+    /// </summary>
+    public static readonly Regex DlNeoForgeVersion = _DlNeoForgeVersion();
+    [GeneratedRegex(@"(?<="")(1\.20\.1-)?\d+\.[^\.]+\.\d+(\.\d+)?(-(beta|alpha)(\.\d+)?)?(\+snapshot-\d+)?(\+pre-\d+)?(?="")", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex _DlNeoForgeVersion();
+
+    #endregion
+    
     #region 外部组件
 
     public static readonly Regex ModIdMatch = _ModIdMatch();

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -1680,6 +1680,20 @@ RetryDir:
         End Try
     End Function
     ''' <summary>
+    ''' 搜索字符串中的所有正则匹配项。
+    ''' </summary>
+    <Extension> Public Function RegexSearch(str As String, regex As Regex, Optional options As RegexOptions = RegexOptions.None) As List(Of String)
+        Try
+            RegexSearch = New List(Of String)
+            For Each item As Match In regex.Matches(str)
+                RegexSearch.Add(item.Value)
+            Next
+        Catch ex As Exception
+            Log(ex, "正则匹配全部项出错")
+            Return New List(Of String)
+        End Try
+    End Function
+    ''' <summary>
     ''' 获取字符串中的第一个正则匹配项，若无匹配则返回 Nothing。
     ''' </summary>
     <Extension> Public Function RegexSeek(str As String, regex As String, Optional options As RegexOptions = RegexOptions.None) As String

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.vb
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.vb
@@ -1685,7 +1685,7 @@ RetryDir:
     <Extension> Public Function RegexSearch(str As String, regex As Regex, Optional options As RegexOptions = RegexOptions.None) As List(Of String)
         Try
             RegexSearch = New List(Of String)
-            For Each item As Match In regex.Matches(str)
+            For Each item As Match In regex.Matches(str, options)
                 RegexSearch.Add(item.Value)
             Next
         Catch ex As Exception

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -998,8 +998,7 @@ Public Module ModDownload
     End Sub
 
     Private Function GetNeoForgeEntries(latestJson As String, latestLegacyJson As String) As List(Of DlNeoForgeListEntry)
-        Dim versionNames = RegexSearch(latestLegacyJson & latestJson,
-                                       "(?<="")(1\.20\.1-)?\d+\.[^\.]+\.\d+(\.\d+)?(-(beta|alpha)(\.\d+)?)?(\+snapshot-\d+)?(?="")")
+        Dim versionNames = RegexSearch(latestLegacyJson & latestJson, RegexPatterns.DlNeoForgeVersion)
         Dim versions = versionNames.
             Where(Function(name) name <> "47.1.82"). '这个版本虽然在版本列表中，但不能下载
                 Select(Function(name) New DlNeoForgeListEntry(name)).

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -928,7 +928,7 @@ Public Module ModDownload
                 VersionName = ApiName
                 Version = New Version(ApiName.BeforeFirst("-"))
                 If Version.Major >= 24 Then
-                    Inherit = Version.ToString.Replace(".0", "")
+                    Inherit = Version.Major & "." & Version.Minor
                 Else
                     Inherit = "1." & Version.Major & If(Version.Minor > 0, "." & Version.Minor, "")
                 End If


### PR DESCRIPTION
Resolve #2642 

我不知道为啥这个码在 CE 这里跑不了

## Summary by Sourcery

修复 Minecraft 26.1 及相关版本的 NeoForge 版本列表与继承处理问题。

Bug 修复：
- 更正针对 Minecraft 1.26.x 及更高版本的 NeoForge 继承版本字符串生成逻辑。
- 通过使用专用的正则表达式模式解析版本列表 JSON，修复 NeoForge 版本发现功能。

增强功能：
- 添加可复用的辅助方法，用于从字符串中收集所有正则匹配结果。
- 在共享正则工具中引入集中管理的 NeoForge 版本提取正则表达式模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix NeoForge version listing and inheritance handling for Minecraft 26.1 and related versions.

Bug Fixes:
- Correct NeoForge inheritance version string generation for Minecraft 1.26.x and later.
- Fix NeoForge version discovery by using a dedicated regex pattern for parsing version list JSON.

Enhancements:
- Add a reusable helper to collect all regex matches from a string.
- Introduce a centralized regex pattern for NeoForge version extraction in the shared regex utilities.

</details>