### PR TITLE
fix(install): 修复带有 Revision 的版本号无法列表 NeoForge 的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -928,7 +928,7 @@ Public Module ModDownload
                 VersionName = ApiName
                 Version = New Version(ApiName.BeforeFirst("-"))
                 If Version.Major >= 24 Then
-                    Inherit = Version.Major & "." & Version.Minor
+                    Inherit = $"{Version.Major}.{Version.Minor}{If(Version.Revision > 0, $".{Version.Revision}", "")}"
                 Else
                     Inherit = "1." & Version.Major & If(Version.Minor > 0, "." & Version.Minor, "")
                 End If

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -928,7 +928,7 @@ Public Module ModDownload
                 VersionName = ApiName
                 Version = New Version(ApiName.BeforeFirst("-"))
                 If Version.Major >= 24 Then
-                    Inherit = $"{Version.Major}.{Version.Minor}{If(Version.Revision > 0, $".{Version.Revision}", "")}"
+                    Inherit = $"{Version.Major}.{Version.Minor}{If(Version.Build > 0, $".{Version.Build}", "")}"
                 Else
                     Inherit = "1." & Version.Major & If(Version.Minor > 0, "." & Version.Minor, "")
                 End If


### PR DESCRIPTION
Resolved #2726 

## Summary by Sourcery

错误修复：
- 修复 NeoForge 版本列表解析问题，解决了对于其 API 名称包含修订号组件的版本无法正确解析的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix NeoForge version list resolution for versions whose API name includes a revision component.

</details>