### PR TITLE
fix(install): Cleanroom 手动安装包下载出错

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -876,9 +876,9 @@ public static class ModDownload
         public string VersionName;
 
         /// <summary>
-        ///     加载器名称。Forge 或 NeoForge。
+        ///     加载器名称。Forge / NeoForge / Cleanroom。
         /// </summary>
-        public string LoaderName => (int)ForgeType == 1 ? "NeoForge" : "Forge";
+        public string LoaderName => ForgeType.ToString();
 
         /// <summary>
         ///     文件扩展名。不以小数点开头。


### PR DESCRIPTION
Resolve #2533

## Summary by Sourcery

错误修复：
- 修正加载器名称映射，使 Cleanroom 和其他类 Forge 类型使用正确的加载器标识符，而不再局限于 Forge/NeoForge。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct loader name mapping so Cleanroom and other forgelike types use the proper loader identifier instead of being limited to Forge/NeoForge.

</details>