### PR TITLE
fix: 修复收藏夹无图标时崩溃并添加 LogoCornerRadius 依赖属性

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
@@ -921,7 +921,65 @@ public partial class MyListItem : IMyRadio
 
     // 菜单与按钮绑定
     public Action<MyListItem, EventArgs> ContentHandler { get; set; }
+    
+    /// <summary>
+    /// 图标可选的圆角。仅当 Logo 为位图（MyImage 或 Canvas）时生效。
+    /// 当所有角的圆角半径均 ≥ 0 时，应用圆角效果；否则不应用。
+    /// </summary>
+    public CornerRadius LogoCornerRadius
+    {
+        get => field;
+        set
+        {
+            field = value;
+            if (PathLogo is Canvas) _canvasClipHandlerAdded = false;
+            ApplyLogoCornerRadius();
+        }
+    } = new CornerRadius(-1);
+    
+    private bool IsLogoCornerRadiusEnabled() => 
+        LogoCornerRadius is { TopLeft: >= 0, TopRight: >= 0, BottomLeft: >= 0, BottomRight: >= 0 };
 
+    private void UpdateCanvasClip(Canvas c)
+    {
+        if (c is { ActualWidth: > 0, ActualHeight: > 0 })
+        {
+            var r = LogoCornerRadius;
+            double radius = Math.Max(Math.Max(r.TopLeft, r.TopRight), Math.Max(r.BottomLeft, r.BottomRight));
+            c.Clip = new RectangleGeometry(new Rect(0, 0, c.ActualWidth, c.ActualHeight), radius, radius);
+        }
+    }
+
+    private bool _canvasClipHandlerAdded = false;
+
+    private void ApplyLogoCornerRadius()
+    {
+        if (PathLogo is null || !IsLogoCornerRadiusEnabled()) return;
+
+        switch (PathLogo)
+        {
+            case MyImage myImage:
+                myImage.CornerRadius = LogoCornerRadius;
+                break;
+            case Canvas canvas when !_canvasClipHandlerAdded && canvas is { ActualWidth: 0, ActualHeight: 0 }:
+                UpdateCanvasClip(canvas);
+                canvas.SizeChanged += OnCanvasLogoSizeChanged;
+                _canvasClipHandlerAdded = true;
+                break;
+            case Canvas canvas:
+                UpdateCanvasClip(canvas);
+                break;
+        }
+    }
+
+    private void OnCanvasLogoSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (sender is not Canvas { ActualWidth: > 0, ActualHeight: > 0 } canvas) return;
+    
+        UpdateCanvasClip(canvas);
+        canvas.SizeChanged -= OnCanvasLogoSizeChanged;
+        _canvasClipHandlerAdded = false;
+    }
     #endregion
 
     #region 点击

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2081,14 +2081,11 @@ public static class ModComp
             {
                 Title = TranslatedName,
                 Info = Description.Replace("\r", "").Replace("\n", ""),
-                Logo = LogoUrl,
+                Logo = string.IsNullOrEmpty(LogoUrl) ? $"{ModBase.PathImage}Icons/NoIcon.png" : LogoUrl,
                 Tags = Tags,
-                Tag = this
+                Tag = this,
+                LogoCornerRadius = new CornerRadius(6)
             };
-
-            var img = (MyImage)result.PathLogo;
-            img.CornerRadius = new CornerRadius(6);
-            img.SnapsToDevicePixels = true;
             return result;
         }
 


### PR DESCRIPTION
close #2739

## Summary by Sourcery

为列表项新增可配置的 Logo 圆角支持，并处理缺失的模组图标以防止崩溃。

New Features:
- 在 `MyListItem` 上引入 `LogoCornerRadius` 属性，用于为位图 Logo 应用可选的圆角效果。

Bug Fixes:
- 当模组没有 `LogoUrl` 时提供默认占位图标，避免在渲染没有图标的收藏项时发生崩溃。

Enhancements:
- 通过新的 `LogoCornerRadius` 属性为 `MyImage` 和 Canvas 两种 Logo 都应用圆角，从而简化 Logo 样式逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable logo corner radius support to list items and handle missing mod icons to prevent crashes.

New Features:
- Introduce a LogoCornerRadius property on MyListItem to allow applying optional rounded corners to bitmap logos.

Bug Fixes:
- Provide a default placeholder icon when a mod has no LogoUrl to avoid crashes when rendering favorites without icons.

Enhancements:
- Apply logo corner radius via the new LogoCornerRadius property for both MyImage and Canvas logos, simplifying logo styling logic.

</details>