### PR TITLE
ref: 移除cleanroom兼容中的无效代码

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -2891,9 +2891,6 @@ public static class ModLaunch
         {
             if (Library.IsNatives)
                 continue;
-            if (Library.Name is not null &&
-                Library.Name.Contains("com.cleanroommc:cleanroom:0.2")) // Cleanroom 的主 Jar 必须放在 ClassPath 第一位
-                CpStrings.Insert(0, Library.LocalPath);
             if (Library.Name is not null && Library.Name == "optifine:OptiFine")
                 OptiFineCp = Library.LocalPath;
             else


### PR DESCRIPTION
删除理论上永远不会生效，并且在测试里确实没发现有用的一段代码
详见 讨论 [#2760 ](https://github.com/PCL-Community/PCL-CE/discussions/2760)

## 由 Sourcery 提供的摘要

增强内容：
- 从模组启动流水线中移除无法到达的 Cleanroom 类路径插入逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove unreachable Cleanroom classpath insertion logic from the mod launch pipeline.

</details>