### PR TITLE
fix(download): OptiFine 与 LiteLoader 一并安装时安装路径错误

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -2753,7 +2753,11 @@ Retry:
         Dim OptiFineAsMod As Boolean = Request.OptiFineEntry IsNot Nothing AndAlso Modable '选择了 OptiFine 与任意 Mod 加载器
         If OptiFineAsMod Then
             Log("[Download] OptiFine 将作为 Mod 进行下载")
-            OptiFineFolder = ModsTempFolder
+            If Request.LiteLoaderEntry IsNot Nothing
+                OptiFineFolder = ModsTempFolder & Request.MinecraftName & "\"
+            Else
+                OptiFineFolder = ModsTempFolder
+            End If
         End If
 
         '记录日志

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.vb
@@ -2753,7 +2753,7 @@ Retry:
         Dim OptiFineAsMod As Boolean = Request.OptiFineEntry IsNot Nothing AndAlso Modable '选择了 OptiFine 与任意 Mod 加载器
         If OptiFineAsMod Then
             Log("[Download] OptiFine 将作为 Mod 进行下载")
-            If Request.LiteLoaderEntry IsNot Nothing
+            If Request.LiteLoaderEntry IsNot Nothing Then
                 OptiFineFolder = ModsTempFolder & Request.MinecraftName & "\"
             Else
                 OptiFineFolder = ModsTempFolder


### PR DESCRIPTION
close #2713

## Summary by Sourcery

Bug Fixes:
- 修正在与 LiteLoader 一同安装时 OptiFine 的目标文件夹，避免出现错误的模组安装路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the target folder for OptiFine when it is installed together with LiteLoader to avoid incorrect mod installation paths.

</details>