### PR TITLE
fix(mem-swap): “all” in mem swap does not include combining physical memory

### DIFF
--- a/PCL.Core/App/Tools/MemSwapWorks.cs
+++ b/PCL.Core/App/Tools/MemSwapWorks.cs
@@ -15,7 +15,7 @@ public enum MemSwapScope
     PurgeLowPriorityStandbyList = 1 << 4,
     RegistryReconciliation = 1 << 5,
     CombinePhysicalMemory = 1 << 6,
-    All = 0b111111
+    All = 0b1111111
 }
 
 // ReSharper disable InconsistentNaming


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保 `MemSwapScope.All` 标志包含 `CombinePhysicalMemory`，从而修复在请求所有内存交换操作时覆盖范围不完整的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the MemSwapScope.All flag includes CombinePhysicalMemory, fixing incomplete coverage when requesting all memory swap actions.

</details>