### PR TITLE
chore: modify log level

### DIFF
--- a/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
@@ -50,7 +50,11 @@ public static class HttpSenderExtension
                             return await httpClient
                                 .SendAsync(requestCopy, httpCompletionOption, token)
                                 .ConfigureAwait(false);
-                                            }
+                        }catch(Exception ex)
+                        {
+                            LogWrapper.Debug(ex, "Request", $"Try attempt failed (id = {requestId})");
+                            throw;
+                        }
                     },
                     
                 .ConfigureAwait(false);

--- a/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
@@ -55,8 +55,8 @@ public static class HttpSenderExtension
                             LogWrapper.Debug(ex, "Request", $"Try attempt failed (id = {requestId})");
                             throw;
                         }
-                    },
-                    
+                    },cancellationToken
+                    )
                 .ConfigureAwait(false);
 
             if (enableLogging)

--- a/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
@@ -53,7 +53,7 @@ public static class HttpSenderExtension
                         } 
                         catch(Exception ex)
                         {
-                            LogWrapper.Error(ex, "Request", $"Try attempt failed (id = {requestId})");
+                            LogWrapper.Debug(ex,  $"Try attempt failed (id = {requestId})", "Request");
                             throw;
                         }
                     },

--- a/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpSenderExtension.cs
@@ -50,15 +50,9 @@ public static class HttpSenderExtension
                             return await httpClient
                                 .SendAsync(requestCopy, httpCompletionOption, token)
                                 .ConfigureAwait(false);
-                        } 
-                        catch(Exception ex)
-                        {
-                            LogWrapper.Debug(ex,  $"Try attempt failed (id = {requestId})", "Request");
-                            throw;
-                        }
+                                            }
                     },
-                    cancellationToken,
-                    false)
+                    
                 .ConfigureAwait(false);
 
             if (enableLogging)

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -85,8 +85,8 @@ public partial class NetworkService {
                 {
                     LogWrapper.Debug(
                         exception,
-                        $"HTTP 请求失败，正在进行第 {retryAttempt} 次重试，等待 {timeSpan.TotalMilliseconds} 毫秒。",
-                        "Network"
+                        "Network",
+                        $"HTTP 请求失败，正在进行第 {retryAttempt} 次重试，等待 {timeSpan.TotalMilliseconds} 毫秒。"
                         );
                 });
     }

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -83,9 +83,10 @@ public partial class NetworkService {
                 attempt => retryPolicy.Invoke(attempt),
                 onRetry: (exception, timeSpan, retryAttempt, context) =>
                 {
-                    LogWrapper.Error(
+                    LogWrapper.Debug(
                         exception,
-                        $"HTTP 请求失败，正在进行第 {retryAttempt} 次重试，等待 {timeSpan.TotalMilliseconds} 毫秒。"
+                        $"HTTP 请求失败，正在进行第 {retryAttempt} 次重试，等待 {timeSpan.TotalMilliseconds} 毫秒。",
+                        "Network"
                         );
                 });
     }

--- a/PCL.Core/Logging/LogWrapper.cs
+++ b/PCL.Core/Logging/LogWrapper.cs
@@ -34,6 +34,8 @@ public static class LogWrapper
     public static void Debug(string? module, string msg) => OnLog?.Invoke(LogLevel.Debug, msg, module);
     public static void Debug(string msg) => Debug(null, msg);
 
+    public static void Debug(Exception ex, string message, string module) => OnLog?.Invoke(LogLevel.Debug, message, module, ex);
+
     // Trace
     public static void Trace(string? module, string msg) => OnLog?.Invoke(LogLevel.Trace, msg, module);
     public static void Trace(string msg) => Trace(null, msg);

--- a/PCL.Core/Logging/LogWrapper.cs
+++ b/PCL.Core/Logging/LogWrapper.cs
@@ -34,7 +34,7 @@ public static class LogWrapper
     public static void Debug(string? module, string msg) => OnLog?.Invoke(LogLevel.Debug, msg, module);
     public static void Debug(string msg) => Debug(null, msg);
 
-    public static void Debug(Exception ex, string message, string module) => OnLog?.Invoke(LogLevel.Debug, message, module, ex);
+    public static void Debug(Exception ex, string module, string message) => Debug(module, $"{message}: {ex.ToString()}");
 
     // Trace
     public static void Trace(string? module, string msg) => OnLog?.Invoke(LogLevel.Trace, msg, module);


### PR DESCRIPTION
将 HTTP 请求的日志等级下调为 Debug，以避免在网络环境不佳的情况下需要连续关掉一堆弹窗才能用启动器

~（先生，这实在是太糟糕了，我的启动器全是无关紧要的错误弹窗）~

## Summary by Sourcery

降低 HTTP 请求重试失败日志的严重级别，在保留诊断信息的同时减少用户可见的错误噪声。

改进内容：
- 将 HTTP 重试和请求尝试失败的日志从 error 级别降为 debug 级别，并用适当的模块对其进行标记。
- 新增一个 debug 级别的日志重载方法，接受异常、消息和模块参数，以便对 HTTP 错误进行一致的结构化日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Lower the log severity of HTTP request retry failures to reduce user-facing error noise while preserving diagnostic information.

Enhancements:
- Change HTTP retry and request attempt failure logs from error level to debug level and tag them with appropriate modules.
- Add a debug-level logging overload that accepts an exception, message, and module for consistent structured logging of HTTP errors.

</details>