### PR TITLE
chore(bump): v2.14.5-beta.3

### DIFF
--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -3,8 +3,8 @@
   "version": {
     "base": "2.14.5",
     "upstream": "2.12.1",
-    "suffix": "beta.2",
-    "code": 512
+    "suffix": "beta.3",
+    "code": 513
   },
   "licenses": [
     {


### PR DESCRIPTION
我想发正式版，因为 26.1 适配做完了值得，但是鸽秋说晚些时候（

## Summary by Sourcery

杂务：
- 更新启动器元数据以反映新的 v2.14.5-beta.3 版本发布。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update launcher metadata to reflect the new v2.14.5-beta.3 release.

</details>