### PR TITLE
fix: 修复实例列表缓存无法读取的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -2014,7 +2014,7 @@ public static class ModMinecraft
                         if (!instanceCfg.LogoPathConfig.IsDefault(instance.PathInstance))
                             instance.Logo = instanceCfg.LogoPath[instance.PathInstance];
                         if (!instanceCfg.ReleaseTimeConfig.IsDefault(instance.PathInstance))
-                            instance.ReleaseTime = (dynamic)instanceCfg.ReleaseTime[instance.PathInstance];
+                            instance.ReleaseTime = DateTime.Parse(instanceCfg.ReleaseTime[instance.PathInstance]);
                         if (!instanceCfg.StateConfig.IsDefault(instance.PathInstance))
                             instance.State =
                                 (McInstanceState)Conversions.ToInteger(instanceCfg.State[instance.PathInstance]);


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正 Minecraft 实例的发布时间反序列化问题，以便可以正确读取缓存的实例数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct release time deserialization for Minecraft instances so cached instance data can be read properly.

</details>