### PR TITLE
fix: `.ToString` -> `.ToString()`

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -2047,7 +2047,7 @@ public static class ModLaunch
                 return;
             if (McLaunchJavaSelected is not null)
             {
-                McLaunchLog("选择的 Java：" + McLaunchJavaSelected.ToString);
+                McLaunchLog("选择的 Java：" + McLaunchJavaSelected);
                 return;
             }
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过移除对已选择 Java 对象的不正确 `ToString` 引用，修正 Java 选择日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Java selection logging by removing an incorrect ToString reference on the selected Java object.

</details>