### PR TITLE
fix: wrong mc version formatter on a1.2.2a

### DIFF
--- a/PCL.Core/Minecraft/McFormatter.cs
+++ b/PCL.Core/Minecraft/McFormatter.cs
@@ -68,12 +68,12 @@ public static class McFormatter {
             return id.Replace("_experimental-snapshot-", "-exp");
         }
 
-        if (id.StartsWith("inf-")) return id.Replace("inf-", "Infdev_");
-        if (id.StartsWith("in-")) return id.Replace("in-", "Indev_");
+        if (id.StartsWith("inf-")) return "Infdev_" + id[4..];
+        if (id.StartsWith("in-")) return "Indev_" + id[3..];
         if (id.StartsWith("rd-")) return "pre-Classic_" + id;
-        if (id.StartsWith('b')) return id.Replace("b", "Beta_");
-        if (id.StartsWith('a')) return id.Replace("a", "Alpha_v");
+        if (id.StartsWith('b')) return "Beta_" + id[1..];
+        if (id.StartsWith('a')) return "Alpha_v" + id[1..];
 
-        return id.StartsWith('c') ? id.Replace("c", "Classic_").Replace("st", "SURVIVAL_TEST") : id;
+        return id.StartsWith('c') ? ("Classic_" + id[1..]).Replace("st", "SURVIVAL_TEST") : id;
     }
 }


### PR DESCRIPTION
Fix #2625 

> Generated By GPT 5.4

## 由 Sourcery 提供的总结

修正适用于 Indev、Infdev、Classic、Alpha 和 Beta 标识符的旧版 Minecraft 版本字符串格式。

错误修复：
- 修复错误的替换逻辑，该逻辑会导致格式化后的版本如 `a1.2.2a` 出现格式错误。
- 确保 Classic 的 `SURVIVAL_TEST` 变体能够被正确格式化，同时不更改无关字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct legacy Minecraft version string formatting for Indev, Infdev, Classic, Alpha, and Beta identifiers.

Bug Fixes:
- Fix incorrect replacement logic that caused malformed formatted versions such as a1.2.2a.
- Ensure Classic SURVIVAL_TEST variants are formatted correctly without altering unrelated characters.

</details>