### PR TITLE
fix(install): Fabric API 是否适配判断方式错误

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
@@ -1624,6 +1624,10 @@ Retry:
         ''' </summary>
         Public ReadOnly ModLoaders As List(Of CompLoaderType)
         ''' <summary>
+        ''' 未经处理的支持的游戏版本列表。
+        ''' </summary>
+        Public ReadOnly RawGameVersions As List(Of String)
+        ''' <summary>
         ''' 支持的游戏版本列表。类型包括："26.1.5"，"26.1"，"26.1 预览版"，"1.18.5"，"1.18"，"1.18 预览版"，"21w15a"，"未知版本"。
         ''' </summary>
         Public ReadOnly GameVersions As List(Of String)
@@ -1714,6 +1718,7 @@ Retry:
                 If Data.ContainsKey("DownloadUrls") Then DownloadUrls = Data("DownloadUrls").ToObject(Of List(Of String))
                 If Data.ContainsKey("ModLoaders") Then ModLoaders = Data("ModLoaders").ToObject(Of List(Of CompLoaderType))
                 If Data.ContainsKey("Hash") Then Hash = Data("Hash").ToString
+                If Data.ContainsKey("RawGameVersions") Then RawGameVersions = Data("RawGameVersions").ToObject(Of List(Of String))
                 If Data.ContainsKey("GameVersions") Then GameVersions = Data("GameVersions").ToObject(Of List(Of String))
                 If Data.ContainsKey("RawDependencies") Then RawDependencies = Data("RawDependencies").ToObject(Of List(Of String))
                 If Data.ContainsKey("Dependencies") Then Dependencies = Data("Dependencies").ToObject(Of List(Of String))
@@ -1754,8 +1759,8 @@ Retry:
                             Select(Function(d) d("modId").ToString).ToList
                     End If
                     'GameVersions
-                    Dim RawVersions As List(Of String) = Data("gameVersions").Select(Function(t) t.ToString.Trim.ToLower).ToList
-                    GameVersions = RawVersions.
+                    RawGameVersions = Data("gameVersions").Select(Function(t) t.ToString.Trim.ToLower).ToList
+                    GameVersions = RawGameVersions.
                         Where(Function(v) McInstanceInfo.IsFormatFit(v)).
                         Select(Function(v) v.Replace("-snapshot", " 预览版")).
                         Distinct.ToList
@@ -1769,10 +1774,10 @@ Retry:
                     End If
                     'ModLoaders
                     ModLoaders = New List(Of CompLoaderType)
-                    If RawVersions.Contains("forge") Then ModLoaders.Add(CompLoaderType.Forge)
-                    If RawVersions.Contains("fabric") Then ModLoaders.Add(CompLoaderType.Fabric)
-                    If RawVersions.Contains("quilt") Then ModLoaders.Add(CompLoaderType.Quilt)
-                    If RawVersions.Contains("neoforge") Then ModLoaders.Add(CompLoaderType.NeoForge)
+                    If RawGameVersions.Contains("forge") Then ModLoaders.Add(CompLoaderType.Forge)
+                    If RawGameVersions.Contains("fabric") Then ModLoaders.Add(CompLoaderType.Fabric)
+                    If RawGameVersions.Contains("quilt") Then ModLoaders.Add(CompLoaderType.Quilt)
+                    If RawGameVersions.Contains("neoforge") Then ModLoaders.Add(CompLoaderType.NeoForge)
 #End Region
                 Else
 #Region "Modrinth"
@@ -1823,8 +1828,8 @@ Retry:
                             Select(Function(d) d("project_id").ToString).ToList
                     End If
                     'GameVersions
-                    Dim RawVersions As List(Of String) = Data("game_versions").Select(Function(t) t.ToString.Trim.ToLower).ToList
-                    GameVersions = RawVersions.Where(Function(v) v.Contains(".")).
+                    RawGameVersions = Data("game_versions").Select(Function(t) t.ToString.Trim.ToLower).ToList
+                    GameVersions = RawGameVersions.Where(Function(v) v.Contains(".")).
                         Select(Function(v) If(v.Contains("-"), v.BeforeFirst("-") & " 预览版", If(v.StartsWithF("b1."), "远古版本", v))).
                         Distinct.ToList
                     If GameVersions.Count > 1 Then
@@ -1832,8 +1837,8 @@ Retry:
                         If Type = CompType.ModPack Then GameVersions = New List(Of String) From {GameVersions(0)} '整合包理应只 “支持” 一个版本
                     ElseIf GameVersions.Count = 1 Then
                         '无需处理
-                    ElseIf RawVersions.Any(Function(v) RegexCheck(v, "[0-9]{2}w[0-9]{2}[a-z]")) Then
-                        GameVersions = RawVersions.Where(Function(v) RegexCheck(v, "[0-9]{2}w[0-9]{2}[a-z]")).ToList
+                    ElseIf RawGameVersions.Any(Function(v) RegexCheck(v, "[0-9]{2}w[0-9]{2}[a-z]")) Then
+                        GameVersions = RawGameVersions.Where(Function(v) RegexCheck(v, "[0-9]{2}w[0-9]{2}[a-z]")).ToList
                     Else
                         GameVersions = New List(Of String) From {"未知版本"}
                     End If
@@ -1864,6 +1869,7 @@ Retry:
             Json.Add("ReleaseDate", ReleaseDate)
             Json.Add("DownloadCount", DownloadCount)
             Json.Add("ModLoaders", New JArray(ModLoaders.Select(Function(m) CInt(m))))
+            Json.Add("RawGameVersions", New JArray(RawGameVersions))
             Json.Add("GameVersions", New JArray(GameVersions))
             Json.Add("Status", CInt(Status))
             If FileName IsNot Nothing Then Json.Add("FileName", FileName)

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -2129,7 +2129,7 @@ Retry:
     Public Function FabricApiDownloadListItem(Entry As CompFile, OnClick As MyListItem.ClickEventHandler) As MyListItem
         '建立控件
         Dim NewItem As New MyListItem With {
-            .Title = Entry.DisplayName.Split("]")(1).Replace("Fabric API ", "").Replace(" build ", ".").BeforeFirst("+").Trim, .SnapsToDevicePixels = True, .Height = 42, .Type = MyListItem.CheckType.Clickable, .Tag = Entry,
+            .Title = Entry.DisplayName.Split("]")(1).Replace("Fabric API ", "").Replace(" build ", ".").Trim, .SnapsToDevicePixels = True, .Height = 42, .Type = MyListItem.CheckType.Clickable, .Tag = Entry,
             .Info = Entry.StatusDescription & "，发布于 " & Entry.ReleaseDate.ToString("yyyy'/'MM'/'dd HH':'mm"),
             .Logo = PathImage & "Blocks/Fabric.png"
         }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -404,7 +404,7 @@ Public Class PageDownloadInstall
             Else
                 BtnFabricApiClear.Visibility = Visibility.Visible
                 ImgFabricApi.Visibility = Visibility.Visible
-                LabFabricApi.Text = SelectedFabricApi.DisplayName.Split("]")(1).Replace("Fabric API ", "").Replace(" build ", ".").Split("+").First.Trim
+                LabFabricApi.Text = SelectedFabricApi.DisplayName.Split("]")(1).Replace("Fabric API ", "").Replace(" build ", ".").Trim
                 LabFabricApi.Foreground = ColorGray1
             End If
         End If
@@ -1282,33 +1282,11 @@ Public Class PageDownloadInstall
         Dim fabricApiName = fabricApi.DisplayName
         Try
             If fabricApiName Is Nothing OrElse _vanillaName Is Nothing Then Return False
-            fabricApiName = fabricApiName.ToLower : _vanillaName = _vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3").ToLower
-            If fabricApiName.StartsWith("[" & _vanillaName & "]") Then Return True
-            If Not fabricApiName.Contains("/") OrElse Not fabricApiName.Contains("]") Then Return False
-            '直接的判断（例如 1.18.1/22w03a）
-            For Each part As String In fabricApiName.BeforeFirst("]").TrimStart("[").Split("/")
-                If part = _vanillaName Then Return True
-            Next
-            '将版本名分割语素（例如 1.16.4/5）
-            Dim lefts = RegexSearch(fabricApiName.BeforeFirst("]"), "[a-z/]+|[0-9/]+")
-            Dim rights = RegexSearch(_vanillaName.BeforeFirst("]"), "[a-z/]+|[0-9/]+")
-            '对每段进行判断
-            Dim i As Integer = 0
-            While True
-                '两边均缺失，感觉是一个东西
-                If lefts.Count - 1 < i AndAlso rights.Count - 1 < i Then Return True
-                '确定两边是否一致
-                Dim leftValue As String = If(lefts.Count - 1 < i, "-1", lefts(i))
-                Dim rightValue As String = If(rights.Count - 1 < i, "-1", rights(i))
-                If Not leftValue.Contains("/") Then
-                    If leftValue <> rightValue Then Return False
-                Else
-                    '左边存在斜杠
-                    If Not leftValue.Contains(rightValue) Then Return False
-                End If
-                i += 1
-            End While
-            Return True
+            Dim targetName = _vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3").ToLower()
+            If FabricApi.RawGameVersions.Any(Function(f) f = targetName)
+                Return True
+            End If
+            Return False
         Catch ex As Exception
             Log(ex, "判断 Fabric API 版本适配性出错（" & FabricApiName & ", " & _vanillaName & "）")
             Return False


### PR DESCRIPTION
close #2701
上游：https://github.com/Meloong-Git/PCL/pull/8460

## Summary by Sourcery

通过利用存储的原始游戏版本数据来修复 Fabric API 版本兼容性检测，并相应调整 Fabric API 的显示标题。

Bug 修复：
- 修正 Fabric API 兼容性检查逻辑，使其与原始游戏版本标识符进行匹配，而不是依赖解析后的显示名称。

改进：
- 在组件文件中引入并持久化 `RawGameVersions` 字段，以保留未经处理的游戏版本标识符，从而实现更精确的逻辑。
- 简化 Fabric API 条目标题格式化逻辑，移除对元数据后缀进行不必要拆分的操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Fabric API version compatibility detection by leveraging stored raw game version data and adjust Fabric API display titles accordingly.

Bug Fixes:
- Correct Fabric API compatibility checks to match against raw game version identifiers instead of relying on parsed display names.

Enhancements:
- Introduce and persist a RawGameVersions field on component files to retain unprocessed game version identifiers for more accurate logic.
- Simplify Fabric API entry title formatting by removing unnecessary splitting on metadata suffixes.

</details>