### PR TITLE
fix(mem-swap): release lock

### DIFF
--- a/PCL.Core/App/Tools/MemSwapService.cs
+++ b/PCL.Core/App/Tools/MemSwapService.cs
@@ -31,38 +31,46 @@ public sealed partial class MemSwapService
         Context.Info("收到内存交换请求，开始处理");
         if (showHint) HintWrapper.Show("正在进行内存优化");
 
-        var before = KernelInterop.GetAvailablePhysicalMemoryBytes();
-        Context.Info($"处理前内存量 {ByteStream.GetReadableLength((long)before)}");
-
-        // 添加内存处理提权操作
-        PromoteService.Append("mem-swap", result =>
+        try
         {
-            try
-            {
-                if (result == null)
-                {
-                    var after = KernelInterop.GetAvailablePhysicalMemoryBytes();
-                    Context.Info($"处理后内存量 {ByteStream.GetReadableLength((long)after)}");
-                    var diff = Math.Max(0, after - before);
-                    var afterStr = ByteStream.GetReadableLength((long)after);
-                    var diffStr = ByteStream.GetReadableLength((long)diff);
-                    Context.Info($"处理结束，总共处理 {diffStr}");
-                    if (showHint) MsgBoxWrapper.Show($"内存优化结束，共优化 {diffStr}，目前可用内存 {afterStr}");
-                }
-                else
-                {
-                    Context.Error($"内存优化失败\n\n详细信息: {result}", actionLevel: ActionLevel.MsgBoxErr);
-                }
-            }
-            catch (Exception ex) { Context.Error("内存优化失败", ex); }
-            finally { _MemSwapLock.Release(); }
-        });
+            var before = KernelInterop.GetAvailablePhysicalMemoryBytes();
+            Context.Info($"处理前内存量 {ByteStream.GetReadableLength((long)before)}");
 
-        // 执行操作
-        if (PromoteService.Activate()) return true;
-        _MemSwapLock.Release();
-        if (showHint) MsgBoxWrapper.Show("提权进程启动失败，请允许管理员权限以使用内存优化", "内存优化失败");
-        return false;
+            // 添加内存处理提权操作
+            PromoteService.Append("mem-swap", result =>
+            {
+                try
+                {
+                    if (result == null)
+                    {
+                        var after = KernelInterop.GetAvailablePhysicalMemoryBytes();
+                        Context.Info($"处理后内存量 {ByteStream.GetReadableLength((long)after)}");
+                        var diff = Math.Max(0, after - before);
+                        var afterStr = ByteStream.GetReadableLength((long)after);
+                        var diffStr = ByteStream.GetReadableLength((long)diff);
+                        Context.Info($"处理结束，总共处理 {diffStr}");
+                        if (showHint) MsgBoxWrapper.Show($"内存优化结束，共优化 {diffStr}，目前可用内存 {afterStr}");
+                    }
+                    else
+                    {
+                        Context.Error($"内存优化失败\n\n详细信息: {result}", actionLevel: ActionLevel.MsgBoxErr);
+                    }
+                }
+                catch (Exception ex) { Context.Error("内存优化失败", ex); }
+                finally { _MemSwapLock.Release(); }
+            });
+
+            // 执行操作
+            if (PromoteService.Activate()) return true;
+            _MemSwapLock.Release();
+            if (showHint) MsgBoxWrapper.Show("提权进程启动失败，请允许管理员权限以使用内存优化", "内存优化失败");
+            return false;
+        }
+        catch (Exception)
+        {
+            _MemSwapLock.Release();
+            throw;
+        }
     }
 
     [LifecycleCommandHandler("memory")]

--- a/PCL.Core/App/Tools/MemSwapService.cs
+++ b/PCL.Core/App/Tools/MemSwapService.cs
@@ -19,23 +19,25 @@ public sealed partial class MemSwapService
     /// 开始内存交换处理。
     /// </summary>
     /// <param name="showHint">是否显示提示</param>
-    public static void MemorySwap(bool showHint = true)
+    /// <returns>请求是否成功，注意：该结果不能表示在提权进程中执行的内存操作是否成功</returns>
+    public static bool MemorySwap(bool showHint = true)
     {
         if (!_MemSwapLock.Wait(0))
         {
             Context.Warn("检测到正在进行的内存处理，取消当前处理");
             if (showHint) HintWrapper.Show("内存优化尚未结束，请稍等！");
-            return;
+            return false;
         }
         Context.Info("收到内存交换请求，开始处理");
         if (showHint) HintWrapper.Show("正在进行内存优化");
-        try
+
+        var before = KernelInterop.GetAvailablePhysicalMemoryBytes();
+        Context.Info($"处理前内存量 {ByteStream.GetReadableLength((long)before)}");
+
+        // 添加内存处理提权操作
+        PromoteService.Append("mem-swap", result =>
         {
-            var before = KernelInterop.GetAvailablePhysicalMemoryBytes();
-            Context.Info($"处理前内存量 {ByteStream.GetReadableLength((long)before)}");
-            
-            // 开始内存处理
-            PromoteService.Append("mem-swap", result =>
+            try
             {
                 if (result == null)
                 {
@@ -51,17 +53,16 @@ public sealed partial class MemSwapService
                 {
                     Context.Error($"内存优化失败\n\n详细信息: {result}", actionLevel: ActionLevel.MsgBoxErr);
                 }
-                _MemSwapLock.Release();
-            });
-            if (!PromoteService.Activate() && showHint)
-            {
-                MsgBoxWrapper.Show("提权进程启动失败，请允许管理员权限以使用内存优化", "内存优化失败");
             }
-        }
-        catch (Exception ex)
-        {
-            Context.Error("内存优化失败", ex, ActionLevel.MsgBoxErr);
-        }
+            catch (Exception ex) { Context.Error("内存优化失败", ex); }
+            finally { _MemSwapLock.Release(); }
+        });
+
+        // 执行操作
+        if (PromoteService.Activate()) return true;
+        _MemSwapLock.Release();
+        if (showHint) MsgBoxWrapper.Show("提权进程启动失败，请允许管理员权限以使用内存优化", "内存优化失败");
+        return false;
     }
 
     [LifecycleCommandHandler("memory")]


### PR DESCRIPTION
Close #2689

## Summary by Sourcery

从内存交换操作中返回一个布尔类型的成功标志，并确保内部锁始终会被释放，包括在权限提升失败或发生异常的情况下。

Bug 修复：
- 通过在成功和失败路径（包括在提权回调中）都释放锁，防止内存交换锁被持续占用。

增强：
- 修改内存交换 API，使其返回一个布尔值，用于指示启动提权操作请求是否已成功发出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Return a boolean success flag from the memory swap operation and ensure the internal lock is always released, including when elevation fails or exceptions occur.

Bug Fixes:
- Prevent the memory swap lock from remaining held by always releasing it in both success and failure paths, including within the elevated callback.

Enhancements:
- Change the memory swap API to return a boolean indicating whether the request to start the elevated operation was successfully made.

</details>