### PR TITLE
feat(app): 全新的公告系统

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -37,6 +37,11 @@ public static partial class Config
         /// 动画帧率上限。
         /// </summary>
         [ConfigItem<int>("UiAniFPS", 59)] public partial int AnimationFpsLimit { get; set; }
+        
+        /// <summary>
+        /// 隐藏的公告
+        /// </summary>
+        [ConfigItem<string>("HiddenAnnouncementList", "[]")] public partial string HiddenAnnouncement { get; set; }
     }
 
     /// <summary>

--- a/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
+++ b/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
@@ -45,7 +45,7 @@ public partial class AnnouncementService
                 var invalid = _ignored.Except(response.Select(a => a.Id)).ToList();
                 _ignored.RemoveAll(invalid.Contains);
                 
-                var announcements = response.OrderBy(a => a.Priority).Where(a =>
+                var announcements = response.OrderByDescending(a => a.Priority).Where(a =>
                 {
                     var isNotAfterValid = DateTimeOffset.TryParse(a.SkipOn.NotAfter, out var notAfter);
                     var isNotBeforeValid = DateTimeOffset.TryParse(a.SkipOn.NotBefore, out var notBefore);

--- a/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
+++ b/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using PCL.Core.App.Essentials.Announcement.Models;
 using PCL.Core.App.IoC;
-using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.IO.Net.Http;
 using PCL.Core.Logging;
 using PCL.Core.UI;
 

--- a/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
+++ b/PCL.Core/App/Essentials/Announcement/AnnouncementService.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using PCL.Core.App.Essentials.Announcement.Models;
+using PCL.Core.App.IoC;
+using PCL.Core.IO.Net.Http.Client.Request;
+using PCL.Core.Logging;
+using PCL.Core.UI;
+
+namespace PCL.Core.App.Essentials.Announcement;
+
+[LifecycleScope("announcement","公告")]
+[LifecycleService(LifecycleState.Running)]
+public partial class AnnouncementService
+{
+    
+    private static readonly string[] _AllowScheme = ["http", "https", "minecraft" ];
+    private static readonly string[] _AnnouncementServerList = Secrets.AnnouncementServerList;
+
+    private static List<string> _ignored =
+        JsonSerializer.Deserialize<string[]>(Config.System.HiddenAnnouncement)?.ToList() ?? [];
+    
+    [LifecycleStart]
+    private static async Task _Start()
+    {
+        // 可能会出现公告服务比配置服务晚关闭的情况
+        Lifecycle.StateChanged += state =>
+        {
+            if (state == LifecycleState.Closing) Config.System.HiddenAnnouncement = JsonSerializer.Serialize(_ignored);
+        };
+        try
+        {
+            foreach (var source in _AnnouncementServerList)
+            {
+                var response = await HttpRequest.GetJsonAsync<List<AnnouncementDetails>>(source)
+                    .ConfigureAwait(false);
+                if (response is null) continue;
+                
+                // 对忽略的公告进行检查1，以确保仍然处于公告列表内
+                
+                var invalid = _ignored.Except(response.Select(a => a.Id)).ToList();
+                _ignored.RemoveAll(invalid.Contains);
+                
+                var announcements = response.OrderBy(a => a.Priority).Where(a =>
+                {
+                    var isNotAfterValid = DateTimeOffset.TryParse(a.SkipOn.NotAfter, out var notAfter);
+                    var isNotBeforeValid = DateTimeOffset.TryParse(a.SkipOn.NotBefore, out var notBefore);
+                    var localTime = DateTimeOffset.Now;
+                    if (isNotAfterValid && localTime > notAfter) return false;
+                    if (isNotBeforeValid && localTime < notBefore) return false;
+                    var currentVersion = new Version(Basics.VersionName.Split("-")[0]);
+                    var max = new Version(a.SkipOn.MaxVersion ?? "999.999.999");
+                    var min = new Version(a.SkipOn.MinVersion ?? "0.0.0");
+                    
+                    // [min,max]
+                    return currentVersion >= min && currentVersion <= max;
+
+                });
+                foreach (var detail in announcements)
+                {
+                    Context.Debug(MsgBoxWrapper.ShowWithCustomButtons(
+                        detail.Details, $"{detail.Title} ({detail.ReleaseDate})", _GetSelectTheme(detail.Level),
+                        false,
+                        detail.Buttons.Select(operation => new MsgBoxButtonInfo(operation.ButtonText,
+                            OnClick: _GetSelectCallback(operation.Operation, operation.Argument))).ToArray()).ToString());
+                }
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Context.Error("加载公告失败", ex, ActionLevel.HintErr);
+        }
+    }
+    
+    private static Action _GetSelectCallback(string operation, string arguments) => operation switch
+    {
+        "OpenWebSite" => () =>
+        {
+            if (arguments.Length == 0) throw new ArgumentException("Uri is missing");
+            if (_AllowScheme.All(s => new Uri(arguments).Scheme != s))
+                throw new InvalidOperationException("This uri contains a unsupported scheme.");
+            Process.Start(new ProcessStartInfo(arguments){ UseShellExecute = true });
+
+        },
+        "StopShow" => () =>
+        {
+            _ignored.Add(arguments);
+        },
+        _ => static () => { }
+    };
+
+    private static MsgBoxTheme _GetSelectTheme(AnnouncementLevel level) => level switch
+    {
+        AnnouncementLevel.Medium => MsgBoxTheme.Warning,
+        AnnouncementLevel.Highest => MsgBoxTheme.Error,
+        _ => MsgBoxTheme.Info
+    };
+}

--- a/PCL.Core/App/Essentials/Announcement/Models/AnnouncementDetails.cs
+++ b/PCL.Core/App/Essentials/Announcement/Models/AnnouncementDetails.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PCL.Core.App.Essentials.Announcement.Models;
+
+public record AnnouncementDetails
+{
+    /// <summary>
+    /// 公告标题
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+    
+    /// <summary>
+    /// 公告内容
+    /// </summary>
+    [JsonPropertyName("details")]
+    public required string Details { get; init; }
+    
+    /// <summary>
+    /// 该公告的优先级，值越高优先级越高
+    /// </summary>
+    [JsonPropertyName("priority")] 
+    public int Priority { get; init; }
+    
+    /// <summary>
+    /// 公告 ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// 该公告的等级，决定弹窗应该用什么样式
+    /// </summary>
+    [JsonPropertyName("level")] 
+    public required AnnouncementLevel Level { get; init; }
+    
+    /// <summary>
+    /// 该公告的发布日期
+    /// </summary>
+    [JsonPropertyName("date")]
+    public required string ReleaseDate { get; init; }
+    
+    /// <summary>
+    /// 显示条件
+    /// </summary>
+    [JsonPropertyName("skip")]
+    public required AnnouncementSkipCondition SkipOn { get; init; }
+    
+    /// <summary>
+    /// 弹窗按钮信息
+    /// </summary>
+    [JsonPropertyName("buttons")]
+    public required IEnumerable<AnnouncementOperation> Buttons { get; init; }
+}

--- a/PCL.Core/App/Essentials/Announcement/Models/AnnouncementLevel.cs
+++ b/PCL.Core/App/Essentials/Announcement/Models/AnnouncementLevel.cs
@@ -1,0 +1,17 @@
+﻿namespace PCL.Core.App.Essentials.Announcement.Models;
+
+public enum AnnouncementLevel
+{
+    /// <summary>
+    /// 最低的等级，属于可看可不看的那种
+    /// </summary>
+    Lowest,
+    /// <summary>
+    /// 用户应该稍微有点了解的公告
+    /// </summary>
+    Medium,
+    /// <summary>
+    /// 必须让用户知道并理解的公告内容
+    /// </summary>
+    Highest
+}

--- a/PCL.Core/App/Essentials/Announcement/Models/AnnouncementOperation.cs
+++ b/PCL.Core/App/Essentials/Announcement/Models/AnnouncementOperation.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PCL.Core.App.Essentials.Announcement.Models;
+
+public record AnnouncementOperation
+{
+    /// <summary>
+    /// 按钮文本
+    /// </summary>
+    [JsonPropertyName("text")]
+    public required string ButtonText { get; init; }
+    
+    /// <summary>
+    /// 按下后的操作
+    /// </summary>
+    [JsonPropertyName("exec")]
+    public required string Operation { get; init; }
+    
+    /// <summary>
+    /// 参数列表
+    /// </summary>
+    [JsonPropertyName("argument")]
+    public required string Argument { get; init; }
+}

--- a/PCL.Core/App/Essentials/Announcement/Models/AnnouncementSkipCondition.cs
+++ b/PCL.Core/App/Essentials/Announcement/Models/AnnouncementSkipCondition.cs
@@ -6,7 +6,7 @@ public class AnnouncementSkipCondition
 {
     [JsonPropertyName("min")]
     public string? MinVersion { get; init; }
-    [JsonPropertyName("Max")]
+    [JsonPropertyName("max")]
     public string? MaxVersion { get; init; }
     [JsonPropertyName("notAfter")]
     public string? NotAfter { get; init; }

--- a/PCL.Core/App/Essentials/Announcement/Models/AnnouncementSkipCondition.cs
+++ b/PCL.Core/App/Essentials/Announcement/Models/AnnouncementSkipCondition.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PCL.Core.App.Essentials.Announcement.Models;
+
+public class AnnouncementSkipCondition
+{
+    [JsonPropertyName("min")]
+    public string? MinVersion { get; init; }
+    [JsonPropertyName("Max")]
+    public string? MaxVersion { get; init; }
+    [JsonPropertyName("notAfter")]
+    public string? NotAfter { get; init; }
+    [JsonPropertyName("notBefore")]
+    public string? NotBefore { get; init; }
+
+}

--- a/PCL.Core/App/Secrets.cs
+++ b/PCL.Core/App/Secrets.cs
@@ -40,4 +40,10 @@ public static class Secrets
     /// 当前版本的 Git 提交 SHA
     /// </summary>
     public static string CommitHash { get; } = EnvironmentInterop.GetSecret("GITHUB_SHA", readEnvDebugOnly: true).ReplaceNullOrEmpty();
+
+    /// <summary>
+    /// 公告服务器地址
+    /// </summary>
+    public static string[] AnnouncementServerList { get; } = EnvironmentInterop
+        .GetSecret("ANNOUNCEMENT_SERVER", readEnvDebugOnly: true).ReplaceNullOrEmpty().Split("|");
 }


### PR DESCRIPTION
重做了整套公告系统，使其和更新服务解耦

并且扩展支持了按时间和版本进行展示

目前可能还需要修一点 bug，以及配套设施还没落地

## Summary by Sourcery

引入一个专用的公告服务，用于根据时间和版本约束获取并展示远程公告，并与更新系统解耦。

新功能：
- 添加一个由生命周期管理的 AnnouncementService，用于从已配置的服务器获取公告，并通过带主题样式的消息框进行展示。
- 支持按公告配置客户端版本范围和有效时间窗口的过滤，以控制可见性。
- 允许为每条公告配置操作，包括打开已验证的 URL，以及永久隐藏特定公告。

增强内容：
- 定义强类型的公告模型，包括公告级别、跳过条件以及按按钮配置的操作，以标准化公告弹窗的远程配置方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated announcement service that fetches and displays remote announcements based on time and version constraints, decoupled from the update system.

New Features:
- Add a lifecycle-managed AnnouncementService that retrieves announcements from configured servers and displays them via themed message boxes.
- Support per-announcement filtering by client version range and valid time window to control visibility.
- Allow per-announcement actions including opening validated URLs and permanently hiding specific announcements.

Enhancements:
- Define strongly typed models for announcements, including levels, skip conditions, and per-button operations to standardize remote configuration of announcement dialogs.

</details>