### PR TITLE
fix: missing yggdrasil error message

### DIFF
--- a/PCL.Core/IO/Net/Http/HttpResponseException.cs
+++ b/PCL.Core/IO/Net/Http/HttpResponseException.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+
+namespace PCL.Core.IO.Net.Http;
+
+public class HttpResponseException:HttpRequestException,IDisposable
+{
+    public HttpResponseMessage? Response { get; init; }
+
+    public HttpResponseException()
+    {
+        
+    }
+
+    public HttpResponseException(string message) : base(message)
+    {
+        
+    }
+
+    public HttpResponseException(string message, Exception? inner) : base(message, inner)
+    {
+        
+    }
+
+    public HttpResponseException(HttpResponseMessage? response):this($"{(int?)response?.StatusCode} {response?.ReasonPhrase ?? Enum.GetName(response.StatusCode)}")
+    {
+        Response = response;
+    }
+
+    public void Dispose()
+    {
+        Response?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    ~HttpResponseException()
+    {
+        try
+        {
+            Response?.Dispose();
+        }
+        catch
+        {
+            // Suppress Exception
+        }
+    }
+}

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1,9 +1,11 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Windows;
 using Microsoft.VisualBasic;
@@ -18,6 +20,7 @@ using PCL.Core.Utils.Secret;
 using PCL.Network;
 using PCL.Core.IO.Net.Http;
 using PCL;
+using PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 
 namespace PCL;
 
@@ -183,7 +186,11 @@ public static class ModLaunch
             }
             else
             {                
-                switch (ModMain.MyMsgBox("你必须先登录正版账号才能启动游戏！", "正版验证", "购买正版", "试玩", "返回",
+                switch (ModMain.MyMsgBox("你必须先登录正版账号才能启动游戏！", 
+                            "正版验证", 
+                            "购买正版", 
+                            "试玩", 
+                            "返回",
                             Button1Action: () =>
                                 ModBase.OpenWebsite(
                                     "https://www.xbox.com/zh-cn/games/store/minecraft-java-bedrock-edition-for-pc/9nxp44l49shj")))
@@ -1465,7 +1472,7 @@ public static class ModLaunch
         }
         catch (Exception ex)
         {
-            HandleException(ex, "第三方验证登录失败");
+            HandleException(ex, "第三方登录失败");
         }
 
         // 如果需要刷新，循环刷新一次
@@ -1603,39 +1610,50 @@ public static class ModLaunch
     private static void McLoginRequestRefresh(ref ModLoader.LoaderTask<McLoginServer, McLoginResult> Data,
         bool RequestUser)
     {
-        var RefreshInfo = new JObject();
-        var SelectProfile = new JObject
-            { { "name", ModProfile.SelectedProfile.Username }, { "id", ModProfile.SelectedProfile.Uuid } };
-        RefreshInfo.Add("selectedProfile", SelectProfile);
-        RefreshInfo.Add(new JProperty("accessToken", ModProfile.SelectedProfile.AccessToken));
-        RefreshInfo.Add(new JProperty("requestUser", true));
-        ModProfile.ProfileLog("刷新登录开始（Refresh, Authlib");
-        var LoginJson = (JObject)ModBase.GetJson(Requester.Fetch(Data.Input.BaseUrl + "/refresh",
-            new FetchParam
-            {
-                Method = "POST",
-                Content = RefreshInfo.ToString(Newtonsoft.Json.Formatting.None),
-                Headers = new Dictionary<string, string> { { "Accept-Language", "zh-CN" } },
-                ContentType = "application/json"
-            }
-        ));
-        // 将登录结果输出
-        if (LoginJson["selectedProfile"] is null)
-            throw new Exception("选择的角色 " + ModProfile.SelectedProfile.Username + " 无效！");
-        Data.Output.AccessToken = LoginJson["accessToken"].ToString();
-        Data.Output.ClientToken = LoginJson["clientToken"].ToString();
-        Data.Output.Uuid = LoginJson["selectedProfile"]["id"].ToString();
-        Data.Output.Name = LoginJson["selectedProfile"]["name"].ToString();
-        Data.Output.Type = "Auth";
-        // 保存缓存
-        var ProfileIndex = ModProfile.ProfileList.IndexOf(ModProfile.SelectedProfile);
-        ModProfile.ProfileList[ProfileIndex].Username = Data.Output.Name;
-        ModProfile.ProfileList[ProfileIndex].AccessToken = Data.Output.AccessToken;
-        ModProfile.ProfileList[ProfileIndex].ClientToken = Data.Output.ClientToken;
-        ModProfile.ProfileList[ProfileIndex].Uuid = Data.Output.Uuid;
-        ModProfile.ProfileList[ProfileIndex].Name = Data.Input.UserName;
-        ModProfile.ProfileList[ProfileIndex].Password = Data.Input.Password;
-        ModProfile.ProfileLog("刷新登录成功（Refresh, Authlib）");
+        try
+        {
+
+            var RefreshInfo = new JObject();
+            var SelectProfile = new JObject
+                { { "name", ModProfile.SelectedProfile.Username }, { "id", ModProfile.SelectedProfile.Uuid } };
+            RefreshInfo.Add("selectedProfile", SelectProfile);
+            RefreshInfo.Add(new JProperty("accessToken", ModProfile.SelectedProfile.AccessToken));
+            RefreshInfo.Add(new JProperty("requestUser", true));
+            ModProfile.ProfileLog("刷新登录开始（Refresh, Authlib");
+            var LoginJson = (JObject)ModBase.GetJson(Requester.Fetch(Data.Input.BaseUrl + "/refresh",
+                new FetchParam
+                {
+                    Method = "POST",
+                    Content = RefreshInfo.ToString(Newtonsoft.Json.Formatting.None),
+                    Headers = new Dictionary<string, string> { { "Accept-Language", "zh-CN" } },
+                    ContentType = "application/json",
+                    RequireContent = true
+                }
+            ));
+            // 将登录结果输出
+            if (LoginJson["selectedProfile"] is null)
+                throw new Exception("选择的角色 " + ModProfile.SelectedProfile.Username + " 无效！");
+            Data.Output.AccessToken = LoginJson["accessToken"].ToString();
+            Data.Output.ClientToken = LoginJson["clientToken"].ToString();
+            Data.Output.Uuid = LoginJson["selectedProfile"]["id"].ToString();
+            Data.Output.Name = LoginJson["selectedProfile"]["name"].ToString();
+            Data.Output.Type = "Auth";
+            // 保存缓存
+            var ProfileIndex = ModProfile.ProfileList.IndexOf(ModProfile.SelectedProfile);
+            ModProfile.ProfileList[ProfileIndex].Username = Data.Output.Name;
+            ModProfile.ProfileList[ProfileIndex].AccessToken = Data.Output.AccessToken;
+            ModProfile.ProfileList[ProfileIndex].ClientToken = Data.Output.ClientToken;
+            ModProfile.ProfileList[ProfileIndex].Uuid = Data.Output.Uuid;
+            ModProfile.ProfileList[ProfileIndex].Name = Data.Input.UserName;
+            ModProfile.ProfileList[ProfileIndex].Password = Data.Input.Password;
+            ModProfile.ProfileLog("刷新登录成功（Refresh, Authlib）");
+        }
+        catch (HttpResponseException ex)
+        {
+            if (_TryGetLastError(ex, out var message)) ModMain.MyMsgBox(message, "登录失败");
+            ex.Dispose();
+            return;
+        }
     }
 
     private static bool McLoginRequestLogin(ref ModLoader.LoaderTask<McLoginServer, McLoginResult> Data)
@@ -1654,7 +1672,8 @@ public static class ModLaunch
                     Method = "POST",
                     Content = RequestData.ToString(0),
                     Headers = new Dictionary<string, string> { { "Accept-Language", "zh-CN" } },
-                    ContentType = "application/json"
+                    ContentType = "application/json",
+                    RequireContent = true
                 }));
             // 检查登录结果
             if (LoginJson["availableProfiles"].Count() == 0)
@@ -1755,18 +1774,42 @@ public static class ModLaunch
             ModProfile.ProfileLog("登录成功（Login, Authlib）");
             return NeedRefresh;
         }
-        catch (WebException ex)
+        catch (HttpResponseException ex)
         {
-            throw;
+            
+            if (_TryGetLastError(ex, out var message)) ModMain.MyMsgBox(message, "登录失败");
+            ex.Dispose();
+            return false;
         }
         catch (Exception ex)
         {
-            var AllMessage = ex.ToString();
-            ModProfile.ProfileLog("第三方验证失败: " + ex);
+            
+            ModProfile.ProfileLog($"第三方验证失败: {ex}");
             if (ex.Message.StartsWithF("$")) throw;
 
             throw new Exception("登录失败：" + ex.Message, ex);
         }
+    }
+
+    private static bool _TryGetLastError(HttpResponseException ex,[NotNullWhen(true)] out string? message)
+    {
+        message = null;
+        try
+        {
+            using var responseStream = ex.Response?.Content.ReadAsStream();
+            if (responseStream is null) return false;
+            using var reader = new StreamReader(responseStream);
+            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(reader.ReadToEnd());
+            if (result?.ErrorMessage is null) return false;
+            message = result.ErrorMessage;
+            return true;
+        }
+        catch (Exception)
+        {
+            // Suppress Exception
+        }
+
+        return false;
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1798,8 +1798,7 @@ public static class ModLaunch
         {
             using var responseStream = ex.Response?.Content.ReadAsStream();
             if (responseStream is null) return false;
-            using var reader = new StreamReader(responseStream);
-            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(reader.ReadToEnd());
+            var result  = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream);
             if (result?.ErrorMessage is null) return false;
             message = result.ErrorMessage;
             return true;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1798,7 +1798,7 @@ public static class ModLaunch
         {
             using var responseStream = ex.Response?.Content.ReadAsStream();
             if (responseStream is null) return false;
-            var result  = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream);
+            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream);
             if (result?.ErrorMessage is null) return false;
             message = result.ErrorMessage;
             return true;

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -6,15 +6,16 @@ using System.Text;
 using Downloader;
 using Newtonsoft.Json.Linq;
 using PCL.Core.IO.Net;
+using PCL.Core.IO.Net.Http;
 
 namespace PCL.Network;
 
 public static class Requester
 {
-    public static void EnsureSuccess(HttpResponseMessage response)
+    public static void EnsureSuccess(HttpResponseMessage? response)
     {
-        if (!response.IsSuccessStatusCode)
-            throw new HttpRequestException($"HTTP 响应失败: {response.ReasonPhrase} ({(int)response.StatusCode})");
+        if (!response?.IsSuccessStatusCode ?? true)
+            throw new HttpResponseException(response);
     }
 
     public static async Task<string> FetchStringAsync(string url, RequestParam param = default)
@@ -95,6 +96,7 @@ public static class Requester
 
     private static async Task<string> FetchOnceAsync(string url, FetchParam param)
     {
+        HttpResponseMessage? response = null;
         var request = new HttpRequestMessage(ParseMethod(param.Method), ModSecret.SecretCdnSign(url));
         ModSecret.SecretHeadersSign(url, ref request, param.UseBrowserUserAgent);
         try
@@ -113,12 +115,13 @@ public static class Requester
 
             using var cts = new CancellationTokenSource();
             cts.CancelAfter(param.Timeout <= 0 ? 30000 : param.Timeout);
-            using var response = await NetworkService.GetClient().SendAsync(request, cts.Token).ConfigureAwait(false);
+            response = await NetworkService.GetClient().SendAsync(request, cts.Token).ConfigureAwait(false);
             EnsureSuccess(response);
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
         finally
         {
+            if(!param.RequireContent) response?.Dispose();
             request.Dispose();
         }
     }

--- a/Plain Craft Launcher 2/Modules/Network/Models/FetchParam.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Models/FetchParam.cs
@@ -15,4 +15,5 @@ public struct FetchParam
     public bool MakeLog { get; set; }
     public bool DontRetryOnRefused { get; set; }
     public int Timeout { get; set; }
+    public bool RequireContent { get; set; }
 }


### PR DESCRIPTION
Resolve #2785

## Summary by Sourcery

在第三方登录和令牌刷新过程中处理并呈现来自 Yggdrasil/authlib 的错误响应，从而在身份验证流程失败时改进用户可见的提示信息。

Bug 修复：
- 当第三方登录或令牌刷新失败时，显示详细的 Yggdrasil 错误信息，而不是泛化的失败提示或静默错误。
- 确保 authlib 的登录和刷新请求要求响应内容存在，以便可以解析错误负载。

增强功能：
- 优化第三方登录失败的日志记录以及面向用户的对话框标题，使其能更好地反映身份验证错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle and surface Yggdrasil/authlib error responses during third-party login and token refresh, improving user-facing messaging for failed authentication flows.

Bug Fixes:
- Show detailed Yggdrasil error messages when third-party login or token refresh fails instead of generic failures or silent errors.
- Ensure authlib login and refresh requests require response content so error payloads can be parsed.

Enhancements:
- Refine third-party login failure logging and user-facing dialog titles to better reflect authentication errors.

</details>