### PR TITLE
feat(saves): 支持 26.1 新存档格式

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.vb
@@ -50,7 +50,7 @@ Class PageInstanceSavesInfo
                 Dim CurrentVersionId = If(versionId?.Value, Nothing)
                 FrmInstanceSavesLeft.ItemDatapack.Visibility = If(Not CurrentVersionId.HasValue OrElse CurrentVersionId < 1444, Visibility.Collapsed, Visibility.Visible)
 
-                Dim hasDifficulty = gameLevel.Contains("Difficulty")
+                Dim hasDifficulty = gameLevel.Contains("Difficulty") OrElse gameLevel.Contains("difficulty_settings")
                 Dim hasAllowCommands = gameLevel.Contains("allowCommands")
 
                 If versionName Is Nothing Then
@@ -75,7 +75,14 @@ Class PageInstanceSavesInfo
                 If gameLevel.TryGet(Of NbtLong)("RandomSeed", seedNbt) Then
                     seed = seedNbt.Value().ToString()
                 Else
-                    seed = gameLevel.Get(Of NbtCompound)("WorldGenSettings").Get(Of NbtLong)("seed").Value.ToString()
+                    If gameLevel.Contains("WorldGenSettings") Then
+                        seed = gameLevel.Get(Of NbtCompound)("WorldGenSettings").Get(Of NbtLong)("seed").Value.ToString()
+                    Else
+                        Dim worldGenSettingsDatPath = IO.Path.Combine(PageInstanceSavesLeft.CurrentSave, "data", "minecraft", "world_gen_settings.dat")
+                        Dim worldGenSettingsNbt As New NbtFile(worldGenSettingsDatPath)
+                        Dim worldGenSettings = worldGenSettingsNbt.RootTag.Get(Of NbtCompound)("data")
+                        seed = worldGenSettings.Get(Of NbtLong)("seed").Value.ToString()
+                    End If
                 End If
 
                 AddInfoTable("种子", seed, True, versionName?.Value, True)
@@ -119,8 +126,28 @@ Class PageInstanceSavesInfo
 
                 If hasDifficulty Then
                     PanSettings.Visibility = Visibility.Visible
-                    Dim difficultyElement = gameLevel.Get(Of NbtByte)("Difficulty")
-                    Dim difficultyValue As Integer = Integer.Parse(difficultyElement.Value)
+                    Dim difficultyElement = Nothing
+                    
+                    If gameLevel.Contains("difficulty_settings") Then
+                        Dim difficultyElementString = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtString)("difficulty").Value
+                        Select Case difficultyElementString
+                            Case "peaceful"
+                                difficultyElement = 0
+                            Case "easy"
+                                difficultyElement = 1
+                            Case "normal"
+                                difficultyElement = 2
+                            Case "hard"
+                                difficultyElement = 3
+                            Case Else
+                                difficultyElement = 0
+                        End Select
+                        
+                    Else 
+                        difficultyElement = gameLevel.Get(Of NbtByte)("Difficulty")
+                    End If
+                    
+                    Dim difficultyValue As Integer = Integer.Parse(difficultyElement)
 
                     Dim difficultyCombo As New MyComboBox() With {.Width = 100, .HorizontalAlignment = HorizontalAlignment.Left, .ToolTip = "修改设置前请确保该存档未在游戏中打开，否则会导致设置无效"}
                     difficultyCombo.Items.Add(New With {.Value = 0, .Display = "和平"})
@@ -130,8 +157,15 @@ Class PageInstanceSavesInfo
                     difficultyCombo.SelectedValuePath = "Value"
                     difficultyCombo.DisplayMemberPath = "Display"
                     difficultyCombo.SelectedValue = difficultyValue
-
-                    Dim isHardcoreCheck = gameLevel.Get(Of NbtByte)("hardcore")
+                    
+                    Dim isHardcoreCheck As NbtByte = Nothing
+                    
+                    If gameLevel.Contains("difficulty_settings") Then
+                        isHardcoreCheck = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtByte)("hardcore")
+                    Else
+                        isHardcoreCheck = gameLevel.Get(Of NbtByte)("hardcore")
+                    End If
+                    
                     Dim isHardcoreMode As Boolean = (isHardcoreCheck.Value = "1")
 
                     Dim lockCheckBox As New MyCheckBox() With {.Text = "锁定难度", .ToolTip = "锁定当前难度设置，锁定后无法在游戏中更改游戏难度", .VerticalAlignment = VerticalAlignment.Center, .Margin = New Thickness(10, 0, 0, 0)
@@ -140,7 +174,14 @@ Class PageInstanceSavesInfo
                     If isHardcoreMode Then
                         lockCheckBox.Visibility = Visibility.Collapsed
                     Else
-                        Dim lockedElement = gameLevel.Get(Of NbtByte)("DifficultyLocked")
+                        Dim lockedElement As NbtByte
+                        
+                        If gameLevel.Contains("difficulty_settings") Then
+                            lockedElement = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtByte)("locked")
+                        Else
+                            lockedElement = gameLevel.Get(Of NbtByte)("DifficultyLocked")
+                        End If
+                        
                         Dim isLocked As Boolean = (lockedElement IsNot Nothing AndAlso lockedElement.Value = "1")
                         lockCheckBox.Checked = isLocked
                     End If
@@ -157,8 +198,13 @@ Class PageInstanceSavesInfo
                                                                          If difficultyCombo.SelectedValue Is Nothing Then Return
 
                                                                          Dim newDifficulty As Integer = CInt(difficultyCombo.SelectedValue)
-
-                                                                         gameLevel.Get(Of NbtByte)("Difficulty").Value = CByte(newDifficulty)
+                                                                         
+                                                                         If gameLevel.Contains("difficulty_settings") Then
+                                                                             Dim newDifficultyString = GetDifficultyName(newDifficulty)
+                                                                             gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtString)("difficulty").Value = newDifficultyString
+                                                                         Else 
+                                                                             gameLevel.Get(Of NbtByte)("Difficulty").Value = CByte(newDifficulty)
+                                                                         End If
 
                                                                          If Not isHardcoreMode Then
                                                                              Dim newLocked As Integer = If(lockCheckBox.Checked, 1, 0)
@@ -184,14 +230,25 @@ Class PageInstanceSavesInfo
 
                                                             Dim newDifficulty As Integer = CInt(difficultyCombo.SelectedValue)
 
-                                                            gameLevel.Get(Of NbtByte)("Difficulty").Value = CByte(newDifficulty)
+                                                            If gameLevel.Contains("difficulty_settings") Then
+                                                                Dim newDifficultyString = GetDifficultyName(newDifficulty)
+                                                                gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtString)("difficulty").Value = newDifficultyString
+                                                            Else 
+                                                                gameLevel.Get(Of NbtByte)("Difficulty").Value = CByte(newDifficulty)
+                                                            End If
 
                                                             If Not isHardcoreMode Then
                                                                 Dim newLocked As Integer = If(lockCheckBox.Checked, 1, 0)
-                                                                If gameLevel.Contains("DifficultyLocked") Then
+                                                                If gameLevel.Contains("difficulty_settings") Then
+                                                                    gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtByte)("locked").Value = CByte(newLocked)
+                                                                Else If gameLevel.Contains("DifficultyLocked") Then
                                                                     gameLevel.Get(Of NbtByte)("DifficultyLocked").Value = CByte(newLocked)
-                                                                ElseIf newLocked = 1 Then
-                                                                    gameLevel.Add(New NbtByte("DifficultyLocked", CByte(newLocked)))
+                                                                Else If newLocked = 1 Then
+                                                                    If gameLevel.Contains("difficulty_settings") Then
+                                                                        gameLevel.Get(Of NbtCompound)("difficulty_settings").Add(New NbtByte("locked", CByte(newLocked)))
+                                                                    Else
+                                                                        gameLevel.Add(New NbtByte("DifficultyLocked", CByte(newLocked)))
+                                                                    End If
                                                                 End If
                                                             End If
 
@@ -233,9 +290,15 @@ Class PageInstanceSavesInfo
                     AddInfoTable("出生点 (X/Y/Z)", $"{spawnXPos} / {spawnYPos} / {spawnZPos}")
                 End If
                 Dim gameTypeName As String = "获取失败"
-
-                Dim isHardcore = gameLevel.Get(Of NbtByte)("hardcore")
-                If isHardcore.Value = "1" Then
+                Dim isHardcore As NbtByte = Nothing
+                
+                If gameLevel.Contains("difficulty_settings") Then
+                    isHardcore = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtByte)("hardcore")
+                Else
+                    isHardcore = gameLevel.Get(Of NbtByte)("hardcore")
+                End If
+                
+                If isHardcore.Value = 1 Then
                     gameTypeName = "极限模式"
                 Else
                     Dim gameType = gameLevel.Get(Of NbtInt)("GameType")
@@ -255,20 +318,27 @@ Class PageInstanceSavesInfo
                 AddInfoTable("游戏模式", gameTypeName)
 
                 If hasDifficulty Then
-                    Dim difficultyElement = gameLevel.Get(Of NbtByte)("Difficulty")
+                    Dim difficultyRaw As String
+                    If gameLevel.Contains("difficulty_settings") Then
+                        difficultyRaw = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtString)("difficulty").Value
+                    Else
+                        difficultyRaw = gameLevel.Get(Of NbtByte)("Difficulty").Value.ToString()
+                    End If
+
                     Dim difficultyName As String = "获取失败"
-                    Dim difficultyValue As Integer = Integer.Parse(difficultyElement.Value)
-                    Select Case difficultyValue
-                        Case 0
-                            difficultyName = "和平"
-                        Case 1
-                            difficultyName = "简单"
-                        Case 2
-                            difficultyName = "普通"
-                        Case 3
-                            difficultyName = "困难"
+                    Select Case difficultyRaw
+                        Case "0", "peaceful" : difficultyName = "和平"
+                        Case "1", "easy"     : difficultyName = "简单"
+                        Case "2", "normal"   : difficultyName = "普通"
+                        Case "3", "hard"     : difficultyName = "困难"
                     End Select
-                    Dim lockedElement = gameLevel.Get(Of NbtByte)("DifficultyLocked")
+                    
+                    Dim lockedElement = Nothing
+                    If gameLevel.Contains("difficulty_settings") Then
+                        lockedElement = gameLevel.Get(Of NbtCompound)("difficulty_settings").Get(Of NbtByte)("locked")
+                    Else
+                        lockedElement = gameLevel.Get(Of NbtByte)("DifficultyLocked")
+                    End If
                     Dim isDifficultyLocked As String = If((lockedElement IsNot Nothing AndAlso lockedElement.Value = "1") OrElse isHardcore.Value = "1", "是", If(lockedElement IsNot Nothing, "否", "获取失败"))
                     If Hintversion1_8.Visibility <> Visibility.Visible Then
                         AddInfoTable("困难度", $"{difficultyName} (是否已锁定难度：{isDifficultyLocked})")
@@ -367,4 +437,19 @@ Class PageInstanceSavesInfo
         Grid.SetRow(contentStack, rowIndex)
         Grid.SetColumn(contentStack, 2)
     End Sub
+    
+    Public Function GetDifficultyName(newDifficulty As Integer) As String
+        Select Case newDifficulty
+            Case 0
+                Return "peaceful"
+            Case 1
+                Return "easy"
+            Case 2
+                Return "normal"
+            Case 3
+                Return "hard"
+            Case Else
+                Throw New ArgumentOutOfRangeException(NameOf(newDifficulty), "Invalid difficulty value")
+        End Select
+    End Function
 End Class


### PR DESCRIPTION
本 PR 在现有的存档管理上修修补补，从而使其适配 Minecraft 自 26.1-snapshot-6 起使用的新存档格式。close #2629 

参阅：[Java版26.1-snapshot-6 - 中文 Minecraft Wiki](https://zh.minecraft.wiki/w/Java%E7%89%8826.1-snapshot-6#%E5%B8%B8%E8%A7%84_2)

## Summary by Sourcery

为 Minecraft 26.1+ 存档文件添加兼容性，这些存档使用新的 `difficulty_settings` 和 `world_gen_settings` 布局，同时继续支持旧世界。

新功能：
- 当 `level.dat` 中不再包含世界种子时，支持从外部的 `world_gen_settings.dat` 中读取世界种子。
- 支持从 `level.dat` 中新的 `difficulty_settings` 复合标签读取和写入难度、极限模式标志（hardcore flag）以及难度锁定状态。

改进：
- 同时回退兼容旧版和新版的难度表示方式，以在不同游戏版本之间正确显示和编辑存档元数据。
- 引入一个辅助工具，用于在新存档格式中将数字难度值映射为其字符串标识符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add compatibility for Minecraft 26.1+ save files that use the new difficulty_settings and world_gen_settings layout while preserving support for older worlds.

New Features:
- Support reading world seed from external world_gen_settings.dat when it is no longer present in level.dat.
- Support reading and writing difficulty, hardcore flag, and difficulty lock from the new difficulty_settings compound in level.dat.

Enhancements:
- Fallback to both legacy and new difficulty representations to correctly display and edit save metadata across game versions.
- Introduce a helper to map numeric difficulty values to their string identifiers for the new save format.

</details>