### PR TITLE
fix(telemetry): correct log level handling

### DIFF
--- a/PCL.Core/App/Essentials/TelemetryService.cs
+++ b/PCL.Core/App/Essentials/TelemetryService.cs
@@ -64,15 +64,17 @@ public sealed partial class TelemetryService
     // 错误上报
     public static void ReportException(Exception ex, string plain, LogLevel level)
     {
-        var sentryEvent = new SentryEvent(ex);
-        
-        sentryEvent.Level = level.RealLevel() switch
+        var sentryEvent = new SentryEvent(ex)
         {
-            LogLevel.Fatal => SentryLevel.Fatal,
-            LogLevel.Error => SentryLevel.Error,
-            LogLevel.Warning => SentryLevel.Warning,
-            LogLevel.Info => SentryLevel.Info,
-            LogLevel.Debug or LogLevel.Trace => SentryLevel.Debug,
+            Level = level.RealLevel() switch
+            {
+                LogLevel.Fatal => SentryLevel.Fatal,
+                LogLevel.Error => SentryLevel.Error,
+                LogLevel.Warning => SentryLevel.Warning,
+                LogLevel.Info => SentryLevel.Info,
+                LogLevel.Debug or LogLevel.Trace => SentryLevel.Debug,
+                _ => throw new ArgumentOutOfRangeException(nameof(level))
+            }
         };
 
         if (!string.IsNullOrWhiteSpace(plain))

--- a/PCL.Core/Logging/LogService.cs
+++ b/PCL.Core/Logging/LogService.cs
@@ -52,7 +52,7 @@ public class LogService : ILifecycleLogService
         
         // log
 #if !TRACE
-        if (level != ActionLevel.TraceLog)
+        if (actionLevel != ActionLevel.TraceLog)
 #endif
         Logger.Log(formatted);
 


### PR DESCRIPTION
## Summary by Sourcery

修复遥测报告和日志记录中对日志级别处理不正确的问题。

Bug 修复：
- 确保 Sentry 事件能正确地将应用程序的日志级别映射到 Sentry 日志级别，并对不支持的值进行校验。
- 在决定是否在非 trace 构建中跳过 trace 日志时，使用操作（action）的日志级别，而不是消息（message）的日志级别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect handling of log levels in telemetry reporting and logging.

Bug Fixes:
- Ensure Sentry events correctly map application log levels to Sentry log levels, including validation for unsupported values.
- Use the action log level rather than the message log level when deciding whether to skip trace logs in non-trace builds.

</details>