### PR TITLE
fix(saves): 修复非 26.1 存档无法读取的问题

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.vb
@@ -144,7 +144,7 @@ Class PageInstanceSavesInfo
                         End Select
                         
                     Else 
-                        difficultyElement = gameLevel.Get(Of NbtByte)("Difficulty")
+                        difficultyElement = gameLevel.Get(Of NbtByte)("Difficulty").Value()
                     End If
                     
                     Dim difficultyValue As Integer = Integer.Parse(difficultyElement)


### PR DESCRIPTION
本 PR 修复了非 Minecraft 26.1 的存档无法被读取的问题，close #2740 

~~我去我这下真是傻逼了，类型没写对直接爆炸了.~~

## Summary by Sourcery

错误修复：
- 纠正从 NBT 数据中读取 `difficulty` 字段的方式，使得旧版本/非 26.1 的存档文件也可以在不报错的情况下被解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct reading of the difficulty field from NBT data so older/non-26.1 save files can be parsed without errors.

</details>