### PR TITLE
fix(net): namespace error & proxy string format support

### DIFF
--- a/PCL.Core.Test/Network/DohConnection.cs
+++ b/PCL.Core.Test/Network/DohConnection.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PCL.Core.IO.Net.Http.Client;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Test.Network;
 

--- a/PCL.Core/IO/Net/Dns/DnsQuery.cs
+++ b/PCL.Core/IO/Net/Dns/DnsQuery.cs
@@ -9,7 +9,7 @@ using Ae.Dns.Client;
 using Ae.Dns.Protocol;
 using Ae.Dns.Protocol.Enums;
 using Ae.Dns.Protocol.Records;
-using PCL.Core.IO.Net.Http.Client;
+using PCL.Core.IO.Net.Http;
 using PCL.Core.Logging;
 
 namespace PCL.Core.IO.Net.Dns;

--- a/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
+++ b/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
@@ -16,15 +16,18 @@ public class DnsSrvResource : IDnsResource
     public void WriteBytes(Memory<byte> bytes, ref int offset)
     {
         // 6 Bytes for priority, weight, port and 2 bytes for length
-        var length = 8 + Target.Length;
-        var buf = new byte[length];
+        var buf = new byte[8 + Target.Length * 6];
         var span = buf.AsSpan();
         BinaryPrimitives.WriteUInt16BigEndian(span[..2], (ushort)Priority);
         BinaryPrimitives.WriteUInt16BigEndian(span[2..4], (ushort)Weight);
         BinaryPrimitives.WriteUInt16BigEndian(span[4..6], (ushort)Port);
-        BinaryPrimitives.WriteUInt16BigEndian(span[6..8], (ushort)Target.Length);
-        Encoding.UTF8.GetBytes(Target).CopyTo(span[8..]);
-        buf.CopyTo(bytes);
+        // target string
+        var targetString = Encoding.UTF8.GetBytes(Target);
+        BinaryPrimitives.WriteUInt16BigEndian(span[6..8], (ushort)targetString.Length);
+        targetString.CopyTo(span[8..]);
+
+        var length = 8 + targetString.Length;
+        span[..length].CopyTo(bytes.Span[offset..]);
         offset += length;
     }
 

--- a/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
+++ b/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
@@ -16,19 +16,23 @@ public class DnsSrvResource : IDnsResource
     public void WriteBytes(Memory<byte> bytes, ref int offset)
     {
         // 6 Bytes for priority, weight, port and 2 bytes for length
-        var buf = new byte[8 + Target.Length * 6];
-        var span = buf.AsSpan();
-        BinaryPrimitives.WriteUInt16BigEndian(span[..2], (ushort)Priority);
-        BinaryPrimitives.WriteUInt16BigEndian(span[2..4], (ushort)Weight);
-        BinaryPrimitives.WriteUInt16BigEndian(span[4..6], (ushort)Port);
+        var buf = bytes.Span[offset..];
+        BinaryPrimitives.WriteUInt16BigEndian(buf[offset..(offset + 2)], (ushort)Priority);
+        offset += 2;
+        BinaryPrimitives.WriteUInt16BigEndian(buf[offset..(offset + 2)], (ushort)Weight);
+        offset += 2;
+        BinaryPrimitives.WriteUInt16BigEndian(buf[offset..(offset + 2)], (ushort)Port);
+        offset += 2;
         // target string
-        var targetString = Encoding.UTF8.GetBytes(Target);
-        BinaryPrimitives.WriteUInt16BigEndian(span[6..8], (ushort)targetString.Length);
-        targetString.CopyTo(span[8..]);
-
-        var length = 8 + targetString.Length;
-        span[..length].CopyTo(bytes.Span[offset..]);
-        offset += length;
+        foreach (var seg in Target.Split('.'))
+        {
+            var segBuf = Encoding.UTF8.GetBytes(seg);
+            var segLength = (byte)segBuf.Length;
+            buf[offset] = segLength;
+            offset++;
+            segBuf.CopyTo(buf[offset..]);
+            offset += segBuf.Length;
+        }
     }
 
     public void ReadBytes(ReadOnlyMemory<byte> bytes, ref int offset, int length)

--- a/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
+++ b/PCL.Core/IO/Net/Dns/DnsSrvResource.cs
@@ -24,6 +24,8 @@ public class DnsSrvResource : IDnsResource
         BinaryPrimitives.WriteUInt16BigEndian(span[4..6], (ushort)Port);
         BinaryPrimitives.WriteUInt16BigEndian(span[6..8], (ushort)Target.Length);
         Encoding.UTF8.GetBytes(Target).CopyTo(span[8..]);
+        buf.CopyTo(bytes);
+        offset += length;
     }
 
     public void ReadBytes(ReadOnlyMemory<byte> bytes, ref int offset, int length)

--- a/PCL.Core/IO/Net/Http/HostConnectionHandler.cs
+++ b/PCL.Core/IO/Net/Http/HostConnectionHandler.cs
@@ -12,7 +12,7 @@ using PCL.Core.IO.Net.Dns;
 using PCL.Core.Logging;
 using PCL.Core.Utils.Exts;
 
-namespace PCL.Core.IO.Net.Http.Client;
+namespace PCL.Core.IO.Net.Http;
 
 public class HostConnectionHandler
 {

--- a/PCL.Core/IO/Net/Http/HttpBasicExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpBasicExtension.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Net.Http;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpBasicExtension
 {

--- a/PCL.Core/IO/Net/Http/HttpContentExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpContentExtension.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpContentExtension
 {

--- a/PCL.Core/IO/Net/Http/HttpCookieExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpCookieExtension.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpCookieExtension
 {

--- a/PCL.Core/IO/Net/Http/HttpHeaderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpHeaderExtension.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpHeaderHandler
 {

--- a/PCL.Core/IO/Net/Http/HttpProxyManager.cs
+++ b/PCL.Core/IO/Net/Http/HttpProxyManager.cs
@@ -58,7 +58,7 @@ public class HttpProxyManager : IWebProxy, IDisposable
         var ret = new List<ProxyItem>();
 
         // 形式：http=192.168.1.100:8080;socks=192.168.1.100:1080
-        if (proxyString.Contains('=') && proxyString.Contains(';'))
+        if (proxyString.Contains('='))
         {
             foreach (var segment in proxyString.Split(';', StringSplitOptions.RemoveEmptyEntries))
             {

--- a/PCL.Core/IO/Net/Http/HttpProxyManager.cs
+++ b/PCL.Core/IO/Net/Http/HttpProxyManager.cs
@@ -119,10 +119,10 @@ public class HttpProxyManager : IWebProxy, IDisposable
 
                 // filter
                 if (proxies.Length == 0 || !proxies.Any(static x => x.Protocol.Equals(ProxyProtocol.Http))) isSystemProxyEnabled = 0;
-                var selectedProxy = proxies.First(static x => x.Protocol.Equals(ProxyProtocol.Http));
+                var selectedProxy = proxies.FirstOrDefault(static x => x.Protocol.Equals(ProxyProtocol.Http));
 
                 // apply
-                _systemWebProxy.Address = (selectedProxy.Address.IsNullOrEmpty() || isSystemProxyEnabled == 0)
+                _systemWebProxy.Address = (isSystemProxyEnabled == 0 || selectedProxy!.Address.IsNullOrEmpty())
                     ? null
                     : new Uri($"http://{selectedProxy.Address}");
 

--- a/PCL.Core/IO/Net/Http/HttpProxyManager.cs
+++ b/PCL.Core/IO/Net/Http/HttpProxyManager.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Net;
 using Microsoft.Win32;
 using PCL.Core.Logging;
 using PCL.Core.Utils.OS;
 
-namespace PCL.Core.IO.Net.Http.Client;
+namespace PCL.Core.IO.Net.Http;
 
 public class HttpProxyManager : IWebProxy, IDisposable
 {
@@ -19,8 +19,8 @@ public class HttpProxyManager : IWebProxy, IDisposable
 
     private readonly object _lock = new();
     private ProxyMode _mode = ProxyMode.SystemProxy;
-    private readonly WebProxy _customWebProxy = new() {BypassProxyOnLocal = true};
-    private readonly WebProxy _systemWebProxy = new() {BypassProxyOnLocal = true};
+    private readonly WebProxy _customWebProxy = new() { BypassProxyOnLocal = true };
+    private readonly WebProxy _systemWebProxy = new() { BypassProxyOnLocal = true };
     private const string ProxyRegPathFull = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings";
     private const string ProxyRegPath = @"Software\Microsoft\Windows\CurrentVersion\Internet Settings";
     private readonly RegistryChangeMonitor _proxyMonitor = new(ProxyRegPath);
@@ -28,10 +28,10 @@ public class HttpProxyManager : IWebProxy, IDisposable
     private HttpProxyManager()
     {
         RefreshSystemProxy(); // 初始化系统代理
-        _proxyMonitor.Changed += _onSystemProxyChanged;
+        _proxyMonitor.Changed += _OnSystemProxyChanged;
     }
 
-    private void _onSystemProxyChanged(object? sender, EventArgs e)
+    private void _OnSystemProxyChanged(object? sender, EventArgs e)
     {
         RefreshSystemProxy();
     }

--- a/PCL.Core/IO/Net/Http/HttpProxyManager.cs
+++ b/PCL.Core/IO/Net/Http/HttpProxyManager.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Microsoft.Win32;
 using PCL.Core.Logging;
+using PCL.Core.Utils.Exts;
 using PCL.Core.Utils.OS;
 
 namespace PCL.Core.IO.Net.Http;
@@ -36,6 +39,70 @@ public class HttpProxyManager : IWebProxy, IDisposable
         RefreshSystemProxy();
     }
 
+    private enum ProxyProtocol
+    {
+        Http,
+        Socks
+    }
+
+    private record ProxyItem
+    {
+        public ProxyProtocol Protocol;
+        public required string Address;
+    }
+
+    private static ProxyItem[] _GetProxyFromString(string? proxyString)
+    {
+        if (proxyString.IsNullOrWhiteSpace()) return [];
+
+        var ret = new List<ProxyItem>();
+
+        // 形式：http=192.168.1.100:8080;socks=192.168.1.100:1080
+        if (proxyString.Contains('=') && proxyString.Contains(';'))
+        {
+            foreach (var segment in proxyString.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var eqIndex = segment.IndexOf('=');
+                if (eqIndex <= 0 || eqIndex >= segment.Length - 1)
+                    continue;
+
+                var protocolStr = segment[..eqIndex].Trim();
+                var address = segment[(eqIndex + 1)..].Trim();
+
+                if (string.IsNullOrWhiteSpace(address))
+                    continue;
+
+                ret.Add(new ProxyItem { Protocol = _ParseProtocol(protocolStr), Address = address });
+            }
+
+            return ret.Count > 0 ? [.. ret] : [];
+        }
+
+        // 形式：http://127.0.0.1:1145/ 或者单纯 127.0.0.1:1145
+        if (Uri.TryCreate(proxyString, new UriCreationOptions(), out var proxyAddr))
+        {
+            var address = proxyAddr.Port > 0
+                ? $"{proxyAddr.Host}:{proxyAddr.Port}"
+                : proxyAddr.Host;
+            ret.Add(new ProxyItem { Protocol = _ParseProtocol(proxyAddr.Scheme), Address = address });
+        }
+        else
+        {
+            ret.Add(new ProxyItem { Protocol = ProxyProtocol.Http, Address = proxyString.Trim() });
+        }
+
+        return [.. ret];
+    }
+
+    private static ProxyProtocol _ParseProtocol(string scheme)
+    {
+        return scheme.ToLowerInvariant() switch
+        {
+            "socks" or "socks4" or "socks5" => ProxyProtocol.Socks,
+            _ => ProxyProtocol.Http
+        };
+    }
+
     /// <summary>刷新系统代理设置</summary>
     public void RefreshSystemProxy()
     {
@@ -43,14 +110,24 @@ public class HttpProxyManager : IWebProxy, IDisposable
         {
             try
             {
+                // read from reg
                 var isSystemProxyEnabled = (int)(Registry.GetValue(ProxyRegPathFull, "ProxyEnable", 0) ?? 0);
-                var systemProxyAddress = Registry.GetValue(ProxyRegPathFull, "ProxyServer", string.Empty) as string;
-                if (systemProxyAddress is not null && !systemProxyAddress.StartsWith("http")) systemProxyAddress = $"http://{systemProxyAddress}/";
-                _systemWebProxy.Address = (string.IsNullOrEmpty(systemProxyAddress) || isSystemProxyEnabled == 0)
+                var systemProxyString = Registry.GetValue(ProxyRegPathFull, "ProxyServer", string.Empty) as string;
+
+                // parse
+                var proxies = _GetProxyFromString(systemProxyString);
+
+                // filter
+                if (proxies.Length == 0 || !proxies.Any(static x => x.Protocol.Equals(ProxyProtocol.Http))) isSystemProxyEnabled = 0;
+                var selectedProxy = proxies.First(static x => x.Protocol.Equals(ProxyProtocol.Http));
+
+                // apply
+                _systemWebProxy.Address = (selectedProxy.Address.IsNullOrEmpty() || isSystemProxyEnabled == 0)
                     ? null
-                    : new Uri(systemProxyAddress);
+                    : new Uri($"http://{selectedProxy.Address}");
+
                 LogWrapper.Info("Proxy",
-                    $"已从操作系统更新代理设置，系统代理状态：{isSystemProxyEnabled}|{systemProxyAddress}");
+                    $"已从操作系统更新代理设置，系统代理状态：{isSystemProxyEnabled}|{systemProxyString}");
             }
             catch (Exception ex)
             {

--- a/PCL.Core/IO/Net/Http/HttpRequest.cs
+++ b/PCL.Core/IO/Net/Http/HttpRequest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpRequest
 {

--- a/PCL.Core/IO/Net/Http/HttpResponseExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpResponseExtension.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpResponseExtension
 {

--- a/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace PCL.Core.IO.Net.Http.Client.Request;
+namespace PCL.Core.IO.Net.Http;
 
 public static class HttpSenderExtension
 {

--- a/PCL.Core/IO/Net/Http/HttpServer.cs
+++ b/PCL.Core/IO/Net/Http/HttpServer.cs
@@ -74,10 +74,10 @@ public abstract class HttpServer : IDisposable
 
         _cancellationTokenSource = new CancellationTokenSource();
         _server.Start();
-        _handleLoop = _handleRequest();
+        _handleLoop = _HandleRequest();
     }
 
-    private async Task _handleRequest()
+    private async Task _HandleRequest()
     {
         var cancellationToken = _cancellationTokenSource?.Token ?? CancellationToken.None;
 
@@ -86,7 +86,7 @@ public abstract class HttpServer : IDisposable
             try
             {
                 var context = await _server.GetContextAsync();
-                _ = Task.Run(async () => await _processRequest(context), cancellationToken);
+                _ = Task.Run(async () => await _ProcessRequest(context), cancellationToken);
             }
             catch (OperationCanceledException) { break; } // Cancellation
             catch (ObjectDisposedException) { break; } // Disposed
@@ -94,7 +94,7 @@ public abstract class HttpServer : IDisposable
         }
     }
 
-    private async Task _processRequest(HttpListenerContext context)
+    private async Task _ProcessRequest(HttpListenerContext context)
     {
         try
         {

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using PCL.Core.App;
 using PCL.Core.App.IoC;
-using PCL.Core.IO.Net.Http.Client;
+using PCL.Core.IO.Net.Http;
 using PCL.Core.Logging;
 using Polly;
 
@@ -31,7 +31,7 @@ public partial class NetworkService {
                 MaxAutomaticRedirections = 20,
                 UseCookies = false, //禁止自动 Cookie 管理
                 ConnectCallback = Config.Network.EnableDoH
-                    ? HostConnectionHandler.Instance.GetConnectionAsync
+                    ? PCL.Core.IO.Net.Http.HostConnectionHandler.Instance.GetConnectionAsync
                     : null
             }
         );

--- a/PCL.Core/IO/Net/TcpForward.cs
+++ b/PCL.Core/IO/Net/TcpForward.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Net;
@@ -195,11 +195,11 @@ public sealed class TcpForward(
 
     public void Dispose()
     {
-        Dispose(true);
+        _Dispose(true);
         GC.SuppressFinalize(this);
     }
 
-    private void Dispose(bool disposing)
+    private void _Dispose(bool disposing)
     {
         if (!disposing) return;
         if (_disposed) return;
@@ -211,7 +211,7 @@ public sealed class TcpForward(
 
     ~TcpForward()
     {
-        Dispose(false);
+        _Dispose(false);
     }
 
     private class ConnectionPair(Socket clientSocket, Socket targetSocket)

--- a/PCL.Core/Link/Lobby/LobbyController.cs
+++ b/PCL.Core/Link/Lobby/LobbyController.cs
@@ -19,7 +19,7 @@ using static PCL.Core.Link.Lobby.LobbyInfoProvider;
 using static PCL.Core.Link.Natayark.NatayarkProfileManager;
 using LobbyType = PCL.Core.Link.Scaffolding.Client.Models.LobbyType;
 using PCL.Core.Link.McPing;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Link.Lobby;
 

--- a/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
+++ b/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Link.Natayark;
 

--- a/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
@@ -17,7 +17,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using PCL.Core.IO.Net;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Link.Scaffolding.EasyTier;
 

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
@@ -5,9 +5,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Minecraft.IdentityModel.Extensions.JsonWebToken;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilOptions.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilOptions.cs
@@ -2,10 +2,10 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 using PCL.Core.Utils.Exts;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.IdentityModel.Extensions.YggdrasilConnect;
 

--- a/PCL.Core/Minecraft/IdentityModel/OAuth/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/OAuth/Client.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.IdentityModel.OAuth;
 

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -1,9 +1,9 @@
-using PCL.Core.IO.Net.Http.Client.Request;
 using System;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 

--- a/PCL.Core/Minecraft/Yggdrasil/ApiLocation.cs
+++ b/PCL.Core/Minecraft/Yggdrasil/ApiLocation.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.Yggdrasil;
 

--- a/PCL.Core/ViewModel/Homepage/NewsViewModel.cs
+++ b/PCL.Core/ViewModel/Homepage/NewsViewModel.cs
@@ -1,13 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Logging;
 using PCL.Core.Model.Tools.News;
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Threading.Tasks;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.ViewModel.Homepage;
 

--- a/Plain Craft Launcher 2/Controls/MyImage.cs
+++ b/Plain Craft Launcher 2/Controls/MyImage.cs
@@ -5,8 +5,8 @@ using System.Net.Http;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Utils;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 using System.Windows.Media.Effects;
 using PCL.Core.App;
 using PCL.Core.App.Configuration;
-using PCL.Core.IO.Net.Http.Client;
+using PCL.Core.IO.Net.Http;
 using PCL.Core.UI.Theme;
 using PCL.Core.Utils.Exts;
 using PCL.Network;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -7,10 +7,11 @@ using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Utils;
 using PCL.Network;
 using PCL.Network.Loaders;
+using PCL.Core.IO.Net.Http;
+using PCL;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -10,13 +10,14 @@ using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Minecraft;
 using PCL.Core.Minecraft.Launch.Utils;
 using PCL.Core.Utils;
 using PCL.Core.Utils.OS;
 using PCL.Core.Utils.Secret;
 using PCL.Network;
+using PCL.Core.IO.Net.Http;
+using PCL;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
@@ -2,11 +2,11 @@ using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Diff;
 using PCL.Network;
 using PCL.Network.Loaders;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMirrorChyanModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMirrorChyanModel.cs
@@ -1,10 +1,10 @@
 using System.Net.Http;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Utils;
 using PCL.Network;
 using PCL.Network.Loaders;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -10,12 +10,13 @@ using System.Windows.Controls.Primitives;
 using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Minecraft;
 using PCL.Core.UI;
 using PCL.Core.Utils;
 using PCL.Network;
 using PCL.Network.Loaders;
+using PCL.Core.IO.Net.Http;
+using PCL;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginAuth.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginAuth.xaml.cs
@@ -3,11 +3,11 @@ using System.Windows;
 using System.Windows.Controls;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
-using PCL.Core.IO.Net.Http.Client.Request;
 using PCL.Core.Minecraft.Yggdrasil;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Exts;
 using PCL.Core.Utils.Validate;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageHomePageMarket.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageHomePageMarket.xaml.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Input;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL
 {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 using System.Windows;
 using System.Windows.Input;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL;
 


### PR DESCRIPTION
Close https://github.com/PCL-Community/PCL-CE/issues/2694

## Summary by Sourcery

将 HTTP 网络类型统一到 `PCL.Core.IO.Net.Http` 命名空间下，并改进代理处理及 DNS 序列化。

新功能：
- 在初始化系统 HTTP 代理时，支持解析多种格式的 Windows 代理配置字符串（按协议分别配置、URI 形式以及 `host:port` 形式）。

错误修复：
- 修正 `HttpProxyManager` 的系统代理选择逻辑，确保能可靠选取有效的 HTTP 代理条目，避免使用无效或不受支持的配置。
- 修复 `DnsSrvResource.WriteBytes`，使其真正将编码后的 SRV 记录字节复制到目标缓冲区并推进偏移量，确保 DNS 序列化正确。

改进优化：
- 将 HTTP 客户端、代理和辅助扩展类从子命名空间移动到 `PCL.Core.IO.Net.Http` 中，并相应更新所有调用处。
- 统一网络类中内部方法和释放（dispose）模式的命名，以提高清晰度和一致性。
- 在命名空间调整后，将 `NetworkService` 连接到正确的 `HostConnectionHandler` 类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify HTTP networking types under the PCL.Core.IO.Net.Http namespace and improve proxy handling and DNS serialization.

New Features:
- Support parsing Windows proxy configuration strings in multiple formats (per-protocol entries, URI forms, and host:port) when initializing the system HTTP proxy.

Bug Fixes:
- Correct the HttpProxyManager system proxy selection to reliably pick a valid HTTP proxy entry and avoid using invalid or unsupported configurations.
- Fix DnsSrvResource.WriteBytes to actually copy the encoded SRV record bytes into the destination buffer and advance the offset, ensuring correct DNS serialization.

Enhancements:
- Move HTTP client, proxy, and helper extension classes from sub-namespaces into PCL.Core.IO.Net.Http and update all call sites accordingly.
- Standardize internal method and dispose pattern naming in networking classes for clarity and consistency.
- Wire NetworkService to use the correct HostConnectionHandler type after the namespace changes.

</details>