### PR TITLE
refactor(promote): use ioc in operation registration

### DIFF
--- a/PCL.Core/App/Essentials/PromoteService.cs
+++ b/PCL.Core/App/Essentials/PromoteService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
@@ -24,7 +25,7 @@ public sealed class PromoteService : GeneralService
     
     private static readonly ConcurrentQueue<PromoteOperation> _PendingOperations = [];
     
-    private record PromoteOperation(string Command, Action<string>? Callback, bool DetailLog);
+    private readonly record struct PromoteOperation(string Command, Action<string?>? Callback, bool DetailLog);
     
     /// <summary>
     /// 提权进程是否正在运行。
@@ -38,7 +39,9 @@ public sealed class PromoteService : GeneralService
     
     private static string _GetPromotePipeName(int processId) => $"PCLCE_PM@{processId}";
 
-    private static readonly Dictionary<string, Func<string?, string?>> _OperationFunctions = new();
+    private static readonly Dictionary<string, PromoteOperationFunction> _OperationFunctions = new();
+
+    public delegate string? PromoteOperationFunction(string? arg);
 
     /// <summary>
     /// 添加提权操作，仅在提权进程中有效。
@@ -46,7 +49,7 @@ public sealed class PromoteService : GeneralService
     /// <param name="name">操作名</param>
     /// <param name="operation">操作实现，接收参数并返回结果，返回值会被自动压缩为单行</param>
     /// <returns>是否添加成功，若在主进程中调用或已存在相同操作名，则为 <c>false</c></returns>
-    public static bool AddOperationFunction(string name, Func<string?, string?> operation)
+    public static bool AddOperationFunction(string name, PromoteOperationFunction operation)
     {
         return IsCurrentProcessPromoted && _OperationFunctions.TryAdd(name, operation);
     }
@@ -71,27 +74,30 @@ public sealed class PromoteService : GeneralService
     private const string OperationErrNotFound = "ERR_OPERATION_NOT_FOUND";
     private const string OperationErrInvalidArgument = "ERR_ILLEGAL_ARGUMENT";
     private const string OperationErrExceptionThrown = "ERR_UNHANDLED_EXCEPTION";
-    private const string OperationErrEmpty = "EMPTY";
+    private const string OperationErrEmpty = "ERR_EMPTY";
     
     /// <summary>
     /// 提权进程接收到操作请求时触发的事件，接收一个字符串作为操作命令并返回一个字符串作为结果。<br/>
     /// <b>注意：如果你不知道这是做什么的，请勿覆盖默认实现。</b>请使用 <see cref="AddOperationFunction"/>。
     /// </summary>
-    public static Func<string, string?> Operate { private get; set; } = command =>
-    {
-        var split = command.Split([' '], 2);
-        _OperationFunctions.TryGetValue(split[0], out var operation);
-        if (operation == null) return OperationErrNotFound;
-        try
+    public static Func<string, string?> Operate {
+        private get => field ??= command =>
         {
-            return operation(split.Length > 1 ? split[1] : null) ?? OperationErrEmpty;
-        }
-        catch (Exception ex)
-        {
-            Context.Warn("操作出错", ex);
-            return OperationErrExceptionThrown;
-        }
-    };
+            var split = command.Split([' '], 2);
+            _OperationFunctions.TryGetValue(split[0], out var operation);
+            if (operation == null) return OperationErrNotFound;
+            try
+            {
+                return operation(split.Length > 1 ? split[1] : null) ?? OperationErrEmpty;
+            }
+            catch (Exception ex)
+            {
+                Context.Warn("操作出错", ex);
+                return OperationErrExceptionThrown;
+            }
+        };
+        set;
+    } = null!;
     
     private static string _ShortenString(string str)
     {
@@ -165,6 +171,7 @@ public sealed class PromoteService : GeneralService
             }
             var resultLog = operation.DetailLog ? result : _ShortenString(result);
             Context.Trace($"执行结果: {resultLog}");
+            if (result == OperationErrEmpty) result = null;
             operation.Callback?.Invoke(result);
         }
         return false;
@@ -195,13 +202,10 @@ public sealed class PromoteService : GeneralService
     /// <param name="command">操作命令</param>
     /// <param name="callback">结果返回后的回调</param>
     /// <param name="detailLog">指定是否打印详细日志，若为 <c>false</c>，则日志仅保留前 40 或 15 字符（取决于是否为调试构建）</param>
-    public static void Append(string command, Action<string>? callback = null, bool detailLog = true)
+    public static void Append(string command, Action<string?>? callback = null, bool detailLog = true)
     {
         _PendingOperations.Enqueue(new PromoteOperation(command, callback, detailLog));
     }
-    
-    [Obsolete("请使用 Append()")]
-    public static void AppendOperation(string command, Action<string>? callback = null, bool detailLog = true) => Append(command, callback, detailLog);
 
     /// <summary>
     /// 尝试启动提权进程并开始执行操作。
@@ -215,24 +219,20 @@ public sealed class PromoteService : GeneralService
     }
 
     /// <summary>
-    /// 向等待区添加操作并开始执行。即使未成功开始执行，添加的操作也不会自动移除。
+    /// 标记一个方法，使其能够被提权进程调用，方法签名需符合 <see cref="PromoteOperationFunction"/>。
     /// </summary>
-    /// <param name="command">操作命令</param>
-    /// <param name="callback">结果返回后的回调</param>
-    /// <param name="detailLog">指定是否打印详细日志，若为 <c>false</c>，则日志仅保留前 40 或 15 字符（取决于是否为调试构建）</param>
-    /// <returns>是否成功开始执行，若提权进程启动失败则为 <c>false</c></returns>
-    public static bool AppendAndActivate(string command, Action<string>? callback = null, bool detailLog = true)
-    {
-        Append(command, callback, detailLog);
-        return Activate();
-    }
+    /// <param name="name">提权操作名</param>
+    [DependencyCollector<PromoteOperationFunction>("promote", AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class PromoteOperationAttribute(string name) : Attribute;
 
     private static readonly Dictionary<string, Process> _RunningProcesses = new();
     
     // name: kill
     // arg: process-id [timeout]
     // return: kill result (false over timeout)
-    private static string? _KillProcess(string? arg)
+    [PromoteOperation("kill")]
+    public static string? KillProcess(string? arg)
     {
         if (arg == null) return OperationErrInvalidArgument;
         var split = arg.Split(' ');
@@ -250,12 +250,13 @@ public sealed class PromoteService : GeneralService
     // name: start
     // arg: path\to\executable[.] ; arguments
     // return: process id
-    private static string? _StartProcess(string? arg)
+    [PromoteOperation("start")]
+    public static string? StartProcess(string? arg)
     {
         if (arg == null) return OperationErrInvalidArgument;
         var split = arg.Split([" ; "], 2, StringSplitOptions.RemoveEmptyEntries);
         var createNoWindow = false;
-        if (split[0].EndsWith("."))
+        if (split[0].EndsWith('.'))
         {
             split[0] = split[0][..^1];
             createNoWindow = true;
@@ -286,6 +287,11 @@ public sealed class PromoteService : GeneralService
         _RunningProcesses[id] = process;
         return id;
     }
+
+    private static void _LoadPromoteOperations(ImmutableList<(PromoteOperationFunction func, string name)> items)
+    {
+        foreach (var (func, name) in items) AddOperationFunction(name, func);
+    }
     
     public override void Start()
     {
@@ -295,12 +301,14 @@ public sealed class PromoteService : GeneralService
             Context.Info("当前进程为提权进程");
             IsCurrentProcessPromoted = true;
             // 预定义操作
-            AddOperationFunction("start", _StartProcess);
+            Context.Info("正在加载提权操作");
+            Action<ImmutableList<(PromoteOperationFunction, string)>> action = _LoadPromoteOperations;
+            DependencyGroups.InvokeInjection(action, "promote", AttributeTargets.Method);
             AddJsonOperationFunction<ProcessStartInfo>("start-json", _StartProcessWithInfo);
-            AddOperationFunction("kill", _KillProcess);
             // 结束生命周期管理，启动提权操作线程
             Lifecycle.PendingLogFileName = "LastPending_Promote.log";
-            new Thread(() => _PerformAsPromoteProcess(args[2])) { Name = "Promote" }.Start();
+            Context.Info("正在启动服务线程");
+            new Thread(() => _PerformAsPromoteProcess(args[1])) { Name = "Promote" }.Start();
             Context.RequestStopLoading();
             Context.DeclareStopped();
         }


### PR DESCRIPTION
## Summary by Sourcery

重构 promote 服务，以支持基于 IoC 的特权操作注册与调用，同时收紧操作结果处理和回调逻辑。

新特性：
- 引入 `PromoteOperationAttribute` 和依赖收集机制，以按名称自动注册 promote 操作。
- 将 kill 和 start 进程操作作为公开的、由特性驱动的 promote 操作暴露出来，取代原先的硬编码注册方式。

缺陷修复：
- 修复 promote 服务线程启动参数索引的问题，并统一空操作错误码的命名。

改进与优化：
- 将 promote 操作的存储和回调改为使用专门的委托类型以及支持可空的签名。
- 对 `Operate` 处理程序进行延迟初始化，提供一个默认实现，该实现使用通过 IoC 注册的操作和标准化的错误码。
- 调整服务启动流程，通过依赖注入加载 promote 操作，并更新日志以反映新的初始化流程。
- 对排队的 promote 操作使用轻量级的只读结构体，并优化空结果错误码的处理，使回调接收到 `null` 而不是占位字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the promote service to support IoC-based registration and invocation of privileged operations while tightening operation result handling and callbacks.

New Features:
- Introduce a PromoteOperationAttribute and dependency-collection mechanism to auto-register promote operations by name.
- Expose kill and start process operations as public, attribute-driven promote operations instead of hard-coded registrations.

Bug Fixes:
- Fix the promote service thread startup argument index and normalize the empty-operation error code name.

Enhancements:
- Change promote operation storage and callbacks to use a dedicated delegate type and nullable-aware signatures.
- Lazy-initialize the Operate handler with a default implementation that uses the IoC-registered operations and standardized error codes.
- Adjust service startup to load promote operations via dependency injection and update logging to reflect the new initialization flow.
- Use a lightweight readonly struct for queued promote operations and refine the empty-result error code handling so callbacks receive null instead of a sentinel string.

</details>