### PR TITLE
chore: remove useless using

### DIFF
--- a/PCL.Core/IO/Net/Http/HttpContentExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpContentExtension.cs
@@ -1,4 +1,3 @@
-using CommunityToolkit.Mvvm.Messaging.Messages;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 using PCL.Core.Minecraft.IdentityModel.Extensions.Pkce;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 using PCL.Core.Utils.Exts;

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Agent.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Agent.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -1,5 +1,6 @@
 using PCL.Core.IO.Net.Http.Client.Request;
 using System;
+using System.Threading.Tasks;
 using System.Net;
 using System.Text.Json.Nodes;
 

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -2,8 +2,6 @@ using PCL.Core.IO.Net.Http.Client.Request;
 using System;
 using System.Net;
 using System.Text.Json.Nodes;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -3,6 +3,8 @@ using System;
 using System.Threading.Tasks;
 using System.Net;
 using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -1,6 +1,5 @@
 using PCL.Core.IO.Net.Http.Client.Request;
 using System;
-using System.Threading.Tasks;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading;

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Serialization;
-using PCL.Core.Link.Scaffolding.Client.Models;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 


### PR DESCRIPTION
~哦我的天哪，先生，你怎么 using 这么多没有用的东西，这看起来糟透了，我的 .NET 11 完全没法构建这个库，这错综复杂的依赖关系看起来像隔壁玛丽奶奶烤焦的苹果派一样糟糕——外表硬得能当砖头，内里还冒着绝望的黑烟。~

## Summary by Sourcery

清理身份验证和 HTTP 相关组件中未使用的导入。

增强内容：
- 从身份模型和 HTTP 扩展类中移除未使用的 `using` 指令，以减少不必要的依赖。
- 规范与 Yggdrasil 相关的客户端类的文件结尾格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up unused imports in identity and HTTP-related components.

Enhancements:
- Remove unused using directives from identity model and HTTP extension classes to reduce unnecessary dependencies.
- Normalize file endings for Yggdrasil-related client classes.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

清理身份验证和 HTTP 相关组件中未使用的导入。

增强内容：
- 从身份模型和 HTTP 扩展类中移除未使用的 `using` 指令，以减少不必要的依赖。
- 规范与 Yggdrasil 相关的客户端类的文件结尾格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up unused imports in identity and HTTP-related components.

Enhancements:
- Remove unused using directives from identity model and HTTP extension classes to reduce unnecessary dependencies.
- Normalize file endings for Yggdrasil-related client classes.

</details>

</details>