### PR TITLE
fix(ModDownload): C# 版本中，所有来自 CurseForge 源的模组无法加载详细内容

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -454,8 +454,7 @@ public static class ModComp
                 await Task.Run(() =>
                 {
                     var RawProjectsData =
-                        ModDownload.DlModRequest($"https://api.modrinth.com/v2/projects?ids=[\"{Ids.Join("\",\"")}\"]",
-                            true);
+                        ModDownload.DlModRequest<JArray>($"https://api.modrinth.com/v2/projects?ids=[\"{Ids.Join("\",\"")}\"]");
                     foreach (var RawData in (IEnumerable)RawProjectsData)
                         Res.Add(new CompProject((JObject)RawData));
                 });
@@ -485,7 +484,7 @@ public static class ModComp
                     var jsonBody = "{\"modIds\": [" + string.Join(",", ids) + "]}";
 
                     // DlModRequest 返回 object，先强转 JObject，再获取 "data" 并强转为 JArray
-                    var response = (JObject)ModDownload.DlModRequest(
+                    var response = ModDownload.DlModRequest<JObject>(
                         "https://api.curseforge.com/v1/mods",
                         "POST",
                         jsonBody,
@@ -582,8 +581,8 @@ public static class ModComp
                         slug = parts[3];
 
                         // 获取资源信息
-                        var json = (JObject)ModDownload.DlModRequest(
-                            $"https://api.curseforge.com/v1/mods/search?gameId=432&slug={slug}", true);
+                        var json = ModDownload.DlModRequest<JObject>(
+                            $"https://api.curseforge.com/v1/mods/search?gameId=432&slug={slug}");
                         var dataArray = (JArray)json["data"];
 
                         if (dataArray.Any())
@@ -604,9 +603,8 @@ public static class ModComp
                                 receivedClassId != targetClassId)
                             {
                                 // 如果分类不匹配，带上 classId 重新搜索
-                                json = (JObject)ModDownload.DlModRequest(
-                                    $"https://api.curseforge.com/v1/mods/search?gameId=432&slug={slug}&classId={targetClassId}",
-                                    true);
+                                json = ModDownload.DlModRequest<JObject>(
+                                    $"https://api.curseforge.com/v1/mods/search?gameId=432&slug={slug}&classId={targetClassId}");
                                 dataArray = (JArray)json["data"];
                             }
 
@@ -620,8 +618,7 @@ public static class ModComp
                         if (parts.Length < 3) return;
 
                         slug = parts[2];
-                        var json = (JObject)ModDownload.DlModRequest($"https://api.modrinth.com/v2/project/{slug}",
-                            true);
+                        var json = ModDownload.DlModRequest<JObject>($"https://api.modrinth.com/v2/project/{slug}");
                         projectId = json["id"]?.ToString();
                     }
                     else
@@ -2769,7 +2766,7 @@ public static class ModComp
                     try
                     {
                         LogWrapper.Info("[Comp] 开始从 CurseForge 获取列表：" + curseForgeUrl);
-                        var json = (JObject)ModDownload.DlModRequest(curseForgeUrl, true);
+                        var json = ModDownload.DlModRequest<JObject>(curseForgeUrl);
                         var projects = json["data"].Select(j => new CompProject((JObject)j))
                             .Where(p => !(request.Type == CompType.ResourcePack && p.Tags.Contains("数据包")))
                             .ToList();
@@ -2795,7 +2792,7 @@ public static class ModComp
                     try
                     {
                         LogWrapper.Info("[Comp] 开始从 Modrinth 获取列表：" + modrinthUrl);
-                        var json = (JObject)ModDownload.DlModRequest(modrinthUrl, true);
+                        var json = ModDownload.DlModRequest<JObject>(modrinthUrl);
                         var projects = json["hits"].Select(j => new CompProject((JObject)j)).ToList();
                         lock (resultsLock)
                         {
@@ -3458,12 +3455,12 @@ public static class ModComp
                 : $"https://api.modrinth.com/v2/project/{ProjectId}";
             if (FromCurseForge)
             {
-                var json = (JObject)ModDownload.DlModRequest(url, true);
+                var json = ModDownload.DlModRequest<JObject>(url);
                 TargetProject = new CompProject((JObject)json["data"]);
             }
             else
             {
-                TargetProject = new CompProject((JObject)ModDownload.DlModRequest(url, true));
+                TargetProject = new CompProject(ModDownload.DlModRequest<JObject>(url));
             }
             // 假设 CompProject 构造函数内已处理缓存，否则此处应添加缓存逻辑
         }
@@ -3476,9 +3473,8 @@ public static class ModComp
             if (FromCurseForge)
             {
                 // 注意：若 pageSize=10000 失效，需考虑分页逻辑
-                var response = (JObject)ModDownload.DlModRequest(
-                    $"https://api.curseforge.com/v1/mods/{ProjectId}/files?pageSize=10000",
-                    true
+                var response = ModDownload.DlModRequest<JObject>(
+                    $"https://api.curseforge.com/v1/mods/{ProjectId}/files?pageSize=10000"
                 );
 
                 ResultJsonArray = (JArray)response["data"];
@@ -3486,7 +3482,7 @@ public static class ModComp
             else
             {
                 ResultJsonArray =
-                    (JArray)ModDownload.DlModRequest($"https://api.modrinth.com/v2/project/{ProjectId}/version?include_changelog=false", true);
+                    ModDownload.DlModRequest<JArray>($"https://api.modrinth.com/v2/project/{ProjectId}/version?include_changelog=false");
             }
 
             CompFilesCache[ProjectId] = ResultJsonArray.Select(a => new CompFile((JObject)a, TargetProject.Type))
@@ -3509,7 +3505,7 @@ public static class ModComp
             if (FromCurseForge)
             {
                 // 1. 获取响应并转为 JObject
-                var response = (JObject)ModDownload.DlModRequest(
+                var response = ModDownload.DlModRequest<JObject>(
                     "https://api.curseforge.com/v1/mods",
                     "POST",
                     "{\"modIds\": [" + string.Join(",", UndoneDeps) + "]}",
@@ -3521,8 +3517,8 @@ public static class ModComp
             }
             else
             {
-                Projects = (JArray)ModDownload.DlModRequest(
-                    $"https://api.modrinth.com/v2/projects?ids=[\"{UndoneDeps.Join("\",\"")}\"]", true);
+                Projects = ModDownload.DlModRequest<JArray>(
+                    $"https://api.modrinth.com/v2/projects?ids=[\"{UndoneDeps.Join("\",\"")}\"]");
             }
 
             foreach (var Project in Projects)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -1927,7 +1927,7 @@ public static class ModDownload
     // ''' </summary>
     // Public DlQuiltListBmclapiLoader As New LoaderTask(Of Integer, DlQuiltListResult)("DlQuiltList Bmclapi", AddressOf DlQuiltListBmclapiMain)
     // Private Sub DlQuiltListBmclapiMain(Loader As LoaderTask(Of Integer, DlQuiltListResult))
-    // Dim Result As JObject = NetGetCodeByRequestRetry("https://bmclapi2.bangbang93.com/Quilt-meta/v2/versions", IsJson:=True)
+    // Dim Result As JObject = NetGetCodeByRequestRetry("https://bmclapi2.bangbang93.com/Quilt-meta/v2/versions")
     // Try
     // Dim Output = New DlQuiltListResult With {.IsOfficial = False, .SourceName = "BMCLAPI", .Value = Result}
     // If Output.Value("game") Is Nothing OrElse Output.Value("loader") Is Nothing OrElse Output.Value("installer") Is Nothing Then Throw New Exception("获取到的列表缺乏必要项")
@@ -2046,36 +2046,42 @@ public static class ModDownload
     #region DlMod | Mod 镜像源请求
 
     /// <summary>
-    ///     对可能涉及 Mod 镜像源的请求进行处理，返回字符串或 JObject。
+    ///     对可能涉及 Mod 镜像源的请求进行处理，返回字符串。
     ///     调用 NetGetCodeByRequest，会进行重试。
     /// </summary>
-    public static object DlModRequest(string Url, bool IsJson = false)
+    public static string DlModRequest(string url) => DlModRequest<string>(url);
+
+    /// <summary>
+    ///     对可能涉及 Mod 镜像源的请求进行处理，返回字符串或 JSON 对象。
+    ///     调用 NetGetCodeByRequest，会进行重试。
+    /// </summary>
+    public static T DlModRequest<T>(string url)
     {
         var Urls = new List<KeyValuePair<string, int>>();
-        var McimUrl = DlSourceModGet(Url);
-        if ((McimUrl ?? "") != (Url ?? ""))
+        var McimUrl = DlSourceModGet(url);
+        if ((McimUrl ?? "") != (url ?? ""))
             switch (Config.Download.Comp.CompSourceSolution)
             {
                 case var @case when Operators.ConditionalCompareObjectEqual(@case, 0, false):
                 {
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 5));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     break;
                 }
                 case var case1 when Operators.ConditionalCompareObjectEqual(case1, 1, false):
                 {
-                    Urls.Add(new KeyValuePair<string, int>(Url, 5));
+                    Urls.Add(new KeyValuePair<string, int>(url, 5));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 5));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
                     break;
                 }
 
                 default:
                 {
-                    Urls.Add(new KeyValuePair<string, int>(Url, 5));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 5));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
                     break;
                 }
@@ -2085,17 +2091,13 @@ public static class ModDownload
         foreach (var Source in Urls)
             try
             {
-                return IsJson
-                    ? Requester.FetchJson(Source.Key, new RequestParam
-                    {
-                        Timeout = Source.Value * 1000,
-                        UseBrowserUserAgent = true
-                    })
-                    : Requester.FetchString(Source.Key, new RequestParam
-                    {
-                        Timeout = Source.Value * 1000,
-                        UseBrowserUserAgent = true
-                    });
+                var json = Requester.FetchString(Source.Key, new RequestParam
+                {
+                    Timeout = Source.Value * 1000,
+                    UseBrowserUserAgent = true
+                });
+                if (typeof(T) == typeof(string)) return (T)(object)json;
+                return (T)ModBase.GetJson(json);
             }
             catch (Exception ex)
             {
@@ -2107,37 +2109,45 @@ public static class ModDownload
     }
 
     /// <summary>
+    ///     非泛型版本的 DlModRequest，返回 string
     ///     对可能涉及 Mod 镜像源的请求进行处理。
     ///     调用 NetRequest，会进行重试。
     /// </summary>
-    public static string DlModRequest(string Url, string Method, string Data, string ContentType,
+    public static string DlModRequest(string url, string method, string data, string contentType,
+        bool allowMirror = false) => DlModRequest<string>(url, method, data, contentType, allowMirror);
+    
+    /// <summary>
+    ///     对可能涉及 Mod 镜像源的请求进行处理。
+    ///     调用 NetRequest，会进行重试。
+    /// </summary>
+    public static T DlModRequest<T>(string url, string method, string data, string contentType,
         bool allowMirror = false)
     {
         var Urls = new List<KeyValuePair<string, int>>();
-        var McimUrl = DlSourceModGet(Url);
-        if ((McimUrl ?? "") != (Url ?? ""))
+        var McimUrl = DlSourceModGet(url);
+        if ((McimUrl ?? "") != (url ?? ""))
             switch (allowMirror ? Config.Download.Comp.CompSourceSolution : 2)
             {
                 case var @case when Operators.ConditionalCompareObjectEqual(@case, 0, false):
                 {
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 5));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     break;
                 }
                 case var case1 when Operators.ConditionalCompareObjectEqual(case1, 1, false):
                 {
-                    Urls.Add(new KeyValuePair<string, int>(Url, 5));
+                    Urls.Add(new KeyValuePair<string, int>(url, 5));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 5));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
                     break;
                 }
 
                 default:
                 {
-                    Urls.Add(new KeyValuePair<string, int>(Url, 5));
-                    Urls.Add(new KeyValuePair<string, int>(Url, 15));
+                    Urls.Add(new KeyValuePair<string, int>(url, 5));
+                    Urls.Add(new KeyValuePair<string, int>(url, 15));
                     Urls.Add(new KeyValuePair<string, int>(McimUrl, 10));
                     break;
                 }
@@ -2147,13 +2157,15 @@ public static class ModDownload
         foreach (var Source in Urls)
             try
             {
-                return Requester.Fetch(Source.Key, new FetchParam
+                string json = Requester.Fetch(Source.Key, new FetchParam
                 {
-                    Method = Method,
-                    Content = Data, 
-                    ContentType = ContentType,
+                    Method = method,
+                    Content = data, 
+                    ContentType = contentType,
                     Timeout = Source.Value * 1000
                 });
+                if (typeof(T) == typeof(string)) return (T)(object)json; // 沟槽的，为什么不能写 T is string
+                return (T)ModBase.GetJson(json);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Close #2788

Refactor `DlModRequest` to use generics instead of returning `object`. This removes the need for manual casting to `JObject` or `JArray` in calling methods and improves type safety across the mod downloading module.

- Convert `DlModRequest` to `DlModRequest<T>(string url)`
- Update `ModComp` to use the new generic method with explicit types
- Remove the `IsJson` boolean parameter in favor of type-based dispatching

## Summary by Sourcery

重构模组下载请求辅助方法以使用通用的 JSON/字符串返回类型，并相应更新模组元数据的使用方，从而修复 C# 实现中 CurseForge 详情加载的问题。

Bug 修复：
- 确保在 C# 模组下载流程中，基于 CurseForge 的模组可以正确获取并解析详细的元数据响应。

增强内容：
- 用泛型重载替换非泛型的 `DlModRequest` API，使其能够根据请求的类型返回原始字符串或已解析的 JSON 对象/数组。
- 通过在 `DlModRequest` 中集中处理 JSON 解析、移除 `IsJson` 标志并改用基于类型的分发，简化对镜像感知的 HTTP 请求处理。
- 更新 `ModComp` 在调用 CurseForge 和 Modrinth API 时使用新的泛型 `DlModRequest` 重载，从而提升模组元数据处理的类型安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor mod download request helpers to use generic JSON/strings return types and update mod metadata consumers accordingly to fix CurseForge detail loading in the C# implementation.

Bug Fixes:
- Ensure CurseForge-backed mods in the C# mod download path correctly retrieve and parse detailed metadata responses.

Enhancements:
- Replace the non-generic DlModRequest API with generic overloads that can return either raw strings or parsed JSON objects/arrays based on the requested type.
- Simplify mirror-aware HTTP request handling by centralizing JSON parsing in DlModRequest and removing the IsJson flag in favor of type-based dispatch.
- Update ModComp to use the new generic DlModRequest overloads when calling CurseForge and Modrinth APIs, improving type safety of mod metadata handling.

</details>