### PR TITLE
chore(deps): upgrade sentry and yaml

### DIFF
--- a/PCL.Core/App/Essentials/TelemetryService.cs
+++ b/PCL.Core/App/Essentials/TelemetryService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -72,7 +72,7 @@ public sealed partial class TelemetryService
         
         SentrySdk.ConfigureScope(scope =>
         {
-            scope.User = new User
+            scope.User = new SentryUser
             {
                 Id = Utils.Secret.Identify.LauncherId
             };

--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -57,7 +57,7 @@
         <PackageReference Include="SharpZipLib" Version="1.4.2" />
         <!-- 配置文件和数据库 -->
         <PackageReference Include="System.Text.Json" Version="10.0.3" />
-        <PackageReference Include="YamlDotNet" Version="16.3.0" />
+        <PackageReference Include="YamlDotNet" Version="17.0.1" />
         <PackageReference Include="fNbt" Version="1.0.0" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="protobuf-net" Version="3.2.56" />
@@ -71,7 +71,7 @@
         <!-- 日志与遥测 -->
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Sentry" Version="3.34.0" />
+        <PackageReference Include="Sentry" Version="6.3.1" />
         <!-- 身份认证 -->
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
         <!-- 验证 -->

--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -122,6 +122,12 @@
       "license": "https://github.com/protobuf-net/protobuf-net/blob/main/Licence.txt"
     },
     {
+      "name": "Sentry",
+      "info": "Copyright © 2018 Sentry\nLicensed under the MIT license.",
+      "website": "https://sentry.io/",
+      "license": "https://github.com/getsentry/sentry-dotnet/blob/main/LICENSE"
+    },
+    {
       "name": "LWJGL Unsafe Agent",
       "info": "Copyright © HMCL-dev\nLicensed under the Apache-2.0 license.",
       "website": "https://github.com/HMCL-dev/lwjgl-unsafe-agent",


### PR DESCRIPTION
Sentry 版本太古早了，而且还没加开源许可声明
YamlDotNet 修了挺多东西的，先升级下再说

## Summary by Sourcery

升级与遥测相关的依赖，并使 Sentry 集成和项目元数据与较新的库版本保持一致。

增强功能：
- 调整遥测服务，以使用与新 SDK 一致的更新版 Sentry 用户模型。
- 刷新启动器元数据，以反映依赖升级。

构建：
- 将项目中 Sentry 和 YamlDotNet 的依赖更新到较新的版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade telemetry-related dependencies and align Sentry integration and project metadata with the newer library versions.

Enhancements:
- Adjust telemetry service to use the updated Sentry user model in line with the new SDK.
- Refresh launcher metadata to reflect the dependency upgrades.

Build:
- Update project dependencies for Sentry and YamlDotNet to more recent versions.

</details>