### PR TITLE
fix: 部分帮助文档查找路径错误

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModEvent.cs
+++ b/Plain Craft Launcher 2/Modules/ModEvent.cs
@@ -407,10 +407,10 @@ namespace PCL
                 workingDir = System.IO.Path.Combine(Basics.ExecutableDirectory, "PCL", "Help");
                 ModBase.Log($"[Control] 自定义事件中由相对 PCL 本地帮助文件夹的路径{type}：{location}");
             }
-            else if (type == EventType.打开帮助 && File.Exists(System.IO.Path.Combine(ModBase.PathTemp, "Help", relativeUrl)))
+            else if (type == EventType.打开帮助 && File.Exists(System.IO.Path.Combine(ModBase.PathTemp, "CE", "Help", relativeUrl)))
             {
-                location = System.IO.Path.Combine(ModBase.PathTemp, "Help", relativeUrl);
-                workingDir = System.IO.Path.Combine(ModBase.PathTemp, "Help");
+                location = System.IO.Path.Combine(ModBase.PathTemp, "CE", "Help", relativeUrl);
+                workingDir = System.IO.Path.Combine(ModBase.PathTemp, "CE", "Help");
                 ModBase.Log($"[Control] 自定义事件中由相对 PCL 自带帮助文件夹的路径{type}：{location}");
             }
             else if (type == EventType.打开文件 || type == EventType.执行命令)


### PR DESCRIPTION
在帮助文档的路径查找中添加`CE`以正确匹配实际解压的路径
解决`指南-资源安装指南`等帮助页面出现`未找到 EventData 指向的本地 xaml 文件`错误的问题

## Summary by Sourcery

错误修复：
- 修正帮助文件查找逻辑，在临时路径下包含 CE 目录，从而解决某些帮助页面缺少本地 XAML 文件的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct help file lookup to include the CE directory under the temporary path, resolving missing local XAML files for certain help pages.

</details>