### PR TITLE
fix: 错误地允许同时安装 Forge 与 LabyMod

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -1007,6 +1007,9 @@ Public Class PageDownloadInstall
     ''' </summary>
     Private Function LoadForgeGetError() As String
         If CompareVersionGE("1.5.1", _vanillaName) AndAlso CompareVersionGE(_vanillaName, "1.1") Then Return "无可用版本"
+        If SelectedLoaderName IsNot Nothing AndAlso Not ReferenceEquals(SelectedLoaderName, "Forge") Then
+            Return $"与 {SelectedLoaderName} 不兼容"
+        End If
         '检查 Loader
         If GetLoaderError(LoadForge) IsNot Nothing Then Return GetLoaderError(LoadForge)
         Dim loader As LoaderTask(Of String, List(Of DlForgeVersionEntry)) = LoadForge.State
@@ -1887,7 +1890,11 @@ Public Class PageDownloadInstall
         SelectedLabyModCommitRef = Nothing
         SelectedLabyModVersion = Nothing
         SelectedLabyModChannel = Nothing
-        SelectedLoaderName = Nothing
+        
+        If SelectedLoaderName = "LabyMod" Then
+            SelectedLoaderName = Nothing
+        End If
+        
         SelectedAPIName = Nothing
         CardLabyMod.IsSwapped = True
         e.Handled = True

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -1007,7 +1007,7 @@ Public Class PageDownloadInstall
     ''' </summary>
     Private Function LoadForgeGetError() As String
         If CompareVersionGE("1.5.1", _vanillaName) AndAlso CompareVersionGE(_vanillaName, "1.1") Then Return "无可用版本"
-        If SelectedLoaderName IsNot Nothing AndAlso Not ReferenceEquals(SelectedLoaderName, "Forge") Then
+        If SelectedLoaderName IsNot Nothing AndAlso SelectedLoaderName <> "Forge" Then
             Return $"与 {SelectedLoaderName} 不兼容"
         End If
         '检查 Loader

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.vb
@@ -1126,6 +1126,9 @@ Public Class PageInstanceInstall
     ''' </summary>
     Private Function LoadForgeGetError() As String
         If CompareVersionGe("1.5.1", _vanillaName) AndAlso CompareVersionGe(_vanillaName, "1.1") Then Return "无可用版本"
+        If SelectedLoaderName IsNot Nothing AndAlso Not ReferenceEquals(SelectedLoaderName, "Forge") Then
+            Return $"与 {SelectedLoaderName} 不兼容"
+        End If
         '检查 Loader
         If GetLoaderError(LoadForge) IsNot Nothing Then Return GetLoaderError(LoadForge)
         Dim loader As LoaderTask(Of String, List(Of DlForgeVersionEntry)) = LoadForge.State
@@ -2004,7 +2007,11 @@ Public Class PageInstanceInstall
         SelectedLabyModCommitRef = Nothing
         SelectedLabyModVersion = Nothing
         SelectedLabyModChannel = Nothing
-        SelectedLoaderName = Nothing
+        
+        If SelectedLoaderName = "LabyMod" Then
+            SelectedLoaderName = Nothing
+        End If
+        
         SelectedAPIName = Nothing
         CardLabyMod.IsSwapped = True
         e.Handled = True

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.vb
@@ -1126,7 +1126,7 @@ Public Class PageInstanceInstall
     ''' </summary>
     Private Function LoadForgeGetError() As String
         If CompareVersionGe("1.5.1", _vanillaName) AndAlso CompareVersionGe(_vanillaName, "1.1") Then Return "无可用版本"
-        If SelectedLoaderName IsNot Nothing AndAlso Not ReferenceEquals(SelectedLoaderName, "Forge") Then
+        If SelectedLoaderName IsNot Nothing AndAlso SelectedLoaderName <> "Forge" Then
             Return $"与 {SelectedLoaderName} 不兼容"
         End If
         '检查 Loader


### PR DESCRIPTION
close #2408 
https://github.com/PCL-Community/PCL-CSharpE/commit/981ba69890bcdab6e21d8d89f64320a17e3490f3
https://github.com/PCL-Community/PCL-CSharpE/commit/19ec15feb282e884dd021982cc68ae8afae9ed39
由于 C#E 在短期内似乎不太可能被合并了，所以先同步过来

## Summary by Sourcery

防止同时安装 Forge 和 LabyMod 这种不兼容的组合，并统一“下载页面”和“实例安装页面”中的加载器选择行为。

Bug 修复：
- 当已选择 LabyMod 等其他加载器时，禁止再选择 Forge，转而显示兼容性错误提示。
- 确保在取消选择 LabyMod 时，只在 LabyMod 是当前活动加载器的情况下才清除加载器选择，避免意外重置其他加载器的选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent incompatible simultaneous installation of Forge and LabyMod and align loader selection behavior between download and instance install pages.

Bug Fixes:
- Disallow selecting Forge when another loader such as LabyMod is already selected by surfacing a compatibility error instead.
- Ensure unselecting LabyMod only clears the loader selection when LabyMod was the active loader, avoiding unintended resets of other loader choices.

</details>