### PR TITLE
fix: 不正确的 Json 模型

### DIFF
--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
@@ -35,7 +35,7 @@ public record YggdrasilAuthenticateResult
     /// <summary>
     /// 可用档案
     /// </summary>
-    [JsonPropertyName("availableProfiles")] public required Profile[]? AvailableProfiles { get; init; }
+    [JsonPropertyName("availableProfiles")] public Profile[]? AvailableProfiles { get; init; }
     /// <summary>
     /// 用户信息
     /// </summary>


### PR DESCRIPTION
此 PR 修复了一个 Bug，当 Yggdrasil 服务器返回错误时，Json 反序列化会直接失败

## Summary by Sourcery

Bug Fixes:
- 允许在没有 `availableProfiles` 的情况下成功反序列化 Yggdrasil 身份验证响应，而不是抛出错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow Yggdrasil authentication responses without availableProfiles to deserialize successfully instead of throwing errors.

</details>