### PR TITLE
feat: support 26w14a

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
@@ -1244,6 +1244,8 @@ ExitDataLoad:
             Return "2024 | 毒马铃薯一直都被大家忽视和低估，于是我们超级加强了它！"
         ElseIf name = "25w14craftmine" Then
             Return "2025 | 你可以合成任何东西——包括合成你的世界！"
+        ElseIf Name = "26w14a" Then
+            Return "2026 | 为什么需要物品栏？让方块们跟着你走吧！"
         Else
             Return ""
         End If

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadClient.xaml.vb
@@ -48,7 +48,7 @@
                                 Version("id") = "20w14∞"
                                 Version("type") = "special"
                                 Version.Add("lore", GetMcFoolName(Version("id")))
-                            Case "3d shareware v1.34", "1.rv-pre1", "15w14a", "2.0", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine"
+                            Case "3d shareware v1.34", "1.rv-pre1", "15w14a", "2.0", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine", "26w14a"
                                 Type = "愚人节版"
                                 Version("type") = "special"
                                 Version.Add("lore", GetMcFoolName(Version("id")))

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -757,7 +757,7 @@ Public Class PageDownloadInstall
                                 Version("id") = "20w14∞"
                                 Version("type") = "special"
                                 Version.Add("lore", GetMcFoolName(Version("id")))
-                            Case "3d shareware v1.34", "1.rv-pre1", "15w14a", "2.0", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine"
+                            Case "3d shareware v1.34", "1.rv-pre1", "15w14a", "2.0", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine", "26w14a"
                                 Type = "愚人节版"
                                 Version("type") = "special"
                                 Version.Add("lore", GetMcFoolName(Version("id")))


### PR DESCRIPTION
close #2661

## Summary by Sourcery

在下载和安装流程中新增对全新 26w14a《我的世界》愚人节快照的支持。

新功能：
- 在客户端下载页面和安装页面中，将 26w14a 识别为特殊的愚人节版本。
- 在《我的世界》版本元数据中，为 26w14a 快照提供本地化的背景/描述字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the new 26w14a Minecraft April Fools snapshot across download and install flows.

New Features:
- Recognize 26w14a as a special April Fools edition in both client download and install pages.
- Provide a localized lore/description string for the 26w14a snapshot in the Minecraft version metadata.

</details>