### PR TITLE
refactor: 替换 + 为 Path.Combine

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.cs
+++ b/Plain Craft Launcher 2/Application.xaml.cs
@@ -59,8 +59,8 @@ public partial class Application
             // 初始化文件结构
             Directory.CreateDirectory(ModBase.ExePath + @"PCL\Pictures");
             Directory.CreateDirectory(ModBase.ExePath + @"PCL\Musics");
-            Directory.CreateDirectory(ModBase.PathTemp + "Cache");
-            Directory.CreateDirectory(ModBase.PathTemp + "Download");
+            Directory.CreateDirectory(Path.Combine(ModBase.PathTemp, "Cache"));
+            Directory.CreateDirectory(Path.Combine(ModBase.PathTemp, "Download"));
             Directory.CreateDirectory(ModBase.PathAppdata);
             // 设置 ToolTipService 默认值
             ToolTipService.InitialShowDelayProperty.OverrideMetadata(typeof(DependencyObject),

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -372,10 +372,10 @@ public partial class FormMain
             ModBase.Log("[Start] 已移动离线自定义皮肤 (162)");
         }
 
-        if (LastVersionCode <= 263 && File.Exists(ModBase.PathTemp + "CustomSkin.png") &&
-            !File.Exists(ModBase.PathAppdata + "CustomSkin.png"))
+        if (LastVersionCode <= 263 && File.Exists(Path.Combine(ModBase.PathTemp, "CustomSkin.png")) &&
+            !File.Exists(Path.Combine(ModBase.PathAppdata, "CustomSkin.png")))
         {
-            ModBase.CopyFile(ModBase.PathTemp + "CustomSkin.png", ModBase.PathAppdata + "CustomSkin.png");
+            ModBase.CopyFile(Path.Combine(ModBase.PathTemp, "CustomSkin.png"), Path.Combine(ModBase.PathAppdata, "CustomSkin.png"));
             ModBase.Log("[Start] 已移动离线自定义皮肤 (264)");
         }
 

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -142,7 +142,7 @@ public static class ModBase
     /// <summary>
     ///     AppData 中的 PCL 文件夹路径，以 \ 结尾。
     /// </summary>
-    public static string PathAppdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\PCL\";
+    public static string PathAppdata = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PCL") + @"\";
 
     /// <summary>
     ///     AppData 中的 PCLCE 配置文件夹路径，以 \ 结尾。

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -42,8 +42,8 @@ public class CrashAnalyzer
     {
         // 构建文件结构
         TempFolder = ModMain.RequestTaskTempFolder();
-        Directory.CreateDirectory(TempFolder + @"Temp\");
-        Directory.CreateDirectory(TempFolder + @"Report\");
+        Directory.CreateDirectory(Path.Combine(TempFolder, "Temp") + @"\");
+        Directory.CreateDirectory(Path.Combine(TempFolder, "Report") + @"\");
         ModBase.Log("[Crash] 崩溃分析暂存文件夹：" + TempFolder);
     }
 
@@ -163,7 +163,7 @@ public class CrashAnalyzer
             var Info = new FileInfo(FilePath);
             if (Info.Exists && Info.Length > 0L && !FilePath.EndsWithF(".jar", true))
             {
-                ModBase.ExtractFile(FilePath, TempFolder + @"Temp\");
+                ModBase.ExtractFile(FilePath, Path.Combine(TempFolder, "Temp") + @"\");
                 ModBase.Log("[Crash] 已解压导入的日志文件：" + FilePath);
                 goto Extracted;
             }
@@ -173,13 +173,13 @@ public class CrashAnalyzer
         }
 
         // 并非压缩包
-        ModBase.CopyFile(FilePath, TempFolder + @"Temp\" + ModBase.GetFileNameFromPath(FilePath));
+        ModBase.CopyFile(FilePath, Path.Combine(TempFolder, "Temp", ModBase.GetFileNameFromPath(FilePath)));
         ModBase.Log("[Crash] 已复制导入的日志文件：" + FilePath);
         Extracted: ;
 
 
         // 导入其中的日志文件
-        foreach (var TargetFile in new DirectoryInfo(TempFolder + @"Temp\").EnumerateFiles().ToList())
+        foreach (var TargetFile in new DirectoryInfo(Path.Combine(TempFolder, "Temp")).EnumerateFiles().ToList())
             try
             {
                 if (!TargetFile.Exists || TargetFile.Length == 0L)
@@ -1210,7 +1210,7 @@ public class CrashAnalyzer
                             }
                             else
                             {
-                                var FilePath = ModBase.PathTemp + "Crash.txt";
+                                var FilePath = Path.Combine(ModBase.PathTemp, "Crash.txt");
                                 ModBase.WriteFile(FilePath, DirectFile.Value.Value.Join("\r\n"));
                                 ModBase.ShellOnly(FilePath);
                             }
@@ -1277,7 +1277,7 @@ public class CrashAnalyzer
                             FileContent = ModMinecraft.FilterAccessToken(FileContent,
                                 FileName == "启动脚本.bat" ? 'F' : '*');
                             FileContent = ModMinecraft.FilterUserName(FileContent, '*');
-                            ModBase.WriteFile(TempFolder + @"Report\" + FileName, FileContent, Encoding: FileEncoding);
+                            ModBase.WriteFile(Path.Combine(TempFolder, "Report", FileName), FileContent, Encoding: FileEncoding);
                             ModBase.Log($"[Crash] 导出文件：{FileName}，编码：{FileEncoding.HeaderName}");
                         }
                     }
@@ -1285,9 +1285,9 @@ public class CrashAnalyzer
                     // 输出环境与启动信息
                     string EnvInfo = null;
                     string McLauncherLog = null;
-                    McLauncherLog = ModBase.ReadFile(TempFolder + @"Report\PCL 启动器日志.txt")
+                    McLauncherLog = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "PCL 启动器日志.txt"))
                         .AfterLast("[Launch] ~ 基础参数 ~").BeforeFirst("开始 Minecraft 日志监控");
-                    var LaunchScript = ModBase.ReadFile(TempFolder + @"Report\启动脚本.bat");
+                    var LaunchScript = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "启动脚本.bat"));
                     EnvInfo += $"PCL CE 版本：{ModBase.VersionBaseName} {"\r\n"}";
                     EnvInfo += $"识别码：{ModBase.UniqueAddress}{"\r\n"}";
                     EnvInfo += $"{"\r\n"}- 档案信息 -{"\r\n"}";
@@ -1312,11 +1312,11 @@ public class CrashAnalyzer
                         EnvInfo += "\r\n";
                     }
 
-                    File.CreateText(TempFolder + @"Report\环境与启动信息.txt").Close();
-                    ModBase.WriteFile(TempFolder + @"Report\环境与启动信息.txt", EnvInfo, Encoding: Encoding.UTF8);
+                    File.CreateText(Path.Combine(TempFolder, "Report", "环境与启动信息.txt")).Close();
+                    ModBase.WriteFile(Path.Combine(TempFolder, "Report", "环境与启动信息.txt"), EnvInfo, Encoding: Encoding.UTF8);
                     // 导出报告
-                    ZipFile.CreateFromDirectory(TempFolder + @"Report\", FileAddress);
-                    ModBase.DeleteDirectory(TempFolder + @"Report\");
+                    ZipFile.CreateFromDirectory(Path.Combine(TempFolder, "Report"), FileAddress);
+                    ModBase.DeleteDirectory(Path.Combine(TempFolder, "Report"));
                     ModMain.Hint("错误报告已导出！", ModMain.HintType.Finish);
                 }
                 catch (Exception ex)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -42,8 +42,8 @@ public class CrashAnalyzer
     {
         // 构建文件结构
         TempFolder = ModMain.RequestTaskTempFolder();
-        Directory.CreateDirectory(Path.Combine(TempFolder, "Temp") + @"\");
-        Directory.CreateDirectory(Path.Combine(TempFolder, "Report") + @"\");
+        Directory.CreateDirectory(Path.Combine(TempFolder, "Temp"));
+        Directory.CreateDirectory(Path.Combine(TempFolder, "Report"));
         ModBase.Log("[Crash] 崩溃分析暂存文件夹：" + TempFolder);
     }
 
@@ -163,7 +163,7 @@ public class CrashAnalyzer
             var Info = new FileInfo(FilePath);
             if (Info.Exists && Info.Length > 0L && !FilePath.EndsWithF(".jar", true))
             {
-                ModBase.ExtractFile(FilePath, Path.Combine(TempFolder, "Temp") + @"\");
+                ModBase.ExtractFile(FilePath, Path.Combine(TempFolder, "Temp"));
                 ModBase.Log("[Crash] 已解压导入的日志文件：" + FilePath);
                 goto Extracted;
             }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -62,7 +62,7 @@ public static class ModDownload
             Version = new ModMinecraft.McInstance(Version.InheritInstanceName);
         // 获取信息
         var IndexInfo = ModMinecraft.McAssetsGetIndex(Version, true, true);
-        var IndexAddress = ModMinecraft.McFolderSelected + @"assets\indexes\" + IndexInfo["id"] + ".json";
+        var IndexAddress = Path.Combine(ModMinecraft.McFolderSelected, "assets", "indexes", IndexInfo["id"] + ".json");
         ModBase.Log("[Download] 实例 " + Version.Name + " 对应的资源文件索引为 " + IndexInfo["id"]);
         var IndexUrl = (string)(IndexInfo["url"] ?? "");
         if (string.IsNullOrEmpty(IndexUrl)) return null;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -2192,7 +2192,7 @@ public static class ModLaunch
     /// </summary>
     public static string ExtractJavaWrapper()
     {
-        var WrapperPath = ModBase.PathPure + "JavaWrapper.jar";
+        var WrapperPath = Path.Combine(ModBase.PathPure, "JavaWrapper.jar");
         ModBase.Log("[Java] 选定的 Java Wrapper 路径：" + WrapperPath);
         lock (ExtractJavaWrapperLock) // 避免 OptiFine 和 Forge 安装时同时释放 Java Wrapper 导致冲突
         {
@@ -2214,7 +2214,7 @@ public static class ModLaunch
                     catch (Exception ex2)
                     {
                         ModBase.Log(ex2, "Java Wrapper 文件重新释放失败，将尝试更换文件名重新生成", ModBase.LogLevel.Developer);
-                        WrapperPath = ModBase.PathPure + "JavaWrapper2.jar";
+                        WrapperPath = Path.Combine(ModBase.PathPure, "JavaWrapper2.jar");
                         try
                         {
                             WriteJavaWrapper(WrapperPath);
@@ -2247,7 +2247,7 @@ public static class ModLaunch
     /// </summary>
     public static string ExtractLinkD()
     {
-        var LinkDPath = ModBase.PathPure + "linkd.exe";
+        var LinkDPath = Path.Combine(ModBase.PathPure, "linkd.exe");
         lock (ExtractLinkDLock) // 避免 OptiFine 和 Forge 安装时同时释放 Java Wrapper 导致冲突
         {
             try
@@ -2491,7 +2491,7 @@ public static class ModLaunch
             {
                 var Response = Requester.FetchString(Server);
                 DataList.Insert(0,
-                    "-javaagent:\"" + ModBase.PathPure + "authlib-injector.jar\"=" + Server +
+                    "-javaagent:\"" + Path.Combine(ModBase.PathPure, "authlib-injector.jar") + "\"=" + Server +
                     " -Dauthlibinjector.side=client" + " -Dauthlibinjector.yggdrasil.prefetched=" +
                     Convert.ToBase64String(Encoding.UTF8.GetBytes(Response)));
             }
@@ -2526,7 +2526,7 @@ public static class ModLaunch
             Renderer = Conversions.ToInteger(Config.Launch.Renderer);
         var MesaLoaderWindowsVersion = "25.3.5";
         var MesaLoaderWindowsTargetFile =
-            ModBase.PathPure + @"\mesa-loader-windows\" + MesaLoaderWindowsVersion + @"\Loader.jar";
+            Path.Combine(ModBase.PathPure, "mesa-loader-windows", MesaLoaderWindowsVersion, "Loader.jar");
 
         if (Renderer != 0)
             DataList.Insert(0,
@@ -2614,7 +2614,7 @@ public static class ModLaunch
             {
                 var Response = Conversions.ToString(ModNet.NetGetCodeByRequestRetry(Server, Encoding.UTF8));
                 DataList.Insert(0,
-                    "-javaagent:\"" + ModBase.PathPure + "authlib-injector.jar\"=" + Server +
+                    "-javaagent:\"" + Path.Combine(ModBase.PathPure, "authlib-injector.jar") + "\"=" + Server +
                     " -Dauthlibinjector.side=client" + " -Dauthlibinjector.yggdrasil.prefetched=" +
                     Convert.ToBase64String(Encoding.UTF8.GetBytes(Response)));
             }
@@ -2651,7 +2651,7 @@ public static class ModLaunch
             Renderer = Conversions.ToInteger(Config.Launch.Renderer);
         var MesaLoaderWindowsVersion = "25.3.5";
         var MesaLoaderWindowsTargetFile =
-            ModBase.PathPure + @"\mesa-loader-windows\" + MesaLoaderWindowsVersion + @"\Loader.jar";
+            Path.Combine(ModBase.PathPure, "mesa-loader-windows", MesaLoaderWindowsVersion, "Loader.jar");
 
         if (Renderer != 0)
             DataList.Insert(0,
@@ -2758,8 +2758,8 @@ public static class ModLaunch
                          " --tweakClass optifine.OptiFineForgeTweaker";
                 try
                 {
-                    ModBase.WriteFile(Version.PathInstance + Version.Name + ".json",
-                        ModBase.ReadFile(Version.PathInstance + Version.Name + ".json")
+                    ModBase.WriteFile(Path.Combine(Version.PathInstance, Version.Name + ".json"),
+                        ModBase.ReadFile(Path.Combine(Version.PathInstance, Version.Name + ".json"))
                             .Replace("optifine.OptiFineTweaker", "optifine.OptiFineForgeTweaker"));
                 }
                 catch (Exception ex)
@@ -2849,8 +2849,8 @@ public static class ModLaunch
                     " --tweakClass optifine.OptiFineForgeTweaker";
                 try
                 {
-                    ModBase.WriteFile(instance.PathInstance + instance.Name + ".json",
-                        ModBase.ReadFile(instance.PathInstance + instance.Name + ".json")
+                    ModBase.WriteFile(Path.Combine(instance.PathInstance, instance.Name + ".json"),
+                        ModBase.ReadFile(Path.Combine(instance.PathInstance, instance.Name + ".json"))
                             .Replace("optifine.OptiFineTweaker", "optifine.OptiFineForgeTweaker"));
                 }
                 catch (Exception ex)
@@ -2966,7 +2966,7 @@ public static class ModLaunch
         // LWJGL Unsafe Agent 释放
         if (McLaunchUsesLwjglUnsafeAgent(instance))
         {
-            string AgentPath = ModBase.PathPure + "lwjgl-unsafe-agent.jar";
+            string AgentPath = Path.Combine(ModBase.PathPure, "lwjgl-unsafe-agent.jar");
             try
             {
                 ModBase.WriteFile(AgentPath, ModBase.GetResourceStream("Resources/lwjgl-unsafe-agent.jar"));
@@ -3102,13 +3102,13 @@ public static class ModLaunch
     /// </summary>
     private static string GetNativesFolder()
     {
-        var Result = ModMinecraft.McInstanceSelected.PathInstance + ModMinecraft.McInstanceSelected.Name + "-natives";
+        var Result = Path.Combine(ModMinecraft.McInstanceSelected.PathInstance, ModMinecraft.McInstanceSelected.Name + "-natives");
         if (ModBase.IsGBKEncoding || Result.IsASCII())
             return Result;
-        Result = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\bin\natives";
+        Result = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft", "bin", "natives");
         if (Result.IsASCII())
             return Result;
-        return ModBase.OsDrive + @"ProgramData\PCL\natives";
+        return Path.Combine(ModBase.OsDrive, "ProgramData", "PCL", "natives");
     }
 
     #endregion
@@ -3230,7 +3230,7 @@ public static class ModLaunch
         } while (false);
 
         // 更新 options.txt
-        var SetupFileAddress = ModMinecraft.McInstanceSelected.PathIndie + "options.txt";
+        var SetupFileAddress = Path.Combine(ModMinecraft.McInstanceSelected.PathIndie, "options.txt");
 
         // 辅助切换游戏语言
         if (Config.Tool.AutoChangeLanguage)
@@ -3238,7 +3238,7 @@ public static class ModLaunch
             if (!File.Exists(SetupFileAddress))
             {
                 // Yosbr Mod 兼容（#2385）：https://www.curseforge.com/minecraft/mc-mods/yosbr
-                var YosbrFileAddress = ModMinecraft.McInstanceSelected.PathIndie + @"config\yosbr\options.txt";
+                var YosbrFileAddress = Path.Combine(ModMinecraft.McInstanceSelected.PathIndie, "config", "yosbr", "options.txt");
                 if (File.Exists(YosbrFileAddress))
                 {
                     McLaunchLog("将修改 Yosbr Mod 中的 options.txt");
@@ -3257,7 +3257,7 @@ public static class ModLaunch
                 // 1.13+    ：zh_cn 时正常，zh_CN 时自动切换为英文
                 var CurrentLang = ModBase.ReadIni(SetupFileAddress, "lang", "none");
                 string RequiredLang; // 需要的语言
-                var hasExistingSaves = Directory.Exists(ModMinecraft.McInstanceSelected.PathIndie + "saves");
+                var hasExistingSaves = Directory.Exists(Path.Combine(ModMinecraft.McInstanceSelected.PathIndie, "saves"));
                 var shouldUseDefault = CurrentLang == "none" || !hasExistingSaves;
 
                 // 获取 Minecraft 版本信息
@@ -3306,7 +3306,7 @@ public static class ModLaunch
                 }
 
                 // 如果是初次设置，一并修改 forceUnicodeFont，确保中文能正常显示
-                if (CurrentLang == "none" || !Directory.Exists(ModMinecraft.McInstanceSelected.PathIndie + "saves"))
+                if (CurrentLang == "none" || !Directory.Exists(Path.Combine(ModMinecraft.McInstanceSelected.PathIndie, "saves")))
                 {
                     ModBase.WriteIni(SetupFileAddress, "forceUnicodeFont", "true");
                     McLaunchLog("已开启 forceUnicodeFont，确保中文字体正常显示");
@@ -3547,7 +3547,7 @@ public static class ModLaunch
         WindowTitle = ArgumentReplace(WindowTitle, false);
 
         // JStack 路径
-        var JStackPath = McLaunchJavaSelected.Installation.JavaFolder + @"\jstack.exe";
+        var JStackPath = Path.Combine(McLaunchJavaSelected.Installation.JavaFolder, "jstack.exe");
 
         // 初始化等待
         var Watcher = new ModWatcher.Watcher(Loader, ModMinecraft.McInstanceSelected, WindowTitle,

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -1983,7 +1983,7 @@ public static class ModLocalComp
                     {
                         var DirInfo = new DirectoryInfo(SearchPath);
                         foreach (var Dir in DirInfo.EnumerateDirectories("*", SearchOption.AllDirectories))
-                            ModList.Add(new LocalCompFile(Dir.FullName + @"\__FOLDER__"));
+                            ModList.Add(new LocalCompFile(Path.Combine(Dir.FullName, "__FOLDER__")));
                         foreach (var File in DirInfo.EnumerateFiles("*", SearchOption.AllDirectories))
                             try
                             {
@@ -2313,7 +2313,7 @@ public static class ModLocalComp
             Cache[Entry.ModrinthHash + McInstance + string.Join("", ModLoaders)] = Entry.ToJson();
         }
 
-        ModBase.WriteFile(ModBase.PathTemp + "Cache\\LocalComp.json",
+        ModBase.WriteFile(Path.Combine(ModBase.PathTemp, "Cache", "LocalComp.json"),
             Cache.ToString(ModBase.ModeDebug ? Formatting.Indented : Formatting.None));
 
         // 刷新 UI

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -296,7 +296,7 @@ public static class ModMinecraft
                     originalMcFolderList.Add(new McFolder
                         { Name = "当前文件夹", Location = ModBase.ExePath, Type = McFolder.Types.Original });
                 foreach (var folder in new DirectoryInfo(ModBase.ExePath).GetDirectories())
-                    if (Directory.Exists(Path.Combine(folder.FullName, "versions") + @"\") || folder.Name == ".minecraft")
+                    if (Directory.Exists(Path.Combine(folder.FullName, "versions")) || folder.Name == ".minecraft")
                     {
                         var newCurrentFolder = new McFolder
                             { Name = folder.Name, Location = folder.FullName + @"\", Type = McFolder.Types.Original };
@@ -312,7 +312,7 @@ public static class ModMinecraft
             // 扫描官启文件夹
             var MojangPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft") + @"\";
             if ((!currentMcFolderList.Any() || (MojangPath ?? "") != (currentMcFolderList[0].Location ?? "")) &&
-                Directory.Exists(Path.Combine(MojangPath, "versions") + @"\")) // 当前文件夹不是官启文件夹
+                Directory.Exists(Path.Combine(MojangPath, "versions"))) // 当前文件夹不是官启文件夹
                 // 具有权限且存在 versions 文件夹
                 originalMcFolderList.Add(new McFolder
                     { Name = "官方启动器文件夹", Location = MojangPath, Type = McFolder.Types.Original });
@@ -479,9 +479,7 @@ public static class ModMinecraft
         /// <param name="name">实例名，或实例文件夹的完整路径（不规定是否以 \ 结尾）。</param>
         public McInstance(string name)
         {
-            PathInstance = (name.Contains(":") ? "" : Path.Combine(McFolderSelected, "versions") + @"\") + name +
-                           (name.EndsWithF(@"\") ? "" : @"\"); // 补全完整路径
-            // 补全右划线
+            PathInstance = (name.Contains(":") ? name : Path.Combine(McFolderSelected, "versions", name)) + (name.EndsWithF(@"\") ? "" : @"\");
         }
 
         /// <summary>
@@ -2758,7 +2756,7 @@ public static class ModMinecraft
                     {
                         if ((OriginalInstance.InheritInstanceName ?? "") == (OriginalInstance.Name ?? ""))
                             break;
-                        OriginalInstance = new McInstance(Path.Combine(McFolderSelected, "versions", OriginalInstance.InheritInstanceName) + @"\");
+                        OriginalInstance = new McInstance(Path.Combine(McFolderSelected, "versions", OriginalInstance.InheritInstanceName));
                     }
 
                 // 需要新建对象，否则后面的 Check 会导致 McInstanceCurrent 的 State 变回 Original
@@ -3269,7 +3267,7 @@ public static class ModMinecraft
                 // 下一个实例
                 if (string.IsNullOrEmpty(instance.InheritInstanceName))
                     break;
-                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName) + @"\");
+                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName));
             }
         }
         catch
@@ -3313,7 +3311,7 @@ public static class ModMinecraft
                 if (instance.JsonObject["assets"] is not null) return instance.JsonObject["assets"].ToString();
                 if (string.IsNullOrEmpty(instance.InheritInstanceName))
                     break;
-                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName) + @"\");
+                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName));
             }
         }
         catch (Exception ex)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -296,7 +296,7 @@ public static class ModMinecraft
                     originalMcFolderList.Add(new McFolder
                         { Name = "当前文件夹", Location = ModBase.ExePath, Type = McFolder.Types.Original });
                 foreach (var folder in new DirectoryInfo(ModBase.ExePath).GetDirectories())
-                    if (Directory.Exists(folder.FullName + @"versions\") || folder.Name == ".minecraft")
+                    if (Directory.Exists(Path.Combine(folder.FullName, "versions") + @"\") || folder.Name == ".minecraft")
                     {
                         var newCurrentFolder = new McFolder
                             { Name = folder.Name, Location = folder.FullName + @"\", Type = McFolder.Types.Original };
@@ -310,9 +310,9 @@ public static class ModMinecraft
             }
 
             // 扫描官启文件夹
-            var MojangPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\";
+            var MojangPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft") + @"\";
             if ((!currentMcFolderList.Any() || (MojangPath ?? "") != (currentMcFolderList[0].Location ?? "")) &&
-                Directory.Exists(MojangPath + @"versions\")) // 当前文件夹不是官启文件夹
+                Directory.Exists(Path.Combine(MojangPath, "versions") + @"\")) // 当前文件夹不是官启文件夹
                 // 具有权限且存在 versions 文件夹
                 originalMcFolderList.Add(new McFolder
                     { Name = "官方启动器文件夹", Location = MojangPath, Type = McFolder.Types.Original });
@@ -379,7 +379,7 @@ public static class ModMinecraft
     {
         try
         {
-            if (File.Exists(Folder + "launcher_profiles.json"))
+            if (File.Exists(Path.Combine(Folder, "launcher_profiles.json")))
                 return;
             var ResultJson = @"{
     ""profiles"":  {
@@ -395,7 +395,7 @@ public static class ModMinecraft
     ""selectedProfile"": ""PCL"",
     ""clientToken"": ""23323323323323323323323323323333""
 }";
-            ModBase.WriteFile(Folder + "launcher_profiles.json", ResultJson, Encoding: Encoding.GetEncoding("GB18030"));
+            ModBase.WriteFile(Path.Combine(Folder, "launcher_profiles.json"), ResultJson, Encoding: Encoding.GetEncoding("GB18030"));
             ModBase.Log("[Minecraft] 已创建 launcher_profiles.json：" + Folder);
         }
         catch (Exception ex)
@@ -479,7 +479,7 @@ public static class ModMinecraft
         /// <param name="name">实例名，或实例文件夹的完整路径（不规定是否以 \ 结尾）。</param>
         public McInstance(string name)
         {
-            PathInstance = (name.Contains(":") ? "" : McFolderSelected + @"versions\") + name +
+            PathInstance = (name.Contains(":") ? "" : Path.Combine(McFolderSelected, "versions") + @"\") + name +
                            (name.EndsWithF(@"\") ? "" : @"\"); // 补全完整路径
             // 补全右划线
         }
@@ -1090,8 +1090,7 @@ public static class ModMinecraft
             try
             {
                 if (!string.IsNullOrEmpty(InheritInstanceName))
-                    if (!File.Exists(ModBase.GetPathFromFullPath(PathInstance) + InheritInstanceName + @"\" +
-                                     InheritInstanceName + ".json"))
+                    if (!File.Exists(Path.Combine(ModBase.GetPathFromFullPath(PathInstance), InheritInstanceName, InheritInstanceName + ".json")))
                     {
                         State = McInstanceState.Error;
                         Desc = "需要安装 " + InheritInstanceName + " 作为前置实例";
@@ -2111,7 +2110,7 @@ public static class ModMinecraft
             }
 
             if ((folder.Name == "cache" || folder.Name == "BLClient" || folder.Name == "PCL") &&
-                !File.Exists(folder.FullName + @"\" + folder.Name + ".json"))
+                !File.Exists(Path.Combine(folder.FullName, folder.Name + ".json")))
             {
                 ModBase.Log("[Minecraft] 跳过可能不是实例文件夹的项目：" + folder.FullName);
                 continue;
@@ -2759,8 +2758,7 @@ public static class ModMinecraft
                     {
                         if ((OriginalInstance.InheritInstanceName ?? "") == (OriginalInstance.Name ?? ""))
                             break;
-                        OriginalInstance = new McInstance(McFolderSelected + @"versions\" +
-                                                          OriginalInstance.InheritInstanceName + @"\");
+                        OriginalInstance = new McInstance(Path.Combine(McFolderSelected, "versions", OriginalInstance.InheritInstanceName) + @"\");
                     }
 
                 // 需要新建对象，否则后面的 Check 会导致 McInstanceCurrent 的 State 变回 Original
@@ -2858,8 +2856,8 @@ public static class ModMinecraft
                             init.Url = (string)(RootUrl ?? Library["downloads"]["artifact"]["url"]),
                             init.LocalPath = Library["downloads"]["artifact"]["path"] is null
                                 ? McLibGet((string)Library["name"], customMcFolder: CustomMcFolder)
-                                : CustomMcFolder + @"libraries\" + Library["downloads"]["artifact"]["path"].ToString()
-                                    .Replace("/", @"\"),
+                                : Path.Combine(CustomMcFolder, "libraries", Library["downloads"]["artifact"]["path"].ToString()
+                                    .Replace("/", @"\")),
                             init.Size = (long)Math.Round(
                                 ModBase.Val(Library["downloads"]["artifact"]["size"].ToString())),
                             init.IsNatives = false, init.SHA1 = Library["downloads"]["artifact"]["sha1"]?.ToString(),
@@ -2898,9 +2896,9 @@ public static class ModMinecraft
                                 ? McLibGet((string)Library["name"], customMcFolder: CustomMcFolder)
                                     .Replace(".jar", "-" + Library["natives"]["windows"] + ".jar")
                                     .Replace("${arch}", Environment.Is64BitOperatingSystem ? "64" : "32")
-                                : CustomMcFolder + @"libraries\" +
+                                : Path.Combine(CustomMcFolder, "libraries",
                                   Library["downloads"]["classifiers"]["natives-windows"]["path"].ToString()
-                                      .Replace("/", @"\"),
+                                      .Replace("/", @"\")),
                             Size = (long)Math.Round(
                                 ModBase.Val(Library["downloads"]["classifiers"]["natives-windows"]["size"].ToString())),
                             IsNatives = true,
@@ -3000,7 +2998,7 @@ public static class ModMinecraft
         result.AddRange(McLibNetFilesFromTokens(McLibListGet(instance, false)));
 
         // Authlib-Injector 文件
-        var authlibTargetFile = ModBase.PathPure + @"\authlib-injector.jar";
+        var authlibTargetFile = Path.Combine(ModBase.PathPure, "authlib-injector.jar");
         JObject authlibDownloadInfo = null;
         try
         {
@@ -3041,7 +3039,7 @@ public static class ModMinecraft
         // 修改渲染器
         var mesaLoaderWindowsVersion = "25.3.5";
         var mesaLoaderWindowsTargetFile =
-            ModBase.PathPure + @"\mesa-loader-windows\" + mesaLoaderWindowsVersion + @"\Loader.jar";
+            Path.Combine(ModBase.PathPure, "mesa-loader-windows", mesaLoaderWindowsVersion, "Loader.jar");
         var renderer = -1;
         if (McInstanceSelected is not null)
             renderer = Conversions.ToInteger(
@@ -3062,9 +3060,9 @@ public static class ModMinecraft
         {
             if ((instance.PathIndie ?? "") == (instance.PathInstance ?? ""))
             {
-                if (Directory.Exists(instance.PathInstance + "labymod-neo"))
-                    Directory.Delete(instance.PathInstance + "labymod-neo", true);
-                ModBase.CreateSymbolicLink(instance.PathInstance + "labymod-neo", McFolderSelected + "labymod-neo",
+                if (Directory.Exists(Path.Combine(instance.PathInstance, "labymod-neo")))
+                    Directory.Delete(Path.Combine(instance.PathInstance, "labymod-neo"), true);
+                ModBase.CreateSymbolicLink(Path.Combine(instance.PathInstance, "labymod-neo"), Path.Combine(McFolderSelected, "labymod-neo"),
                     0x2);
             }
 
@@ -3174,7 +3172,7 @@ public static class ModMinecraft
             {
                 // OptiFine 主 Jar
                 var optiFineBase =
-                    token.LocalPath.Replace(customMcFolder + @"libraries\optifine\OptiFine\", "").Split("_")[0] + "/" +
+                    token.LocalPath.Replace(Path.Combine(customMcFolder, "libraries", "optifine", "OptiFine") + @"\", "").Split("_")[0] + "/" +
                     ModBase.GetFileNameFromPath(token.LocalPath).Replace("-", "_");
                 optiFineBase = "/maven/com/optifine/" + optiFineBase;
                 if (optiFineBase.Contains("_pre"))
@@ -3215,8 +3213,9 @@ public static class ModMinecraft
         string McLibGetRet = default;
         customMcFolder = customMcFolder ?? McFolderSelected;
         var splited = original.Split(":");
-        McLibGetRet = (withHead ? customMcFolder + @"libraries\" : "") + splited[0].Replace(".", @"\") + @"\" +
-                      splited[1] + @"\" + splited[2] + @"\" + splited[1] + "-" + splited[2] + ".jar";
+        McLibGetRet = withHead
+            ? Path.Combine(customMcFolder, "libraries", splited[0].Replace(".", @"\"), splited[1], splited[2], splited[1] + "-" + splited[2] + ".jar")
+            : Path.Combine(splited[0].Replace(".", @"\"), splited[1], splited[2], splited[1] + "-" + splited[2] + ".jar");
         // 判断 OptiFine 是否应该使用 installer
         if (McLibGetRet.Contains(@"optifine\OptiFine\1.") && splited[2].Split(".").Count() > 1)
         {
@@ -3270,7 +3269,7 @@ public static class ModMinecraft
                 // 下一个实例
                 if (string.IsNullOrEmpty(instance.InheritInstanceName))
                     break;
-                instance = new McInstance(McFolderSelected + @"versions\" + instance.InheritInstanceName);
+                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName) + @"\");
             }
         }
         catch
@@ -3314,7 +3313,7 @@ public static class ModMinecraft
                 if (instance.JsonObject["assets"] is not null) return instance.JsonObject["assets"].ToString();
                 if (string.IsNullOrEmpty(instance.InheritInstanceName))
                     break;
-                instance = new McInstance(McFolderSelected + @"versions\" + instance.InheritInstanceName);
+                instance = new McInstance(Path.Combine(McFolderSelected, "versions", instance.InheritInstanceName) + @"\");
             }
         }
         catch (Exception ex)
@@ -3365,7 +3364,7 @@ public static class ModMinecraft
             // 初始化
             if (!File.Exists($@"{McFolderSelected}assets\indexes\{indexName}.json"))
                 throw new FileNotFoundException("未找到 Asset Index",
-                    McFolderSelected + @"assets\indexes\" + indexName + ".json");
+                    Path.Combine(McFolderSelected, "assets", "indexes", indexName + ".json"));
             var result = new List<McAssetsToken>();
             var json = (JsonObject)JsonNode.Parse(
                 ModBase.ReadFile($@"{McFolderSelected}assets\indexes\{indexName}.json"));
@@ -3376,14 +3375,13 @@ public static class ModMinecraft
                 string localPath;
                 if (json["map_to_resources"] is not null && json["map_to_resources"].GetValue<bool>())
                     // Remap
-                    localPath = instance.PathIndie + @"resources\" + file.Key.Replace("/", @"\");
+                    localPath = Path.Combine(instance.PathIndie, "resources", file.Key.Replace("/", @"\"));
                 else if (json["virtual"] is not null && json["virtual"].GetValue<bool>())
                     // Virtual
-                    localPath = McFolderSelected + @"assets\virtual\legacy\" + file.Key.Replace("/", @"\");
+                    localPath = Path.Combine(McFolderSelected, "assets", "virtual", "legacy", file.Key.Replace("/", @"\"));
                 else
                     // 正常
-                    localPath = McFolderSelected + @"assets\objects\" + Strings.Left(file.Value["hash"].ToString(), 2) +
-                                @"\" + file.Value["hash"];
+                    localPath = Path.Combine(McFolderSelected, "assets", "objects", Strings.Left(file.Value["hash"].ToString(), 2), file.Value["hash"].ToString());
                 result.Add(new McAssetsToken
                 {
                     LocalPath = localPath,

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1152,7 +1152,7 @@ public static class ModModpack
                 ModBase.OpenExplorer(TargetFolder);
                 // 加入文件夹列表
                 var InstanceName = ModBase.GetFolderNameFromPath(TargetFolder);
-                Directory.CreateDirectory(Path.Combine(TargetFolder, ".minecraft") + @"\");
+                Directory.CreateDirectory(Path.Combine(TargetFolder, ".minecraft"));
                 PageSelectLeft.AddFolder(
                     Path.Combine(TargetFolder, ".minecraft", ArchiveBaseFolder.Replace("/", @"\").TrimStart('\\')), InstanceName,
                     false); // 格式例如：包裹文件夹\.minecraft\（最短为空字符串）

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -362,7 +362,7 @@ public static class ModModpack
         if (InstanceName is null)
         {
             InstanceName = (string)(Json["name"] ?? "");
-            var Validate = new FolderNameValidator(ModMinecraft.McFolderSelected + "versions");
+            var Validate = new FolderNameValidator(Path.Combine(ModMinecraft.McFolderSelected, "versions"));
             if (!Validate.Validate(InstanceName).IsValid)
                 InstanceName = "";
             if (string.IsNullOrEmpty(InstanceName))
@@ -432,8 +432,8 @@ public static class ModModpack
             {
                 ExtractModpackFiles(InstallTemp, FileAddress, Task, 0.6d);
                 CopyOverrideDirectory(
-                    InstallTemp + ArchiveBaseFolder + (OverrideHome == "." || OverrideHome == "./" ? "" : OverrideHome),
-                    $@"{ModMinecraft.McFolderSelected}versions\{InstanceName}", Task, 0.4d); // #5613
+                    Path.Combine(InstallTemp, ArchiveBaseFolder, OverrideHome == "." || OverrideHome == "./" ? "" : OverrideHome),
+                    $@"{ModMinecraft.McFolderSelected}versions\{InstanceName}", Task, 0.4d);
             })
             {
                 ProgressWeight = new FileInfo(FileAddress).Length / 1024d / 1024d / 6d,
@@ -584,14 +584,14 @@ public static class ModModpack
             var VersionFolder = $@"{ModMinecraft.McFolderSelected}versions\{InstanceName}\";
             if (Logo is not null && File.Exists(Logo))
             {
-                File.Copy(Logo, VersionFolder + @"PCL\Logo.png", true);
+                File.Copy(Logo, Path.Combine(VersionFolder, "PCL", "Logo.png"), true);
                 States.Instance.LogoPath[VersionFolder] = @"PCL\Logo.png";
                 States.Instance.IsLogoCustom[VersionFolder] = true;
                 ModBase.Log("[ModPack] 已设置整合包 Logo：" + Logo);
             }
 
             // 删除原始整合包文件
-            foreach (var Target in new[] { VersionFolder + "原始整合包.zip", VersionFolder + "原始整合包.mrpack" })
+            foreach (var Target in new[] { Path.Combine(VersionFolder, "原始整合包.zip"), Path.Combine(VersionFolder, "原始整合包.mrpack") })
                 if (File.Exists(Target))
                 {
                     ModBase.Log("[ModPack] 删除原始整合包文件：" + Target);
@@ -720,7 +720,7 @@ public static class ModModpack
         if (InstanceName is null)
         {
             InstanceName = (string)(Json["name"] ?? "");
-            var Validate = new FolderNameValidator(ModMinecraft.McFolderSelected + "versions");
+            var Validate = new FolderNameValidator(Path.Combine(ModMinecraft.McFolderSelected, "versions"));
             if (!Validate.Validate(InstanceName).IsValid)
                 InstanceName = "";
             if (string.IsNullOrEmpty(InstanceName))
@@ -735,10 +735,10 @@ public static class ModModpack
         InstallLoaders.Add(new LoaderTask<string, int>("解压整合包文件", Task =>
         {
             ExtractModpackFiles(InstallTemp, FileAddress, Task, 0.5d);
-            CopyOverrideDirectory(InstallTemp + ArchiveBaseFolder + "overrides",
-                ModMinecraft.McFolderSelected + @"versions\" + InstanceName, Task, 0.4d);
-            CopyOverrideDirectory(InstallTemp + ArchiveBaseFolder + "client-overrides",
-                ModMinecraft.McFolderSelected + @"versions\" + InstanceName, Task, 0.1d);
+            CopyOverrideDirectory(Path.Combine(InstallTemp, ArchiveBaseFolder, "overrides"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName), Task, 0.4d);
+            CopyOverrideDirectory(Path.Combine(InstallTemp, ArchiveBaseFolder, "client-overrides"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName), Task, 0.1d);
         })
         {
             ProgressWeight = new FileInfo(FileAddress).Length / 1024d / 1024d / 6d,
@@ -814,14 +814,14 @@ public static class ModModpack
             var VersionFolder = $@"{ModMinecraft.McFolderSelected}versions\{InstanceName}\";
             if (Logo is not null && File.Exists(Logo))
             {
-                File.Copy(Logo, VersionFolder + @"PCL\Logo.png", true);
+                File.Copy(Logo, Path.Combine(VersionFolder, "PCL", "Logo.png"), true);
                 States.Instance.LogoPath[VersionFolder] = @"PCL\Logo.png";
                 States.Instance.IsLogoCustom[VersionFolder] = true;
                 ModBase.Log("[ModPack] 已设置整合包 Logo：" + Logo);
             }
 
             // 删除原始整合包文件
-            foreach (var Target in new[] { VersionFolder + "原始整合包.zip", VersionFolder + "原始整合包.mrpack" })
+            foreach (var Target in new[] { Path.Combine(VersionFolder, "原始整合包.zip"), Path.Combine(VersionFolder, "原始整合包.mrpack") })
                 if (File.Exists(Target))
                 {
                     ModBase.Log("[ModPack] 删除原始整合包文件：" + Target);
@@ -897,7 +897,7 @@ public static class ModModpack
 
         // 获取实例名
         var InstanceName = (string)(Json["name"] ?? "");
-        var Validate = new FolderNameValidator(ModMinecraft.McFolderSelected + "versions");
+        var Validate = new FolderNameValidator(Path.Combine(ModMinecraft.McFolderSelected, "versions"));
         if (!Validate.Validate(InstanceName).IsValid)
             InstanceName = "";
         if (string.IsNullOrEmpty(InstanceName))
@@ -910,8 +910,8 @@ public static class ModModpack
         InstallLoaders.Add(new LoaderTask<string, int>("解压整合包文件", Task =>
         {
             ExtractModpackFiles(InstallTemp, FileAddress, Task, 0.6d);
-            CopyOverrideDirectory(InstallTemp + ArchiveBaseFolder + "minecraft",
-                ModMinecraft.McFolderSelected + @"versions\" + InstanceName, Task, 0.4d);
+            CopyOverrideDirectory(Path.Combine(InstallTemp, ArchiveBaseFolder, "minecraft"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName), Task, 0.4d);
         })
         {
             ProgressWeight = new FileInfo(FileAddress).Length / 1024d / 1024d / 6d,
@@ -980,7 +980,7 @@ public static class ModModpack
         if (InstanceName == null)
         {
             InstanceName = Json["name"]?.ToString() ?? "";
-            var Validate = new FolderNameValidator(ModMinecraft.McFolderSelected + "versions");
+            var Validate = new FolderNameValidator(Path.Combine(ModMinecraft.McFolderSelected, "versions"));
 
             if (!Validate.Validate(InstanceName).IsValid) InstanceName = "";
 
@@ -1000,8 +1000,8 @@ public static class ModModpack
         {
             ExtractModpackFiles(InstallTemp, FileAddress, Task, 0.6);
             CopyOverrideDirectory(
-                InstallTemp + ArchiveBaseFolder + "overrides",
-                ModMinecraft.McFolderSelected + "versions\\" + InstanceName,
+                Path.Combine(InstallTemp, ArchiveBaseFolder, "overrides"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName),
                 Task, 0.4);
 
             // JVM 参数处理
@@ -1152,9 +1152,9 @@ public static class ModModpack
                 ModBase.OpenExplorer(TargetFolder);
                 // 加入文件夹列表
                 var InstanceName = ModBase.GetFolderNameFromPath(TargetFolder);
-                Directory.CreateDirectory(TargetFolder + @".minecraft\");
+                Directory.CreateDirectory(Path.Combine(TargetFolder, ".minecraft") + @"\");
                 PageSelectLeft.AddFolder(
-                    TargetFolder + @".minecraft\" + ArchiveBaseFolder.Replace("/", @"\").TrimStart('\\'), InstanceName,
+                    Path.Combine(TargetFolder, ".minecraft", ArchiveBaseFolder.Replace("/", @"\").TrimStart('\\')), InstanceName,
                     false); // 格式例如：包裹文件夹\.minecraft\（最短为空字符串）
                 // 调用 modpack 文件进行安装
                 var ModpackFile = Directory.GetFiles(TargetFolder, "modpack.*", SearchOption.AllDirectories).First();
@@ -1217,7 +1217,7 @@ public static class ModModpack
             {
                 ExtractModpackFiles(TargetFolder, FileAddress, Task, 0.95d);
                 // 加入文件夹列表
-                PageSelectLeft.AddFolder(TargetFolder + ArchiveBaseFolder, ModBase.GetFolderNameFromPath(TargetFolder),
+                PageSelectLeft.AddFolder(Path.Combine(TargetFolder, ArchiveBaseFolder), ModBase.GetFolderNameFromPath(TargetFolder),
                     false);
                 Thread.Sleep(400); // 避免文件争用
                 ModBase.RunInUi(() => ModMain.FrmMain.PageChange(FormMain.PageType.InstanceSelect));
@@ -1507,7 +1507,7 @@ public static class ModModpack
 
         // 获取实例名
         var InstanceName = PackInstance.RegexSeek(@"(?<=\nname\=)[^\n]+") ?? "";
-        var Validate = new FolderNameValidator(ModMinecraft.McFolderSelected + "versions");
+        var Validate = new FolderNameValidator(Path.Combine(ModMinecraft.McFolderSelected, "versions"));
         if (!Validate.Validate(InstanceName).IsValid)
             InstanceName = "";
         if (string.IsNullOrEmpty(InstanceName))
@@ -1521,17 +1521,17 @@ public static class ModModpack
         InstallLoaders.Add(new LoaderTask<string, int>("解压整合包文件", Task =>
         {
             ExtractModpackFiles(InstallTemp, FileAddress, Task, 0.55d);
-            CopyOverrideDirectory(InstallTemp + ArchiveBaseFolder + "libraries",
-                ModMinecraft.McFolderSelected + @"versions\" + InstanceName + @"\libraries", Task, 0.2d);
-            CopyOverrideDirectory(InstallTemp + ArchiveBaseFolder + ".minecraft",
-                ModMinecraft.McFolderSelected + @"versions\" + InstanceName, Task, 0.2d);
+            CopyOverrideDirectory(Path.Combine(InstallTemp, ArchiveBaseFolder, "libraries"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName, "libraries"), Task, 0.2d);
+            CopyOverrideDirectory(Path.Combine(InstallTemp, ArchiveBaseFolder, ".minecraft"),
+                Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName), Task, 0.2d);
 
             #region instance.cfg
 
             // 读取 MMC 设置文件（#2655）
             try
             {
-                var MMCSetupFile = InstallTemp + ArchiveBaseFolder + "instance.cfg";
+                var MMCSetupFile = Path.Combine(InstallTemp, ArchiveBaseFolder, "instance.cfg");
                 // 将其中的等号替换为冒号，以符合 ini 文件格式
                 if (File.Exists(MMCSetupFile))
                 {

--- a/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
@@ -195,7 +195,7 @@ public static class UpdateManager
     internal static void DownloadLatestPCL(ModLoader.LoaderBase LoaderToSyncProgress = null)
     {
         // 注意：如果要自行实现这个功能，请换用另一个文件路径，以免与官方版本冲突
-        var LatestPCLPath = ModBase.PathTemp + "CE-Latest.exe";
+        var LatestPCLPath = Path.Combine(ModBase.PathTemp, "CE-Latest.exe");
         var target = RemoteServer.GetLatestVersion(UpdateChannel.stable,
             ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
         if (target is null)

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -108,7 +108,7 @@ public partial class PageDownloadCompDetail
                     ModDownloadLib.McInstallFailedClearFolder(MyLoader);
                 }
             };
-            Loader.Start(Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName) + @"\");
+            Loader.Start(Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName));
             ModLoader.LoaderTaskbarAdd(Loader);
             ModMain.FrmMain.BtnExtraDownload.ShowRefresh();
             ModMain.FrmMain.BtnExtraDownload.Ribble();

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -108,7 +108,7 @@ public partial class PageDownloadCompDetail
                     ModDownloadLib.McInstallFailedClearFolder(MyLoader);
                 }
             };
-            Loader.Start(ModMinecraft.McFolderSelected + @"versions\" + InstanceName + @"\");
+            Loader.Start(Path.Combine(ModMinecraft.McFolderSelected, "versions", InstanceName) + @"\");
             ModLoader.LoaderTaskbarAdd(Loader);
             ModMain.FrmMain.BtnExtraDownload.ShowRefresh();
             ModMain.FrmMain.BtnExtraDownload.Ribble();

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -45,7 +45,7 @@ public static class ModDownloadLib
     {
         try
         {
-            var versionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", id) + @"\";
+            var versionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", id);
 
             // 重复任务检查
             foreach (var ongoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -107,7 +107,7 @@ public static class ModDownloadLib
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id);
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar)
@@ -159,7 +159,7 @@ public static class ModDownloadLib
         string instanceName = null)
     {
         instanceName = instanceName ?? id;
-        var instanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", instanceName) + @"\";
+        var instanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", instanceName);
 
         var loaders = new List<ModLoader.LoaderBase>();
 
@@ -386,7 +386,7 @@ public static class ModDownloadLib
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id);
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -482,7 +482,7 @@ pause";
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id);
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -542,7 +542,7 @@ pause";
         try
         {
             var Id = DownloadInfo.NameVersion;
-            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Id) + @"\";
+            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Id);
             var IsNewVersion = ModBase.Val(DownloadInfo.Inherit.Split(".")[1]) >= 14d;
             var Target = IsNewVersion
                 ? Path.Combine(ModBase.PathTemp, "Cache", "Code", DownloadInfo.NameVersion + "_" + ModBase.GetUuid())
@@ -797,7 +797,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = DownloadInfo.NameVersion;
-        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id);
         var IsNewVersion = DownloadInfo.Inherit.Contains("w") || ModBase.Val(DownloadInfo.Inherit.Split(".")[1]) >= 14d;
         var Target = IsNewVersion
             ? $"{ModMain.RequestTaskTempFolder()}OptiFine.jar"
@@ -906,13 +906,13 @@ pause";
             Loaders.Add(new ModLoader.LoaderTask<List<DownloadFile>, bool>("安装 OptiFine（方式 A）", Task =>
             {
                 var BaseMcFolderHome = ModMain.RequestTaskTempFolder();
-                var BaseMcFolder = Path.Combine(BaseMcFolderHome, ".minecraft") + @"\";
+                var BaseMcFolder = Path.Combine(BaseMcFolderHome, ".minecraft");
                 try
                 {
                     // 准备安装环境
                     if (Directory.Exists(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit)))
                         ModBase.DeleteDirectory(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit));
-                    Directory.CreateDirectory(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit) + @"\");
+                    Directory.CreateDirectory(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit));
                     ModMinecraft.McFolderLauncherProfilesJsonCreate(BaseMcFolder);
                     ModBase.CopyFile(
                         Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".json"),
@@ -1190,7 +1190,7 @@ pause";
             var Id = DownloadInfo.Inherit;
             var Target = Path.Combine(ModBase.PathTemp, "Download", Id + "-Liteloader.jar");
             var VersionName = DownloadInfo.Inherit + "-LiteLoader";
-            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", VersionName) + @"\";
+            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", VersionName);
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -1328,7 +1328,7 @@ pause";
         var Id = DownloadInfo.Inherit;
         var Target = Path.Combine(ModBase.PathTemp, "Download", Id + "-Liteloader.jar");
         var VersionName = DownloadInfo.Inherit + "-LiteLoader";
-        var VersionFolder = Path.Combine(McFolder, "versions", VersionName) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", VersionName);
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 启动依赖实例的下载
@@ -2198,9 +2198,9 @@ pause";
                             Task.Progress = 0.6d;
                             // 解压支持库文件
                             Installer.Dispose();
-                            ModBase.ExtractFile(InstallerAddress, Path.Combine(InstallerAddress, "_unrar") + @"\");
-                            ModBase.CopyDirectory(Path.Combine(InstallerAddress, "_unrar", "maven") + @"\", Path.Combine(McFolder, "libraries") + @"\");
-                            ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar") + @"\");
+                            ModBase.ExtractFile(InstallerAddress, Path.Combine(InstallerAddress, "_unrar"));
+                            ModBase.CopyDirectory(Path.Combine(InstallerAddress, "_unrar", "maven"), Path.Combine(McFolder, "libraries"));
+                            ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar"));
                         }
                         else
                         {
@@ -2234,8 +2234,8 @@ pause";
                                 Installer.Dispose();
                             if (File.Exists(InstallerAddress))
                                 File.Delete(InstallerAddress);
-                            if (Directory.Exists(Path.Combine(InstallerAddress, "_unrar") + @"\"))
-                                ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar") + @"\");
+                            if (Directory.Exists(Path.Combine(InstallerAddress, "_unrar")))
+                            ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar"));
                         }
                         catch (Exception ex)
                         {
@@ -2740,7 +2740,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "fabric-loader-" + FabricVersion + "-" + MinecraftName;
-        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id);
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -2853,7 +2853,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "legacy-fabric-loader-" + LegacyFabricVersion + "-" + MinecraftName;
-        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id);
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -3067,7 +3067,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "quilt-loader-" + QuiltVersion + "-" + MinecraftName;
-        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id);
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -3264,7 +3264,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "labymod-" + LabyModCommitRef + "-" + MinecraftName;
-        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id);
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -3754,7 +3754,7 @@ pause";
                                                          Request.NeoForgeEntry is not null);
 
         // 获取参数
-        var InstanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Request.TargetInstanceName) + @"\";
+        var InstanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Request.TargetInstanceName);
         if (Directory.Exists(TempMcFolder))
             ModBase.DeleteDirectory(TempMcFolder);
         string OptiFineFolder = null;
@@ -3814,13 +3814,13 @@ pause";
         var Modable = Request.FabricVersion is not null || Request.LegacyFabricVersion is not null ||
                       Request.ForgeEntry is not null || Request.NeoForgeEntry is not null ||
                       Request.LiteLoaderEntry is not null;
-        var ModsTempFolder = Path.Combine(TempMcFolder, "mods") + @"\";
+        var ModsTempFolder = Path.Combine(TempMcFolder, "mods");
         var OptiFineAsMod = Request.OptiFineEntry is not null && Modable; // 选择了 OptiFine 与任意 Mod 加载器
         if (OptiFineAsMod)
         {
             ModBase.Log("[Download] OptiFine 将作为 Mod 进行下载");
             if (Request.LiteLoaderEntry != null)
-                OptiFineFolder = Path.Combine(ModsTempFolder, Request.MinecraftName) + @"\";
+                OptiFineFolder = Path.Combine(ModsTempFolder, Request.MinecraftName);
             else
                 OptiFineFolder = ModsTempFolder;
         }
@@ -4004,7 +4004,7 @@ pause";
                 ModBase.CopyDirectory(Path.Combine(TempMcFolder, "libraries"), Path.Combine(ModMinecraft.McFolderSelected, "libraries"));
             Task.Progress = 0.8d;
             // 创建 Mod 和资源包文件夹
-            var ModsFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "mods") + @"\"; // 版本隔离信息在此时被决定
+            var ModsFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "mods"); // 版本隔离信息在此时被决定
             if (Directory.Exists(ModsTempFolder))
             {
                 ModBase.CopyDirectory(ModsTempFolder, ModsFolder);
@@ -4015,7 +4015,7 @@ pause";
                 ModBase.Log("[Download] 自动创建 Mod 文件夹：" + ModsFolder);
             }
 
-            var ResourcepacksFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "resourcepacks") + @"\";
+            var ResourcepacksFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "resourcepacks");
             Directory.CreateDirectory(ResourcepacksFolder);
             ModBase.Log("[Download] 自动创建资源包文件夹：" + ResourcepacksFolder);
         })

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -45,7 +45,7 @@ public static class ModDownloadLib
     {
         try
         {
-            var versionFolder = ModMinecraft.McFolderSelected + @"versions\" + id + @"\";
+            var versionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", id) + @"\";
 
             // 重复任务检查
             foreach (var ongoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -59,8 +59,8 @@ public static class ModDownloadLib
             }
 
             // 已有实例检查
-            if (behaviour != NetPreDownloadBehaviour.IgnoreCheck && File.Exists(versionFolder + id + ".json") &&
-                File.Exists(versionFolder + id + ".jar"))
+            if (behaviour != NetPreDownloadBehaviour.IgnoreCheck && File.Exists(Path.Combine(versionFolder, id + ".json")) &&
+                File.Exists(Path.Combine(versionFolder, id + ".jar")))
             {
                 if (behaviour == NetPreDownloadBehaviour.ExitWhileExistsOrDownloading)
                     return null;
@@ -68,8 +68,8 @@ public static class ModDownloadLib
                         "实例 " + id + " 已存在，是否重新下载？" + "\r\n" + "这会覆盖实例的 Json 与 Jar 文件，但不会影响版本隔离的文件。", "实例已存在",
                         "继续", "取消") == 1)
                 {
-                    File.Delete(versionFolder + id + ".jar");
-                    File.Delete(versionFolder + id + ".json");
+                    File.Delete(Path.Combine(versionFolder, id + ".jar"));
+                    File.Delete(Path.Combine(versionFolder, id + ".json"));
                 }
                 else
                 {
@@ -107,7 +107,7 @@ public static class ModDownloadLib
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = VersionFolder + Id + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar)
@@ -125,7 +125,7 @@ public static class ModDownloadLib
             Loaders.Add(new LoaderDownload("下载实例 Json 文件",
                 new List<DownloadFile>
                 {
-                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), VersionFolder + Id + ".json",
+                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), Path.Combine(VersionFolder, Id + ".json"),
                         new ModBase.FileChecker(CanUseExistsFile: false, IsJson: true))
                 }) { ProgressWeight = 2d });
             // 获取支持库文件地址
@@ -159,7 +159,7 @@ public static class ModDownloadLib
         string instanceName = null)
     {
         instanceName = instanceName ?? id;
-        var instanceFolder = ModMinecraft.McFolderSelected + @"versions\" + instanceName + @"\";
+        var instanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", instanceName) + @"\";
 
         var loaders = new List<ModLoader.LoaderBase>();
 
@@ -170,7 +170,7 @@ public static class ModDownloadLib
                 var jsonAddress = Conversions.ToString(ModDownload.DlClientListGet(id));
                 task.Output = new List<DownloadFile>
                 {
-                    new(ModDownload.DlSourceLauncherOrMetaGet(jsonAddress), instanceFolder + instanceName + ".json")
+                    new(ModDownload.DlSourceLauncherOrMetaGet(jsonAddress), Path.Combine(instanceFolder, instanceName + ".json"))
                 };
             })
             {
@@ -180,7 +180,7 @@ public static class ModDownloadLib
         loaders.Add(new LoaderDownload(McDownloadClientJsonName,
             new List<DownloadFile>
             {
-                new(ModDownload.DlSourceLauncherOrMetaGet(jsonUrl ?? ""), instanceFolder + instanceName + ".json",
+                new(ModDownload.DlSourceLauncherOrMetaGet(jsonUrl ?? ""), Path.Combine(instanceFolder, instanceName + ".json"),
                     new ModBase.FileChecker(CanUseExistsFile: false, IsJson: true))
             }) { ProgressWeight = 3d });
 
@@ -193,12 +193,12 @@ public static class ModDownloadLib
             if (Conversions.ToBoolean(id == "1.16.5" && Config.Download.FixAuthLib != null)) // 1.16.5 Authlib 修复
                 try
                 {
-                    var json = ModBase.ReadFile(instanceFolder + instanceName + ".json");
+                    var json = ModBase.ReadFile(Path.Combine(instanceFolder, instanceName + ".json"));
                     json = json.Replace("2.1.28/authlib-2.1.28.jar", "2.3.31/authlib-2.3.31.jar")
                         .Replace("com.mojang:authlib:2.1.28", "com.mojang:authlib:2.3.31")
                         .Replace("ad54da276bf59983d02d5ed16fc14541354c71fd", "bbd00ca33b052f73a6312254780fc580d2da3535")
                         .Replace("76328", "87662");
-                    ModBase.WriteFile(instanceFolder + instanceName + ".json", json);
+                    ModBase.WriteFile(Path.Combine(instanceFolder, instanceName + ".json"), json);
                 }
                 catch (Exception ex)
                 {
@@ -234,9 +234,9 @@ public static class ModDownloadLib
             // 顺手添加 Json 项目
             try
             {
-                var versionJson = (JObject)ModBase.GetJson(ModBase.ReadFile(instanceFolder + instanceName + ".json"));
+                var versionJson = (JObject)ModBase.GetJson(ModBase.ReadFile(Path.Combine(instanceFolder, instanceName + ".json")));
                 versionJson.Add("clientVersion", id);
-                ModBase.WriteFile(instanceFolder + instanceName + ".json", versionJson.ToString());
+                ModBase.WriteFile(Path.Combine(instanceFolder, instanceName + ".json"), versionJson.ToString());
             }
             catch (Exception ex)
             {
@@ -386,7 +386,7 @@ public static class ModDownloadLib
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = VersionFolder + Id + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -402,7 +402,7 @@ public static class ModDownloadLib
             Loaders.Add(new LoaderDownload("下载实例 JSON 文件",
                 new List<DownloadFile>
                 {
-                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), VersionFolder + Id + ".json",
+                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), Path.Combine(VersionFolder, Id + ".json"),
                         new ModBase.FileChecker(CanUseExistsFile: false, IsJson: true))
                 }) { ProgressWeight = 2d });
             // 构建服务端
@@ -414,7 +414,7 @@ public static class ModDownloadLib
                     McInstance.JsonObject["downloads"]["server"] is null ||
                     McInstance.JsonObject["downloads"]["server"]["url"] is null)
                 {
-                    File.Delete(VersionFolder + Id + ".json");
+                    File.Delete(Path.Combine(VersionFolder, Id + ".json"));
                     if (!new DirectoryInfo(VersionFolder).GetFileSystemInfos().Any())
                         Directory.Delete(VersionFolder);
                     Task.Output = new List<DownloadFile>();
@@ -429,7 +429,7 @@ public static class ModDownloadLib
                     (long)(McInstance.JsonObject["downloads"]["server"]["size"] ?? -1),
                     (string)McInstance.JsonObject["downloads"]["server"]["sha1"]);
                 Task.Output = new List<DownloadFile>
-                    { new(ModDownload.DlSourceLauncherOrMetaGet(JarUrl), VersionFolder + Id + "-server.jar", Checker) };
+                    { new(ModDownload.DlSourceLauncherOrMetaGet(JarUrl), Path.Combine(VersionFolder, Id + "-server.jar"), Checker) };
                 // 添加启动脚本
                 var Bat = $@"@echo off
 title {Id} 原版服务端
@@ -442,10 +442,10 @@ echo ------------------------------
 echo ----------------------
 echo 服务端已停止。
 pause";
-                ModBase.WriteFile(VersionFolder + "Launch Server.bat", Bat.Replace("\n", "\r\n"),
+                ModBase.WriteFile(Path.Combine(VersionFolder, "Launch Server.bat"), Bat.Replace("\n", "\r\n"),
                     Encoding: Encoding.Default.Equals(Encoding.UTF8) ? Encoding.UTF8 : Encoding.GetEncoding("GB18030"));
                 // 删除实例 JSON
-                File.Delete(VersionFolder + Id + ".json");
+                File.Delete(Path.Combine(VersionFolder, Id + ".json"));
             })
             {
                 ProgressWeight = 0.5d,
@@ -482,7 +482,7 @@ pause";
             var VersionFolder = SystemDialogs.SelectFolder();
             if (!VersionFolder.Contains(@"\"))
                 return;
-            VersionFolder = VersionFolder + Id + @"\";
+            VersionFolder = Path.Combine(VersionFolder, Id) + @"\";
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -498,7 +498,7 @@ pause";
             Loaders.Add(new LoaderDownload("下载实例 JSON 文件",
                 new List<DownloadFile>
                 {
-                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), VersionFolder + Id + ".json",
+                    new(ModDownload.DlSourceLauncherOrMetaGet(JsonUrl), Path.Combine(VersionFolder, Id + ".json"),
                         new ModBase.FileChecker(CanUseExistsFile: false, IsJson: true))
                 }) { ProgressWeight = 2d });
             // 获取支持库文件地址
@@ -542,13 +542,13 @@ pause";
         try
         {
             var Id = DownloadInfo.NameVersion;
-            var VersionFolder = ModMinecraft.McFolderSelected + @"versions\" + Id + @"\";
+            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Id) + @"\";
             var IsNewVersion = ModBase.Val(DownloadInfo.Inherit.Split(".")[1]) >= 14d;
             var Target = IsNewVersion
-                ? ModBase.PathTemp + @"Cache\Code\" + DownloadInfo.NameVersion + "_" + ModBase.GetUuid()
-                : ModMinecraft.McFolderSelected + @"libraries\optifine\OptiFine\" +
-                  DownloadInfo.NameFile.Replace("OptiFine_", "").Replace(".jar", "").Replace("preview_", "") + @"\" +
-                  DownloadInfo.NameFile.Replace("OptiFine_", "OptiFine-").Replace("preview_", "");
+                ? Path.Combine(ModBase.PathTemp, "Cache", "Code", DownloadInfo.NameVersion + "_" + ModBase.GetUuid())
+                : Path.Combine(ModMinecraft.McFolderSelected, "libraries", "optifine", "OptiFine",
+                    DownloadInfo.NameFile.Replace("OptiFine_", "").Replace(".jar", "").Replace("preview_", ""),
+                    DownloadInfo.NameFile.Replace("OptiFine_", "OptiFine-").Replace("preview_", ""));
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar)
@@ -560,14 +560,14 @@ pause";
             }
 
             // 已有实例检查
-            if (File.Exists(VersionFolder + Id + ".json"))
+            if (File.Exists(Path.Combine(VersionFolder, Id + ".json")))
             {
                 if (ModMain.MyMsgBox(
                         "实例 " + Id + " 已存在，是否重新下载？" + "\r\n" + "这会覆盖实例的 Json 和 Jar 文件，但不会影响版本隔离的文件。", "实例已存在",
                         "继续", "取消") == 1)
                 {
-                    File.Delete(VersionFolder + Id + ".jar");
-                    File.Delete(VersionFolder + Id + ".json");
+                    File.Delete(Path.Combine(VersionFolder, Id + ".jar"));
+                    File.Delete(Path.Combine(VersionFolder, Id + ".json"));
                 }
                 else
                 {
@@ -797,7 +797,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = DownloadInfo.NameVersion;
-        var VersionFolder = McFolder + @"versions\" + Id + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
         var IsNewVersion = DownloadInfo.Inherit.Contains("w") || ModBase.Val(DownloadInfo.Inherit.Split(".")[1]) >= 14d;
         var Target = IsNewVersion
             ? $"{ModMain.RequestTaskTempFolder()}OptiFine.jar"
@@ -885,12 +885,11 @@ pause";
             lock (VanillaSyncLock)
             {
                 var ClientName = ModBase.GetFolderNameFromPath(ClientFolder);
-                Directory.CreateDirectory(McFolder + @"versions\" + DownloadInfo.Inherit);
-                if (!File.Exists(McFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit +
-                                 ".json"))
+                Directory.CreateDirectory(Path.Combine(McFolder, "versions", DownloadInfo.Inherit));
+                if (!File.Exists(Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".json")))
                     ModBase.CopyFile($"{ClientFolder}{ClientName}.json",
                         $@"{McFolder}versions\{DownloadInfo.Inherit}\{DownloadInfo.Inherit}.json");
-                if (!File.Exists(McFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".jar"))
+                if (!File.Exists(Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".jar")))
                     ModBase.CopyFile($"{ClientFolder}{ClientName}.jar",
                         $@"{McFolder}versions\{DownloadInfo.Inherit}\{DownloadInfo.Inherit}.jar");
             }
@@ -907,20 +906,20 @@ pause";
             Loaders.Add(new ModLoader.LoaderTask<List<DownloadFile>, bool>("安装 OptiFine（方式 A）", Task =>
             {
                 var BaseMcFolderHome = ModMain.RequestTaskTempFolder();
-                var BaseMcFolder = BaseMcFolderHome + @".minecraft\";
+                var BaseMcFolder = Path.Combine(BaseMcFolderHome, ".minecraft") + @"\";
                 try
                 {
                     // 准备安装环境
-                    if (Directory.Exists(BaseMcFolder + @"versions\" + DownloadInfo.Inherit))
-                        ModBase.DeleteDirectory(BaseMcFolder + @"versions\" + DownloadInfo.Inherit);
-                    Directory.CreateDirectory(BaseMcFolder + @"versions\" + DownloadInfo.Inherit + @"\");
+                    if (Directory.Exists(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit)))
+                        ModBase.DeleteDirectory(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit));
+                    Directory.CreateDirectory(Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit) + @"\");
                     ModMinecraft.McFolderLauncherProfilesJsonCreate(BaseMcFolder);
                     ModBase.CopyFile(
-                        McFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".json",
-                        BaseMcFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".json");
+                        Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".json"),
+                        Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".json"));
                     ModBase.CopyFile(
-                        McFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".jar",
-                        BaseMcFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".jar");
+                        Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".jar"),
+                        Path.Combine(BaseMcFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".jar"));
                     Task.Progress = 0.06d;
                     // 进行安装
                     var UseJavaWrapper = ModBase.IsUtf8CodePage();
@@ -944,7 +943,7 @@ pause";
 
                     Task.Progress = 0.96d;
                     // 复制文件
-                    File.Delete(BaseMcFolder + "launcher_profiles.json");
+                    File.Delete(Path.Combine(BaseMcFolder, "launcher_profiles.json"));
                     ModBase.CopyDirectory(BaseMcFolder, McFolder);
                     Task.Progress = 0.98d;
                     // 清理文件
@@ -972,13 +971,13 @@ pause";
                     {
                         Directory.CreateDirectory(VersionFolder);
                         Task.Progress = 0.1d;
-                        if (File.Exists(VersionFolder + Id + ".jar")) File.Delete(VersionFolder + Id + ".jar");
+                        if (File.Exists(Path.Combine(VersionFolder, Id + ".jar"))) File.Delete(Path.Combine(VersionFolder, Id + ".jar"));
                         ModBase.CopyFile(
-                            McFolder + @"versions\" + DownloadInfo.Inherit + @"\" + DownloadInfo.Inherit + ".jar",
-                            VersionFolder + Id + ".jar");
+                            Path.Combine(McFolder, "versions", DownloadInfo.Inherit, DownloadInfo.Inherit + ".jar"),
+                            Path.Combine(VersionFolder, Id + ".jar"));
                         Task.Progress = 0.7d;
                         var InheritInstance =
-                            new ModMinecraft.McInstance(McFolder + @"versions\" + DownloadInfo.Inherit);
+                            new ModMinecraft.McInstance(Path.Combine(McFolder, "versions", DownloadInfo.Inherit));
                         var Json = @"{
     ""id"": """ + Id + @""",
     ""inheritsFrom"": """ + DownloadInfo.Inherit + @""",
@@ -1016,7 +1015,7 @@ pause";
         ]
     }
 }";
-                        ModBase.WriteFile(VersionFolder + Id + ".json", Json);
+                        ModBase.WriteFile(Path.Combine(VersionFolder, Id + ".json"), Json);
                     }
                     catch (Exception ex)
                     {
@@ -1189,9 +1188,9 @@ pause";
         try
         {
             var Id = DownloadInfo.Inherit;
-            var Target = ModBase.PathTemp + @"Download\" + Id + "-Liteloader.jar";
+            var Target = Path.Combine(ModBase.PathTemp, "Download", Id + "-Liteloader.jar");
             var VersionName = DownloadInfo.Inherit + "-LiteLoader";
-            var VersionFolder = ModMinecraft.McFolderSelected + @"versions\" + VersionName + @"\";
+            var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", VersionName) + @"\";
 
             // 重复任务检查
             foreach (var OngoingLoader in ModLoader.LoaderTaskbar.ToList())
@@ -1203,14 +1202,14 @@ pause";
             }
 
             // 已有实例检查
-            if (File.Exists(VersionFolder + VersionName + ".json"))
+            if (File.Exists(Path.Combine(VersionFolder, VersionName + ".json")))
             {
                 if (ModMain.MyMsgBox(
                         "实例 " + VersionName + " 已存在，是否重新下载？" + "\r\n" + "这会覆盖实例的 Json 和 Jar 文件，但不会影响版本隔离的文件。",
                         "实例已存在", "继续", "取消") == 1)
                 {
-                    File.Delete(VersionFolder + VersionName + ".jar");
-                    File.Delete(VersionFolder + VersionName + ".json");
+                    File.Delete(Path.Combine(VersionFolder, VersionName + ".jar"));
+                    File.Delete(Path.Combine(VersionFolder, VersionName + ".json"));
                 }
                 else
                 {
@@ -1327,9 +1326,9 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = DownloadInfo.Inherit;
-        var Target = ModBase.PathTemp + @"Download\" + Id + "-Liteloader.jar";
+        var Target = Path.Combine(ModBase.PathTemp, "Download", Id + "-Liteloader.jar");
         var VersionName = DownloadInfo.Inherit + "-LiteLoader";
-        var VersionFolder = McFolder + @"versions\" + VersionName + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", VersionName) + @"\";
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 启动依赖实例的下载
@@ -1373,7 +1372,7 @@ pause";
                 VersionJson.Add("minimumLauncherVersion", 18);
                 VersionJson.Add("inheritsFrom", DownloadInfo.Inherit);
                 VersionJson.Add("jar", DownloadInfo.Inherit);
-                ModBase.WriteFile(VersionFolder + VersionName + ".json", VersionJson.ToString());
+                ModBase.WriteFile(Path.Combine(VersionFolder, VersionName + ".json"), VersionJson.ToString());
             }
             catch (Exception ex)
             {
@@ -2051,13 +2050,13 @@ pause";
                 lock (VanillaSyncLock)
                 {
                     var ClientName = ModBase.GetFolderNameFromPath(ClientFolder);
-                    Directory.CreateDirectory(McFolder + @"versions\" + Inherit);
-                    if (!File.Exists(McFolder + @"versions\" + Inherit + @"\" + Inherit + ".json"))
-                        ModBase.CopyFile(ClientFolder + ClientName + ".json",
-                            McFolder + @"versions\" + Inherit + @"\" + Inherit + ".json");
-                    if (!File.Exists(McFolder + @"versions\" + Inherit + @"\" + Inherit + ".jar"))
-                        ModBase.CopyFile(ClientFolder + ClientName + ".jar",
-                            McFolder + @"versions\" + Inherit + @"\" + Inherit + ".jar");
+                    Directory.CreateDirectory(Path.Combine(McFolder, "versions", Inherit));
+                    if (!File.Exists(Path.Combine(McFolder, "versions", Inherit, Inherit + ".json")))
+                        ModBase.CopyFile(Path.Combine(ClientFolder, ClientName + ".json"),
+                            Path.Combine(McFolder, "versions", Inherit, Inherit + ".json"));
+                    if (!File.Exists(Path.Combine(McFolder, "versions", Inherit, Inherit + ".jar")))
+                        ModBase.CopyFile(Path.Combine(ClientFolder, ClientName + ".jar"),
+                            Path.Combine(McFolder, "versions", Inherit, Inherit + ".jar"));
                 }
 
                 #endregion
@@ -2093,7 +2092,7 @@ pause";
                         try
                         {
                             // 释放 Forge 注入器
-                            ModBase.WriteFile(ModBase.PathTemp + @"Cache\forge_installer.jar",
+                            ModBase.WriteFile(Path.Combine(ModBase.PathTemp, "Cache", "forge_installer.jar"),
                                 ModBase.GetResourceStream("Resources/forge-installer.jar"));
                             Task.Progress = 0.06d;
                             // 运行注入器
@@ -2127,7 +2126,7 @@ pause";
                         if (DeltaList.Count == 1)
                         {
                             var JsonFile = DeltaList[0].EnumerateFiles().First();
-                            ModBase.WriteFile(VersionFolder + TargetVersion + ".json",
+                            ModBase.WriteFile(Path.Combine(VersionFolder, TargetVersion + ".json"),
                                 ModBase.ReadFile(JsonFile.FullName));
                             ModBase.Log(
                                 $"[Download] 已拷贝新增的实例 Json 文件：{JsonFile.FullName} -> {VersionFolder}{TargetVersion}.json");
@@ -2195,13 +2194,13 @@ pause";
                             var JsonVersion = (JObject)ModBase.GetJson(
                                 ModBase.ReadFile(Installer.GetEntry(Json["json"].ToString().TrimStart('/')).Open()));
                             JsonVersion["id"] = TargetVersion;
-                            ModBase.WriteFile(VersionFolder + TargetVersion + ".json", JsonVersion.ToString());
+                            ModBase.WriteFile(Path.Combine(VersionFolder, TargetVersion + ".json"), JsonVersion.ToString());
                             Task.Progress = 0.6d;
                             // 解压支持库文件
                             Installer.Dispose();
-                            ModBase.ExtractFile(InstallerAddress, InstallerAddress + @"_unrar\");
-                            ModBase.CopyDirectory(InstallerAddress + @"_unrar\maven\", McFolder + @"libraries\");
-                            ModBase.DeleteDirectory(InstallerAddress + @"_unrar\");
+                            ModBase.ExtractFile(InstallerAddress, Path.Combine(InstallerAddress, "_unrar") + @"\");
+                            ModBase.CopyDirectory(Path.Combine(InstallerAddress, "_unrar", "maven") + @"\", Path.Combine(McFolder, "libraries") + @"\");
+                            ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar") + @"\");
                         }
                         else
                         {
@@ -2219,7 +2218,7 @@ pause";
                             Json["versionInfo"]["id"] = TargetVersion;
                             if (Json["versionInfo"]["inheritsFrom"] is null)
                                 ((JObject)Json["versionInfo"]).Add("inheritsFrom", Inherit);
-                            ModBase.WriteFile(VersionFolder + TargetVersion + ".json", Json["versionInfo"].ToString());
+                            ModBase.WriteFile(Path.Combine(VersionFolder, TargetVersion + ".json"), Json["versionInfo"].ToString());
                         }
                     }
                     catch (Exception ex)
@@ -2235,8 +2234,8 @@ pause";
                                 Installer.Dispose();
                             if (File.Exists(InstallerAddress))
                                 File.Delete(InstallerAddress);
-                            if (Directory.Exists(InstallerAddress + @"_unrar\"))
-                                ModBase.DeleteDirectory(InstallerAddress + @"_unrar\");
+                            if (Directory.Exists(Path.Combine(InstallerAddress, "_unrar") + @"\"))
+                                ModBase.DeleteDirectory(Path.Combine(InstallerAddress, "_unrar") + @"\");
                         }
                         catch (Exception ex)
                         {
@@ -2411,7 +2410,7 @@ pause";
 
                 if (RecommendedList.Count < 5) throw new Exception("获取的推荐版本数过少（" + Result + "）");
                 var CacheJson = "{" + RecommendedList.Join(",") + "}";
-                ModBase.WriteFile(ModBase.PathTemp + @"Cache\ForgeRecommendedList.json", CacheJson);
+                ModBase.WriteFile(Path.Combine(ModBase.PathTemp, "Cache", "ForgeRecommendedList.json"), CacheJson);
                 ModBase.Log("[Download] 刷新 Forge 推荐版本缓存成功");
             }
             catch (Exception ex)
@@ -2432,7 +2431,7 @@ pause";
         {
             if (McInstance is null)
                 return null;
-            var List = ModBase.ReadFile(ModBase.PathTemp + @"Cache\ForgeRecommendedList.json");
+            var List = ModBase.ReadFile(Path.Combine(ModBase.PathTemp, "Cache", "ForgeRecommendedList.json"));
             if (List is null || string.IsNullOrEmpty(List))
             {
                 ModBase.Log("[Download] 没有 Forge 推荐版本缓存文件");
@@ -2741,7 +2740,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "fabric-loader-" + FabricVersion + "-" + MinecraftName;
-        var VersionFolder = McFolder + @"versions\" + Id + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -2854,7 +2853,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "legacy-fabric-loader-" + LegacyFabricVersion + "-" + MinecraftName;
-        var VersionFolder = McFolder + @"versions\" + Id + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -2872,7 +2871,7 @@ pause";
                     {
                         "https://meta.legacyfabric.net/v2/versions/loader/" + MinecraftName + "/" +
                         LegacyFabricVersion + "/profile/json"
-                    }, VersionFolder + Id + ".json", new ModBase.FileChecker(IsJson: true))
+                    }, Path.Combine(VersionFolder, Id + ".json"), new ModBase.FileChecker(IsJson: true))
             };
         })
         {
@@ -3068,7 +3067,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "quilt-loader-" + QuiltVersion + "-" + MinecraftName;
-        var VersionFolder = McFolder + @"versions\" + Id + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -3087,7 +3086,7 @@ pause";
                     {
                         "https://meta.quiltmc.org/v3/versions/loader/" + MinecraftName + "/" + QuiltVersion +
                         "/profile/json"
-                    }, VersionFolder + Id + ".json", new ModBase.FileChecker(IsJson: true))
+                    }, Path.Combine(VersionFolder, Id + ".json"), new ModBase.FileChecker(IsJson: true))
             };
             // 新建 mods 文件夹
             Directory.CreateDirectory($@"{McFolder ?? ModMinecraft.McFolderSelected}mods\");
@@ -3265,7 +3264,7 @@ pause";
         McFolder = McFolder ?? ModMinecraft.McFolderSelected;
         var IsCustomFolder = (McFolder ?? "") != (ModMinecraft.McFolderSelected ?? "");
         var Id = "labymod-" + LabyModCommitRef + "-" + MinecraftName;
-        var VersionFolder = McFolder + @"versions\" + Id + @"\";
+        var VersionFolder = Path.Combine(McFolder, "versions", Id) + @"\";
         var Loaders = new List<ModLoader.LoaderBase>();
 
         // 下载 Json
@@ -3284,7 +3283,7 @@ pause";
                     new[]
                     {
                         $"https://releases.r2.labymod.net/api/v1/download/manifest/labymod4/{LabyModChannel}/{MinecraftName}/{LabyModCommitRef}.json"
-                    }, VersionFolder + Id + ".json", new ModBase.FileChecker(IsJson: true))
+                    }, Path.Combine(VersionFolder, Id + ".json"), new ModBase.FileChecker(IsJson: true))
             };
             Task.Progress = 1d;
         })
@@ -3315,7 +3314,7 @@ pause";
         string LabyCommitRef, string VersionName = null)
     {
         VersionName = VersionName ?? Id;
-        var VersionFolder = ModMinecraft.McFolderSelected + @"versions\" + VersionName + @"\";
+        var VersionFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", VersionName) + @"\";
 
         var Loaders = new List<ModLoader.LoaderBase>();
 
@@ -3353,9 +3352,9 @@ pause";
             // 顺手添加 Json 项目
             try
             {
-                var VersionJson = (JObject)ModBase.GetJson(ModBase.ReadFile(VersionFolder + VersionName + ".json"));
+                var VersionJson = (JObject)ModBase.GetJson(ModBase.ReadFile(Path.Combine(VersionFolder, VersionName + ".json")));
                 VersionJson.Add("clientVersion", Id);
-                ModBase.WriteFile(VersionFolder + VersionName + ".json", VersionJson.ToString());
+                ModBase.WriteFile(Path.Combine(VersionFolder, VersionName + ".json"), VersionJson.ToString());
             }
             catch (Exception ex)
             {
@@ -3755,7 +3754,7 @@ pause";
                                                          Request.NeoForgeEntry is not null);
 
         // 获取参数
-        var InstanceFolder = ModMinecraft.McFolderSelected + @"versions\" + Request.TargetInstanceName + @"\";
+        var InstanceFolder = Path.Combine(ModMinecraft.McFolderSelected, "versions", Request.TargetInstanceName) + @"\";
         if (Directory.Exists(TempMcFolder))
             ModBase.DeleteDirectory(TempMcFolder);
         string OptiFineFolder = null;
@@ -3776,52 +3775,52 @@ pause";
         }
 
         if (Request.OptiFineEntry is not null)
-            OptiFineFolder = TempMcFolder + @"versions\" + Request.OptiFineEntry.NameVersion;
+            OptiFineFolder = Path.Combine(TempMcFolder, "versions", Request.OptiFineEntry.NameVersion);
         string ForgeFolder = null;
         if (Request.ForgeEntry is not null)
             Request.ForgeVersion = Request.ForgeVersion ?? Request.ForgeEntry.VersionName;
         if (Request.ForgeVersion is not null)
-            ForgeFolder = TempMcFolder + @"versions\forge-" + Request.ForgeVersion;
+            ForgeFolder = Path.Combine(TempMcFolder, "versions", "forge-" + Request.ForgeVersion);
         string NeoForgeFolder = null;
         if (Request.NeoForgeEntry is not null)
             Request.NeoForgeVersion = Request.NeoForgeVersion ?? Request.NeoForgeEntry.VersionName;
         if (Request.NeoForgeVersion is not null)
-            NeoForgeFolder = TempMcFolder + @"versions\neoforge-" + Request.NeoForgeVersion;
+            NeoForgeFolder = Path.Combine(TempMcFolder, "versions", "neoforge-" + Request.NeoForgeVersion);
         string CleanroomFolder = null;
         if (Request.CleanroomEntry is not null)
             Request.CleanroomVersion = Request.CleanroomVersion ?? Request.CleanroomEntry.VersionName;
         if (Request.CleanroomVersion is not null)
-            CleanroomFolder = TempMcFolder + @"versions\cleanroom-" + Request.CleanroomVersion;
+            CleanroomFolder = Path.Combine(TempMcFolder, "versions", "cleanroom-" + Request.CleanroomVersion);
         string FabricFolder = null;
         if (Request.FabricVersion is not null)
-            FabricFolder = TempMcFolder + @"versions\fabric-loader-" + Request.FabricVersion + "-" +
-                           Request.MinecraftName;
+            FabricFolder = Path.Combine(TempMcFolder, "versions", "fabric-loader-" + Request.FabricVersion + "-" +
+                           Request.MinecraftName);
         string LegacyFabricFolder = null;
         if (Request.LegacyFabricVersion is not null)
-            LegacyFabricFolder = TempMcFolder + @"versions\legacy-fabric-loader-" + Request.LegacyFabricVersion + "-" +
-                                 Request.MinecraftName;
+            LegacyFabricFolder = Path.Combine(TempMcFolder, "versions", "legacy-fabric-loader-" + Request.LegacyFabricVersion + "-" +
+                                 Request.MinecraftName);
         string QuiltFolder = null;
         if (Request.QuiltVersion is not null)
-            QuiltFolder = TempMcFolder + @"versions\quilt-loader-" + Request.QuiltVersion + "-" + Request.MinecraftName;
+            QuiltFolder = Path.Combine(TempMcFolder, "versions", "quilt-loader-" + Request.QuiltVersion + "-" + Request.MinecraftName);
         string LabyModFolder = null;
         if (Request.LabyModCommitRef is not null)
-            LabyModFolder = TempMcFolder + @"versions\labymod-" + Request.LabyModCommitRef + "-" +
-                            Request.MinecraftName;
+            LabyModFolder = Path.Combine(TempMcFolder, "versions", "labymod-" + Request.LabyModCommitRef + "-" +
+                            Request.MinecraftName);
         string LiteLoaderFolder = null;
         if (Request.LiteLoaderEntry is not null)
-            LiteLoaderFolder = TempMcFolder + @"versions\" + Request.MinecraftName + "-LiteLoader";
+            LiteLoaderFolder = Path.Combine(TempMcFolder, "versions", Request.MinecraftName + "-LiteLoader");
 
         // 判断 OptiFine 是否作为 Mod 进行下载
         var Modable = Request.FabricVersion is not null || Request.LegacyFabricVersion is not null ||
                       Request.ForgeEntry is not null || Request.NeoForgeEntry is not null ||
                       Request.LiteLoaderEntry is not null;
-        var ModsTempFolder = TempMcFolder + @"mods\";
+        var ModsTempFolder = Path.Combine(TempMcFolder, "mods") + @"\";
         var OptiFineAsMod = Request.OptiFineEntry is not null && Modable; // 选择了 OptiFine 与任意 Mod 加载器
         if (OptiFineAsMod)
         {
             ModBase.Log("[Download] OptiFine 将作为 Mod 进行下载");
             if (Request.LiteLoaderEntry != null)
-                OptiFineFolder = ModsTempFolder + Request.MinecraftName + "\\";
+                OptiFineFolder = Path.Combine(ModsTempFolder, Request.MinecraftName) + @"\";
             else
                 OptiFineFolder = ModsTempFolder;
         }
@@ -3848,7 +3847,7 @@ pause";
         ModBase.Log("[Download] 对应的原版版本：" + Request.MinecraftName);
 
         // 重复实例检查
-        if (File.Exists(InstanceFolder + Request.TargetInstanceName + ".json") && !IgnoreDump)
+        if (File.Exists(Path.Combine(InstanceFolder, Request.TargetInstanceName + ".json")) && !IgnoreDump)
         {
             ModMain.Hint("实例 " + Request.TargetInstanceName + " 已经存在！", ModMain.HintType.Critical);
             throw new ModBase.CancelledException();
@@ -3857,7 +3856,7 @@ pause";
         var LoaderList = new List<ModLoader.LoaderBase>();
         // 添加忽略标识
         LoaderList.Add(new ModLoader.LoaderTask<int, int>("添加忽略标识",
-                _ => ModBase.WriteFile(InstanceFolder + ".pclignore", "用于临时地在 PCL 的实例列表中屏蔽此实例。"))
+                _ => ModBase.WriteFile(Path.Combine(InstanceFolder, ".pclignore"), "用于临时地在 PCL 的实例列表中屏蔽此实例。"))
             { Show = false, Block = false });
         // Fabric API
         if (Request.FabricApi is not null)
@@ -3906,7 +3905,7 @@ pause";
             if (OptiFineAsMod)
                 LoaderList.Add(new ModLoader.LoaderCombo<string>("下载 OptiFine " + Request.OptiFineEntry.DisplayName,
                     McDownloadOptiFineSaveLoader(Request.OptiFineEntry,
-                        OptiFineFolder + Request.OptiFineEntry.NameFile))
+                        Path.Combine(OptiFineFolder, Request.OptiFineEntry.NameFile)))
                 {
                     Show = false,
                     ProgressWeight = 16d,
@@ -4001,11 +4000,11 @@ pause";
                 LegacyFabricFolder);
             Task.Progress = 0.2d;
             // 迁移文件
-            if (Directory.Exists(TempMcFolder + "libraries"))
-                ModBase.CopyDirectory(TempMcFolder + "libraries", ModMinecraft.McFolderSelected + "libraries");
+            if (Directory.Exists(Path.Combine(TempMcFolder, "libraries")))
+                ModBase.CopyDirectory(Path.Combine(TempMcFolder, "libraries"), Path.Combine(ModMinecraft.McFolderSelected, "libraries"));
             Task.Progress = 0.8d;
             // 创建 Mod 和资源包文件夹
-            var ModsFolder = new ModMinecraft.McInstance(InstanceFolder).PathIndie + @"mods\"; // 版本隔离信息在此时被决定
+            var ModsFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "mods") + @"\"; // 版本隔离信息在此时被决定
             if (Directory.Exists(ModsTempFolder))
             {
                 ModBase.CopyDirectory(ModsTempFolder, ModsFolder);
@@ -4016,7 +4015,7 @@ pause";
                 ModBase.Log("[Download] 自动创建 Mod 文件夹：" + ModsFolder);
             }
 
-            var ResourcepacksFolder = new ModMinecraft.McInstance(InstanceFolder).PathIndie + @"resourcepacks\";
+            var ResourcepacksFolder = Path.Combine(new ModMinecraft.McInstance(InstanceFolder).PathIndie, "resourcepacks") + @"\";
             Directory.CreateDirectory(ResourcepacksFolder);
             ModBase.Log("[Download] 自动创建资源包文件夹：" + ResourcepacksFolder);
         })
@@ -4054,7 +4053,7 @@ pause";
         }
 
         // 删除忽略标识
-        LoaderList.Add(new ModLoader.LoaderTask<int, int>("删除忽略标识", _ => File.Delete(InstanceFolder + ".pclignore"))
+        LoaderList.Add(new ModLoader.LoaderTask<int, int>("删除忽略标识", _ => File.Delete(Path.Combine(InstanceFolder, ".pclignore")))
             { Show = false });
         // 总加载器
         return LoaderList;
@@ -4121,21 +4120,21 @@ pause";
         if (!OutputFolder.EndsWithF(@"\"))
             OutputFolder += @"\";
         OutputName = ModBase.GetFolderNameFromPath(OutputFolder);
-        OutputJsonPath = OutputFolder + OutputName + ".json";
-        OutputJar = OutputFolder + OutputName + ".jar";
+        OutputJsonPath = Path.Combine(OutputFolder, OutputName + ".json");
+        OutputJar = Path.Combine(OutputFolder, OutputName + ".jar");
 
         if (!MinecraftFolder.EndsWithF(@"\"))
             MinecraftFolder += @"\";
         MinecraftName = ModBase.GetFolderNameFromPath(MinecraftFolder);
-        MinecraftJsonPath = MinecraftFolder + MinecraftName + ".json";
-        MinecraftJar = MinecraftFolder + MinecraftName + ".jar";
+        MinecraftJsonPath = Path.Combine(MinecraftFolder, MinecraftName + ".json");
+        MinecraftJar = Path.Combine(MinecraftFolder, MinecraftName + ".jar");
 
         if (HasOptiFine)
         {
             if (!OptiFineFolder.EndsWithF(@"\"))
                 OptiFineFolder += @"\";
             OptiFineName = ModBase.GetFolderNameFromPath(OptiFineFolder);
-            OptiFineJsonPath = OptiFineFolder + OptiFineName + ".json";
+            OptiFineJsonPath = Path.Combine(OptiFineFolder, OptiFineName + ".json");
         }
 
         if (HasForge)
@@ -4143,7 +4142,7 @@ pause";
             if (!ForgeFolder.EndsWithF(@"\"))
                 ForgeFolder += @"\";
             ForgeName = ModBase.GetFolderNameFromPath(ForgeFolder);
-            ForgeJsonPath = ForgeFolder + ForgeName + ".json";
+            ForgeJsonPath = Path.Combine(ForgeFolder, ForgeName + ".json");
         }
 
         if (HasNeoForge)
@@ -4151,7 +4150,7 @@ pause";
             if (!NeoForgeFolder.EndsWithF(@"\"))
                 NeoForgeFolder += @"\";
             NeoForgeName = ModBase.GetFolderNameFromPath(NeoForgeFolder);
-            NeoForgeJsonPath = NeoForgeFolder + NeoForgeName + ".json";
+            NeoForgeJsonPath = Path.Combine(NeoForgeFolder, NeoForgeName + ".json");
         }
 
         if (HasCleanroom)
@@ -4159,7 +4158,7 @@ pause";
             if (!CleanroomFolder.EndsWithF(@"\"))
                 CleanroomFolder += @"\";
             CleanroomName = ModBase.GetFolderNameFromPath(CleanroomFolder);
-            CleanroomJsonPath = CleanroomFolder + CleanroomName + ".json";
+            CleanroomJsonPath = Path.Combine(CleanroomFolder, CleanroomName + ".json");
         }
 
         if (HasLiteLoader)
@@ -4167,7 +4166,7 @@ pause";
             if (!LiteLoaderFolder.EndsWithF(@"\"))
                 LiteLoaderFolder += @"\";
             LiteLoaderName = ModBase.GetFolderNameFromPath(LiteLoaderFolder);
-            LiteLoaderJsonPath = LiteLoaderFolder + LiteLoaderName + ".json";
+            LiteLoaderJsonPath = Path.Combine(LiteLoaderFolder, LiteLoaderName + ".json");
         }
 
         if (HasFabric)
@@ -4175,7 +4174,7 @@ pause";
             if (!FabricFolder.EndsWithF(@"\"))
                 FabricFolder += @"\";
             FabricName = ModBase.GetFolderNameFromPath(FabricFolder);
-            FabricJsonPath = FabricFolder + FabricName + ".json";
+            FabricJsonPath = Path.Combine(FabricFolder, FabricName + ".json");
         }
 
         if (HasLegacyFabric)
@@ -4183,7 +4182,7 @@ pause";
             if (!LegacyFabricFolder.EndsWithF(@"\"))
                 LegacyFabricFolder += @"\";
             LegacyFabricName = ModBase.GetFolderNameFromPath(LegacyFabricFolder);
-            LegacyFabricJsonPath = LegacyFabricFolder + LegacyFabricName + ".json";
+            LegacyFabricJsonPath = Path.Combine(LegacyFabricFolder, LegacyFabricName + ".json");
         }
 
         if (HasQuilt)
@@ -4191,7 +4190,7 @@ pause";
             if (!QuiltFolder.EndsWithF(@"\"))
                 QuiltFolder += @"\";
             QuiltName = ModBase.GetFolderNameFromPath(QuiltFolder);
-            QuiltJsonPath = QuiltFolder + QuiltName + ".json";
+            QuiltJsonPath = Path.Combine(QuiltFolder, QuiltName + ".json");
         }
 
         if (HasLabyMod)
@@ -4199,7 +4198,7 @@ pause";
             if (!LabyModFolder.EndsWithF(@"\"))
                 LabyModFolder += @"\";
             LabyModName = ModBase.GetFolderNameFromPath(LabyModFolder);
-            LabyModJsonPath = LabyModFolder + LabyModName + ".json";
+            LabyModJsonPath = Path.Combine(LabyModFolder, LabyModName + ".json");
         }
 
         #endregion

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -196,7 +196,7 @@ public partial class PageInstanceCompResource : IRefreshable
         res.Loaders = RequireLoaders;
         res.CompPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         res.CompType = CurrentCompType;
         return res;
@@ -337,7 +337,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 加载根目录
             LoadPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         else
             // 加载当前文件夹
@@ -408,7 +408,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 获取根路径
             var rootPath = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             rootPath = Path.GetFullPath(rootPath.TrimEnd('\\'));
 
@@ -437,7 +437,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 返回到根目录
             LoadPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         else
             // 加载当前文件夹
@@ -534,7 +534,7 @@ public partial class PageInstanceCompResource : IRefreshable
             ModItems.Clear();
             var rootPath = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             rootPath = Path.GetFullPath(rootPath.TrimEnd('\\'));
 
@@ -939,7 +939,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 // 打开根目录
                 CompFilePath = PageInstanceLeft.Instance.PathIndie +
                                (PageInstanceLeft.Instance.Info.HasLabyMod
-                                   ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                                   ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                                    : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             else
                 // 打开当前子文件夹
@@ -1137,7 +1137,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 if (string.IsNullOrEmpty(TargetFolderPath))
                     CompFolder = targetInstance.PathIndie +
                                  (targetInstance.Info.HasLabyMod
-                                     ? @"labymod-neo\fabric\" + targetInstance.Info.VanillaName + @"\"
+                                     ? Path.Combine("labymod-neo", "fabric", targetInstance.Info.VanillaName) + @"\"
                                      : "") + @"mods\";
                 else
                     CompFolder = TargetFolderPath + @"\";
@@ -2082,7 +2082,7 @@ public partial class PageInstanceCompResource : IRefreshable
                     "资源更新：" + PageInstanceLeft.Instance.Name, InstallLoaders);
             var PathMods = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? @"labymod-neo\fabric\" + PageInstanceLeft.Instance.Info.VanillaName + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             Loader.OnStateChanged = _ =>
             {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -196,7 +196,7 @@ public partial class PageInstanceCompResource : IRefreshable
         res.Loaders = RequireLoaders;
         res.CompPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         res.CompType = CurrentCompType;
         return res;
@@ -337,7 +337,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 加载根目录
             LoadPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         else
             // 加载当前文件夹
@@ -408,7 +408,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 获取根路径
             var rootPath = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             rootPath = Path.GetFullPath(rootPath.TrimEnd('\\'));
 
@@ -437,7 +437,7 @@ public partial class PageInstanceCompResource : IRefreshable
             // 返回到根目录
             LoadPath = PageInstanceLeft.Instance.PathIndie +
                        (PageInstanceLeft.Instance.Info.HasLabyMod
-                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                           ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                            : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
         else
             // 加载当前文件夹
@@ -534,7 +534,7 @@ public partial class PageInstanceCompResource : IRefreshable
             ModItems.Clear();
             var rootPath = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             rootPath = Path.GetFullPath(rootPath.TrimEnd('\\'));
 
@@ -939,7 +939,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 // 打开根目录
                 CompFilePath = PageInstanceLeft.Instance.PathIndie +
                                (PageInstanceLeft.Instance.Info.HasLabyMod
-                                   ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                                   ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                                    : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             else
                 // 打开当前子文件夹
@@ -1137,10 +1137,10 @@ public partial class PageInstanceCompResource : IRefreshable
                 if (string.IsNullOrEmpty(TargetFolderPath))
                     CompFolder = targetInstance.PathIndie +
                                  (targetInstance.Info.HasLabyMod
-                                     ? Path.Combine("labymod-neo", "fabric", targetInstance.Info.VanillaName) + @"\"
+                                     ? Path.Combine("labymod-neo", "fabric", targetInstance.Info.VanillaName)
                                      : "") + @"mods\";
                 else
-                    CompFolder = TargetFolderPath + @"\";
+                    CompFolder = TargetFolderPath;
 
                 break;
             }
@@ -1151,7 +1151,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 if (string.IsNullOrEmpty(TargetFolderPath))
                     CompFolder = targetInstance.PathIndie + @"resourcepacks\";
                 else
-                    CompFolder = TargetFolderPath + @"\";
+                    CompFolder = TargetFolderPath;
 
                 break;
             }
@@ -1162,7 +1162,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 if (string.IsNullOrEmpty(TargetFolderPath))
                     CompFolder = targetInstance.PathIndie + @"shaderpacks\";
                 else
-                    CompFolder = TargetFolderPath + @"\";
+                    CompFolder = TargetFolderPath;
 
                 break;
             }
@@ -1173,7 +1173,7 @@ public partial class PageInstanceCompResource : IRefreshable
                 if (string.IsNullOrEmpty(TargetFolderPath))
                     CompFolder = targetInstance.PathIndie + @"schematics\";
                 else
-                    CompFolder = TargetFolderPath + @"\";
+                    CompFolder = TargetFolderPath;
 
                 break;
             }
@@ -2082,7 +2082,7 @@ public partial class PageInstanceCompResource : IRefreshable
                     "资源更新：" + PageInstanceLeft.Instance.Name, InstallLoaders);
             var PathMods = PageInstanceLeft.Instance.PathIndie +
                            (PageInstanceLeft.Instance.Info.HasLabyMod
-                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName) + @"\"
+                               ? Path.Combine("labymod-neo", "fabric", PageInstanceLeft.Instance.Info.VanillaName)
                                : "") + ModLocalComp.GetPathNameByCompType(CurrentCompType) + @"\";
             Loader.OnStateChanged = _ =>
             {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -720,7 +720,7 @@ public partial class PageInstanceExport : IRefreshable
 
         // 缓存所需参数
         var CacheFolder = ModMain.RequestTaskTempFolder();
-        var OverridesFolder = CacheFolder + @"modpack\overrides\";
+        var OverridesFolder = Path.Combine(CacheFolder, "modpack", "overrides") + @"\";
         var McInstance = PageInstanceLeft.Instance;
         var PathIndie = McInstance.PathIndie;
         var CheckHostedAssets = (bool)!CheckAdvancedInclude.Checked;
@@ -741,7 +741,7 @@ public partial class PageInstanceExport : IRefreshable
             Loaders.Add(new ModLoader.LoaderTask<int, int>("下载 PCL 正式版", Loader =>
             {
                 UpdateManager.DownloadLatestPCL(Loader);
-                ModBase.CopyFile(ModBase.PathTemp + "CE-Latest.exe", CacheFolder + "Plain Craft Launcher.exe");
+                ModBase.CopyFile(Path.Combine(ModBase.PathTemp, "CE-Latest.exe"), Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
             })
             {
                 ProgressWeight = 0.5d,
@@ -815,12 +815,12 @@ public partial class PageInstanceExport : IRefreshable
             ModBase.Log($"[Export] 复制 overrides 文件完成，有 {Loader.Output.Count} 个文件需要联网检查");
             Loader.Progress = 0.95d;
             // 复制追加内容到根目录
-            var BaseFolder = IncludePCL ? CacheFolder : CacheFolder + @"modpack\";
+            var BaseFolder = IncludePCL ? CacheFolder : Path.Combine(CacheFolder, "modpack") + @"\";
             foreach (var Line in AllExtraFiles)
                 if (Line.EndsWithF(@"\") || Line.EndsWithF("/"))
                 {
                     if (Directory.Exists(Line))
-                        ModBase.CopyDirectory(Line, BaseFolder + ModBase.GetFolderNameFromPath(Line) + @"\");
+                        ModBase.CopyDirectory(Line, Path.Combine(BaseFolder, ModBase.GetFolderNameFromPath(Line)) + @"\");
                     else
                         ModMain.Hint($"未找到配置文件中指定的文件夹：{Line}", ModMain.HintType.Critical);
                 }
@@ -835,7 +835,7 @@ public partial class PageInstanceExport : IRefreshable
 
             Loader.Progress = 0.97d;
             // 复制 PCL 实例设置
-            ModBase.CopyDirectory(McInstance.PathInstance + @"PCL\", OverridesFolder + @"PCL\");
+            ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL") + @"\", Path.Combine(OverridesFolder, "PCL") + @"\");
             #if RELEASE
                         '复制 PCL 本体
                         If IncludePCL Then CopyFile(ExePathWithName, CacheFolder & "Plain Craft Launcher.exe")
@@ -843,20 +843,20 @@ public partial class PageInstanceExport : IRefreshable
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)
             {
-                if (Directory.Exists(ModBase.ExePath + @"PCL\Pictures\"))
-                    ModBase.CopyDirectory(ModBase.ExePath + @"PCL\Pictures\", CacheFolder + @"PCL\Pictures\");
-                if (Directory.Exists(ModBase.ExePath + @"PCL\Musics\"))
-                    ModBase.CopyDirectory(ModBase.ExePath + @"PCL\Musics\", CacheFolder + @"PCL\Musics\");
-                if (Directory.Exists(ModBase.ExePath + @"PCL\Help\"))
-                    ModBase.CopyDirectory(ModBase.ExePath + @"PCL\Help\", CacheFolder + @"PCL\Help\");
-                if (File.Exists(ModBase.ExePath + @"PCL\Custom.xaml"))
-                    ModBase.CopyFile(ModBase.ExePath + @"PCL\Custom.xaml", CacheFolder + @"PCL\Custom.xaml");
-                if (File.Exists(ModBase.ExePath + @"PCL\Setup.ini"))
-                    ModBase.CopyFile(ModBase.ExePath + @"PCL\Setup.ini", CacheFolder + @"PCL\Setup.ini");
-                if (File.Exists(ModBase.ExePath + @"PCL\hints.txt"))
-                    ModBase.CopyFile(ModBase.ExePath + @"PCL\hints.txt", CacheFolder + @"PCL\hints.txt");
-                if (File.Exists(ModBase.ExePath + @"PCL\Logo.png"))
-                    ModBase.CopyFile(ModBase.ExePath + @"PCL\Logo.png", CacheFolder + @"PCL\Logo.png");
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Pictures\")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Pictures\"), Path.Combine(CacheFolder, @"PCL\Pictures\"));
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Musics\")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Musics\"), Path.Combine(CacheFolder, @"PCL\Musics\"));
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Help\")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Help\"), Path.Combine(CacheFolder, @"PCL\Help\"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Custom.xaml")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Custom.xaml"), Path.Combine(CacheFolder, @"PCL\Custom.xaml"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Setup.ini")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Setup.ini"), Path.Combine(CacheFolder, @"PCL\Setup.ini"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\hints.txt")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\hints.txt"), Path.Combine(CacheFolder, @"PCL\hints.txt"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Logo.png")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Logo.png"), Path.Combine(CacheFolder, @"PCL\Logo.png"));
             }
         })
         {
@@ -1033,7 +1033,7 @@ public partial class PageInstanceExport : IRefreshable
                     { "game", "minecraft" }, { "formatVersion", 1 }, { "versionId", PackVersion }, { "name", PackName },
                     { "summary", McInstance.Desc }, { "files", Files }, { "dependencies", Dependencies }
                 };
-                File.WriteAllText(CacheFolder + @"modpack\modrinth.index.json",
+                File.WriteAllText(Path.Combine(CacheFolder, @"modpack\modrinth.index.json"),
                     ResultJson.ToString(Formatting.Indented));
                 // 打包
                 Directory.CreateDirectory(ModBase.GetPathFromFullPath(PackPath));
@@ -1042,9 +1042,9 @@ public partial class PageInstanceExport : IRefreshable
                 if (IncludePCL)
                 {
                     // 首次压缩整合包
-                    ZipFile.CreateFromDirectory(CacheFolder + @"modpack\", CacheFolder + "modpack.mrpack");
+                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack") + @"\", Path.Combine(CacheFolder, "modpack.mrpack"));
                     Loader.Progress = 0.5d;
-                    Directory.Delete(CacheFolder + @"modpack\", true);
+                    Directory.Delete(Path.Combine(CacheFolder, "modpack") + @"\", true);
                     Loader.Progress = 0.6d;
                     // 二次压缩整合包
                     ZipFile.CreateFromDirectory(CacheFolder, PackPath);
@@ -1053,7 +1053,7 @@ public partial class PageInstanceExport : IRefreshable
                 else
                 {
                     // 直接压缩整合包
-                    ZipFile.CreateFromDirectory(CacheFolder + @"modpack\", PackPath);
+                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack") + @"\", PackPath);
                     Loader.Progress = 0.8d;
                 }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -720,7 +720,7 @@ public partial class PageInstanceExport : IRefreshable
 
         // 缓存所需参数
         var CacheFolder = ModMain.RequestTaskTempFolder();
-        var OverridesFolder = Path.Combine(CacheFolder, "modpack", "overrides") + @"\";
+        var OverridesFolder = Path.Combine(CacheFolder, "modpack", "overrides");
         var McInstance = PageInstanceLeft.Instance;
         var PathIndie = McInstance.PathIndie;
         var CheckHostedAssets = (bool)!CheckAdvancedInclude.Checked;
@@ -815,7 +815,7 @@ public partial class PageInstanceExport : IRefreshable
             ModBase.Log($"[Export] 复制 overrides 文件完成，有 {Loader.Output.Count} 个文件需要联网检查");
             Loader.Progress = 0.95d;
             // 复制追加内容到根目录
-            var BaseFolder = IncludePCL ? CacheFolder : Path.Combine(CacheFolder, "modpack") + @"\";
+            var BaseFolder = IncludePCL ? CacheFolder : Path.Combine(CacheFolder, "modpack");
             foreach (var Line in AllExtraFiles)
                 if (Line.EndsWithF(@"\") || Line.EndsWithF("/"))
                 {
@@ -835,7 +835,7 @@ public partial class PageInstanceExport : IRefreshable
 
             Loader.Progress = 0.97d;
             // 复制 PCL 实例设置
-            ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL") + @"\", Path.Combine(OverridesFolder, "PCL") + @"\");
+            ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
                         '复制 PCL 本体
                         If IncludePCL Then CopyFile(ExePathWithName, CacheFolder & "Plain Craft Launcher.exe")
@@ -843,20 +843,20 @@ public partial class PageInstanceExport : IRefreshable
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)
             {
-                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Pictures\")))
-                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Pictures\"), Path.Combine(CacheFolder, @"PCL\Pictures\"));
-                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Musics\")))
-                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Musics\"), Path.Combine(CacheFolder, @"PCL\Musics\"));
-                if (Directory.Exists(Path.Combine(ModBase.ExePath, @"PCL\Help\")))
-                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, @"PCL\Help\"), Path.Combine(CacheFolder, @"PCL\Help\"));
-                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Custom.xaml")))
-                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Custom.xaml"), Path.Combine(CacheFolder, @"PCL\Custom.xaml"));
-                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Setup.ini")))
-                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Setup.ini"), Path.Combine(CacheFolder, @"PCL\Setup.ini"));
-                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\hints.txt")))
-                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\hints.txt"), Path.Combine(CacheFolder, @"PCL\hints.txt"));
-                if (File.Exists(Path.Combine(ModBase.ExePath, @"PCL\Logo.png")))
-                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, @"PCL\Logo.png"), Path.Combine(CacheFolder, @"PCL\Logo.png"));
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, "PCL", "Pictures")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, "PCL", "Pictures"), Path.Combine(CacheFolder, "PCL", "Pictures"));
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, "PCL", "Musics")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, "PCL", "Musics"), Path.Combine(CacheFolder, "PCL", "Musics"));
+                if (Directory.Exists(Path.Combine(ModBase.ExePath, "PCL", "Help")))
+                    ModBase.CopyDirectory(Path.Combine(ModBase.ExePath, "PCL", "Help"), Path.Combine(CacheFolder, "PCL", "Help"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, "PCL", "Custom.xaml")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, "PCL", "Custom.xaml"), Path.Combine(CacheFolder, "PCL", "Custom.xaml"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, "PCL", "Setup.ini")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, "PCL", "Setup.ini"), Path.Combine(CacheFolder, "PCL", "Setup.ini"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, "PCL", "hints.txt")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, "PCL", "hints.txt"), Path.Combine(CacheFolder, "PCL", "hints.txt"));
+                if (File.Exists(Path.Combine(ModBase.ExePath, "PCL", "Logo.png")))
+                    ModBase.CopyFile(Path.Combine(ModBase.ExePath, "PCL", "Logo.png"), Path.Combine(CacheFolder, "PCL", "Logo.png"));
             }
         })
         {
@@ -1033,7 +1033,7 @@ public partial class PageInstanceExport : IRefreshable
                     { "game", "minecraft" }, { "formatVersion", 1 }, { "versionId", PackVersion }, { "name", PackName },
                     { "summary", McInstance.Desc }, { "files", Files }, { "dependencies", Dependencies }
                 };
-                File.WriteAllText(Path.Combine(CacheFolder, @"modpack\modrinth.index.json"),
+                File.WriteAllText(Path.Combine(CacheFolder, "modpack", "modrinth.index.json"),
                     ResultJson.ToString(Formatting.Indented));
                 // 打包
                 Directory.CreateDirectory(ModBase.GetPathFromFullPath(PackPath));
@@ -1042,9 +1042,9 @@ public partial class PageInstanceExport : IRefreshable
                 if (IncludePCL)
                 {
                     // 首次压缩整合包
-                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack") + @"\", Path.Combine(CacheFolder, "modpack.mrpack"));
+                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack"), Path.Combine(CacheFolder, "modpack.mrpack"));
                     Loader.Progress = 0.5d;
-                    Directory.Delete(Path.Combine(CacheFolder, "modpack") + @"\", true);
+                    Directory.Delete(Path.Combine(CacheFolder, "modpack"), true);
                     Loader.Progress = 0.6d;
                     // 二次压缩整合包
                     ZipFile.CreateFromDirectory(CacheFolder, PackPath);
@@ -1053,7 +1053,7 @@ public partial class PageInstanceExport : IRefreshable
                 else
                 {
                     // 直接压缩整合包
-                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack") + @"\", PackPath);
+                    ZipFile.CreateFromDirectory(Path.Combine(CacheFolder, "modpack"), PackPath);
                     Loader.Progress = 0.8d;
                 }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -6,7 +6,6 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
-using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
@@ -103,7 +102,7 @@ public partial class PageInstanceInstall
         // 删除 LabyMod Neo 文件
         if ((PageInstanceLeft.Instance.PathIndie ?? "") != (PageInstanceLeft.Instance.PathInstance ?? "") &&
             PageInstanceLeft.Instance.Info.HasLabyMod)
-            Directory.Delete(PageInstanceLeft.Instance.PathIndie + "labymod-neo", true);
+            Directory.Delete(System.IO.Path.Combine(PageInstanceLeft.Instance.PathIndie, "labymod-neo"), true);
         // 备份实例核心文件
         ModBase.CopyFile(PageInstanceLeft.Instance.PathInstance + PageInstanceLeft.Instance.Name + ".json",
             PageInstanceLeft.Instance.PathInstance + @"PCLInstallBackups\" + PageInstanceLeft.Instance.Name + ".json");

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -316,10 +316,10 @@ public partial class PageInstanceOverall
                 [new FolderNameValidator(ModMinecraft.McFolderSelected + "versions", ignoreCase: false)]);
             if (string.IsNullOrWhiteSpace(NewName))
                 return;
-            var NewPath = ModMinecraft.McFolderSelected + @"versions\" + NewName + @"\";
+            var NewPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", NewName) + @"\";
             // 获取临时中间名，以防止仅修改大小写的重命名失败
             var TempName = NewName + "_temp";
-            var TempPath = ModMinecraft.McFolderSelected + @"versions\" + TempName + @"\";
+            var TempPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", TempName) + @"\";
             var IsCaseChangedOnly = (NewName.ToLower() ?? "") == (OldName.ToLower() ?? "");
             // 重新加载实例 Json 信息，避免 HMCL 项被合并
             JObject JsonObject;
@@ -338,7 +338,7 @@ public partial class PageInstanceOverall
             FileSystem.RenameDirectory(OldPath, TempName);
             FileSystem.RenameDirectory(TempPath, NewName);
             // 清理 ini 缓存
-            ModBase.IniClearCache(PageInstanceLeft.Instance.PathIndie + "options.txt");
+            ModBase.IniClearCache(Path.Combine(PageInstanceLeft.Instance.PathIndie, "options.txt"));
             // 重命名 Jar 文件与 natives 文件夹
             // 不能进行遍历重命名，否则在实例名很短的时候容易误伤其他文件（Meloong-Git/#6443）
             if (Directory.Exists($"{NewPath}{OldName}-natives"))
@@ -691,7 +691,7 @@ public partial class PageInstanceOverall
                 {
                     var instancePath = PageInstanceLeft.Instance.PathInstance;
                     var instanceName = PageInstanceLeft.Instance.Name;
-                    ModBase.IniClearCache(PageInstanceLeft.Instance.PathIndie + "options.txt");
+                    ModBase.IniClearCache(Path.Combine(PageInstanceLeft.Instance.PathIndie, "options.txt"));
                     ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance)).InvalidateCache(
                         instancePath);
                     if (IsShiftPressed)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -316,10 +316,10 @@ public partial class PageInstanceOverall
                 [new FolderNameValidator(ModMinecraft.McFolderSelected + "versions", ignoreCase: false)]);
             if (string.IsNullOrWhiteSpace(NewName))
                 return;
-            var NewPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", NewName) + @"\";
+            var NewPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", NewName);
             // 获取临时中间名，以防止仅修改大小写的重命名失败
             var TempName = NewName + "_temp";
-            var TempPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", TempName) + @"\";
+            var TempPath = Path.Combine(ModMinecraft.McFolderSelected, "versions", TempName);
             var IsCaseChangedOnly = (NewName.ToLower() ?? "") == (OldName.ToLower() ?? "");
             // 重新加载实例 Json 信息，避免 HMCL 项被合并
             JObject JsonObject;

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
@@ -183,7 +183,7 @@ public partial class PageInstanceSaves : IRefreshable
                     // 检查文件夹是否仍然存在
                     if (!Directory.Exists(curFolder)) continue;
 
-                    var saveLogo = curFolder + @"\icon.png";
+                    var saveLogo = Path.Combine(curFolder, "icon.png");
                     var tmpCurFolder = curFolder;
                     if (File.Exists(saveLogo))
                     {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -96,7 +96,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
         res.GameVersion = PageInstanceLeft.Instance;
         res.Frm = null;
         res.Loaders = new[] { ModComp.CompLoaderType.Minecraft }.ToList();
-        res.CompPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
+        res.CompPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks");
         res.CompType = ModComp.CompType.DataPack;
         return res;
     }
@@ -176,7 +176,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
 
     public bool LoaderRun(ModLoader.LoaderFolderRunType Type)
     {
-        var LoadPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
+        var LoadPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks");
         return ModLoader.LoaderFolderRun(ModLocalComp.CompResourceListLoader, LoadPath, Type,
             LoaderInput: GetRequireLoaderData());
     }
@@ -544,7 +544,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
     {
         try
         {
-            var DatapackPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
+            var DatapackPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks");
             Directory.CreateDirectory(DatapackPath);
             ModBase.OpenExplorer(DatapackPath);
         }
@@ -610,7 +610,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
         // 执行安装
         try
         {
-            var DatapackFolder = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
+            var DatapackFolder = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks");
             Directory.CreateDirectory(DatapackFolder);
 
             foreach (var FilePath in FilePathList)
@@ -1229,7 +1229,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
             // 结束处理
             var Loader = new ModLoader.LoaderCombo<IEnumerable<ModLocalComp.LocalCompFile>>(
                 $"数据包更新：{ModBase.GetFolderNameFromPath(PageInstanceSavesLeft.CurrentSave)}", InstallLoaders);
-            var PathDatapacks = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
+            var PathDatapacks = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks");
 
             Loader.OnStateChanged = _ =>
             {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -96,7 +96,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
         res.GameVersion = PageInstanceLeft.Instance;
         res.Frm = null;
         res.Loaders = new[] { ModComp.CompLoaderType.Minecraft }.ToList();
-        res.CompPath = PageInstanceSavesLeft.CurrentSave + @"\datapacks\";
+        res.CompPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
         res.CompType = ModComp.CompType.DataPack;
         return res;
     }
@@ -176,7 +176,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
 
     public bool LoaderRun(ModLoader.LoaderFolderRunType Type)
     {
-        var LoadPath = PageInstanceSavesLeft.CurrentSave + @"\datapacks\";
+        var LoadPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
         return ModLoader.LoaderFolderRun(ModLocalComp.CompResourceListLoader, LoadPath, Type,
             LoaderInput: GetRequireLoaderData());
     }
@@ -544,7 +544,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
     {
         try
         {
-            var DatapackPath = PageInstanceSavesLeft.CurrentSave + @"\datapacks\";
+            var DatapackPath = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
             Directory.CreateDirectory(DatapackPath);
             ModBase.OpenExplorer(DatapackPath);
         }
@@ -610,7 +610,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
         // 执行安装
         try
         {
-            var DatapackFolder = PageInstanceSavesLeft.CurrentSave + @"\datapacks\";
+            var DatapackFolder = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
             Directory.CreateDirectory(DatapackFolder);
 
             foreach (var FilePath in FilePathList)
@@ -1178,7 +1178,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
                     continue;
                 // 添加到下载列表
                 var TempAddress = ModBase.PathTemp + @"DownloadedComp\" + File.FileName;
-                var RealAddress = PageInstanceSavesLeft.CurrentSave + @"\datapacks\" + File.FileName;
+                var RealAddress = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks", File.FileName);
                 FileList.Add(File.ToNetFile(TempAddress));
                 FileCopyList[TempAddress] = RealAddress;
             }
@@ -1229,7 +1229,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
             // 结束处理
             var Loader = new ModLoader.LoaderCombo<IEnumerable<ModLocalComp.LocalCompFile>>(
                 $"数据包更新：{ModBase.GetFolderNameFromPath(PageInstanceSavesLeft.CurrentSave)}", InstallLoaders);
-            var PathDatapacks = PageInstanceSavesLeft.CurrentSave + @"\datapacks\";
+            var PathDatapacks = Path.Combine(PageInstanceSavesLeft.CurrentSave, "datapacks") + @"\";
 
             Loader.OnStateChanged = _ =>
             {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceServer.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceServer.xaml.cs
@@ -88,7 +88,7 @@ public partial class PageInstanceServer : MyPageRight
 
         // Write back to NBT file
         if (!await NbtFileHandler.WriteTagInNbtFileAsync(clonedNbtData,
-                PageInstanceLeft.Instance.PathIndie + "servers.dat"))
+                Path.Combine(PageInstanceLeft.Instance.PathIndie, "servers.dat")))
         {
             ModMain.Hint("无法写入服务器数据文件", ModMain.HintType.Critical);
             return;
@@ -110,7 +110,7 @@ public partial class PageInstanceServer : MyPageRight
     {
         // Read NBT file
         var nbtData =
-            await NbtFileHandler.ReadTagInNbtFileAsync<NbtList>(PageInstanceLeft.Instance.PathIndie + "servers.dat",
+            await NbtFileHandler.ReadTagInNbtFileAsync<NbtList>(Path.Combine(PageInstanceLeft.Instance.PathIndie, "servers.dat"),
                 "servers");
         if (nbtData is null)
         {
@@ -136,7 +136,7 @@ public partial class PageInstanceServer : MyPageRight
         // Write updated NBT data
         var clonedNbtData = (NbtList)nbtData.Clone();
         if (!await NbtFileHandler.WriteTagInNbtFileAsync(clonedNbtData,
-                PageInstanceLeft.Instance.PathIndie + "servers.dat"))
+                Path.Combine(PageInstanceLeft.Instance.PathIndie, "servers.dat")))
         {
             ModMain.Hint("无法写入服务器数据文件", ModMain.HintType.Critical);
             return;
@@ -268,7 +268,7 @@ public partial class PageInstanceServer : MyPageRight
     {
         ServerList.Clear();
 
-        var serversFile = PageInstanceLeft.Instance.PathIndie + "servers.dat";
+        var serversFile = Path.Combine(PageInstanceLeft.Instance.PathIndie, "servers.dat");
         if (!File.Exists(serversFile))
             return;
 

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchLeft.xaml.cs
@@ -71,10 +71,10 @@ public partial class PageLaunchLeft
         {
             // 自动整合包安装：准备
             string PackInstallPath = null;
-            if (File.Exists(ModBase.ExePath + "modpack.zip"))
-                PackInstallPath = ModBase.ExePath + "modpack.zip";
-            if (File.Exists(ModBase.ExePath + "modpack.mrpack"))
-                PackInstallPath = ModBase.ExePath + "modpack.mrpack";
+            if (File.Exists(Path.Combine(ModBase.ExePath, "modpack.zip")))
+                PackInstallPath = Path.Combine(ModBase.ExePath, "modpack.zip");
+            if (File.Exists(Path.Combine(ModBase.ExePath, "modpack.mrpack")))
+                PackInstallPath = Path.Combine(ModBase.ExePath, "modpack.mrpack");
             if (PackInstallPath is not null)
             {
                 ModBase.Log("[Launch] 需自动安装整合包：" + PackInstallPath, ModBase.LogLevel.Debug);

--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
@@ -113,7 +113,7 @@ public partial class PageSelectLeft : IRefreshable
                         AddMenuItem("Open", "打开", ICON_OPEN, null, ModMain.FrmSelectLeft.Open_Click);
                         AddMenuItem("Refresh", "刷新", ICON_REFRESH, null, ModMain.FrmSelectLeft.Refresh_Click);
                         AddMenuItem("Delete",
-                            ModMinecraft.McFolderList.Count == 1 && folder.Location == ModBase.ExePath + ".minecraft\\"
+                            ModMinecraft.McFolderList.Count == 1 && folder.Location == Path.Combine(ModBase.ExePath, ".minecraft") + @"\"
                                 ? "清空"
                                 : "删除", ICON_DELETE, new Thickness(0, 0, 0, 2), ModMain.FrmSelectLeft.Delete_Click);
                         break;
@@ -206,7 +206,7 @@ public partial class PageSelectLeft : IRefreshable
             });
 
             // 创建新文件夹按钮
-            if (!Directory.Exists(ModBase.ExePath + ".minecraft\\"))
+            if (!Directory.Exists(Path.Combine(ModBase.ExePath, ".minecraft")))
             {
                 var itemCreate = new MyListItem
                 {
@@ -418,7 +418,7 @@ public partial class PageSelectLeft : IRefreshable
 
                 if (!ModBase.CheckPermission(FolderPath + @"versions\"))
                     foreach (var Folder in new DirectoryInfo(FolderPath).GetDirectories())
-                        if (ModBase.CheckPermission(Folder.FullName + @"\versions\"))
+                        if (ModBase.CheckPermission(Path.Combine(Folder.FullName, "versions") + @"\"))
                         {
                             FolderPath = Folder.FullName + @"\";
                             break;
@@ -521,8 +521,8 @@ public partial class PageSelectLeft : IRefreshable
                     if (Directory.Exists(Folder.Location + @"versions\"))
                         foreach (var Version in new DirectoryInfo(Folder.Location + @"versions\")
                                      .EnumerateDirectories())
-                            if (Directory.Exists(Version.FullName + @"\PCL\"))
-                                Directory.Delete(Version.FullName + @"\PCL\", true);
+                            if (Directory.Exists(Path.Combine(Version.FullName, "PCL") + @"\"))
+                                Directory.Delete(Path.Combine(Version.FullName, "PCL") + @"\", true);
 
                     break;
                 }
@@ -648,7 +648,7 @@ public partial class PageSelectLeft : IRefreshable
 
     public static void RefreshCurrent(string Folder)
     {
-        ModBase.WriteIni(Folder + "PCL.ini", "InstanceCache", ""); // 删除缓存以强制要求下一次加载时更新列表
+        ModBase.WriteIni(Path.Combine(Folder, "PCL.ini"), "InstanceCache", "");
         if ((Folder ?? "") == (ModMinecraft.McFolderSelected ?? ""))
             ModLoader.LoaderFolderRun(ModMinecraft.McInstanceListLoader, ModMinecraft.McFolderSelected,
                 ModLoader.LoaderFolderRunType.ForceRun, 1, @"versions\");

--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
@@ -418,7 +418,7 @@ public partial class PageSelectLeft : IRefreshable
 
                 if (!ModBase.CheckPermission(FolderPath + @"versions\"))
                     foreach (var Folder in new DirectoryInfo(FolderPath).GetDirectories())
-                        if (ModBase.CheckPermission(Path.Combine(Folder.FullName, "versions") + @"\"))
+                        if (ModBase.CheckPermission(Path.Combine(Folder.FullName, "versions")))
                         {
                             FolderPath = Folder.FullName + @"\";
                             break;
@@ -521,8 +521,8 @@ public partial class PageSelectLeft : IRefreshable
                     if (Directory.Exists(Folder.Location + @"versions\"))
                         foreach (var Version in new DirectoryInfo(Folder.Location + @"versions\")
                                      .EnumerateDirectories())
-                            if (Directory.Exists(Path.Combine(Version.FullName, "PCL") + @"\"))
-                                Directory.Delete(Path.Combine(Version.FullName, "PCL") + @"\", true);
+                            if (Directory.Exists(Path.Combine(Version.FullName, "PCL")))
+                                Directory.Delete(Path.Combine(Version.FullName, "PCL"), true);
 
                     break;
                 }

--- a/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -540,7 +541,7 @@ public partial class PageSelectRight
             {
                 case 1:
                 {
-                    ModBase.IniClearCache(instance.PathIndie + "options.txt");
+                    ModBase.IniClearCache(Path.Combine(instance.PathIndie, "options.txt"));
                     ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance)).InvalidateCache(
                         instance.PathInstance);
                     if (IsShiftPressed)


### PR DESCRIPTION
> Partly Generated with Deepseek-v4-pro

## Summary by Sourcery

在 Minecraft 的下载、实例、整合包、崩溃处理和启动等模块中重构文件系统路径处理，将手动字符串拼接统一改为使用 `Path.Combine` 和相关辅助方法。

增强点：
- 在下载、启动、实例管理、整合包安装、崩溃报告以及组件/资源管理代码中，统一使用 `Path.Combine` 和相关工具来构建文件和目录路径。
- 提高针对 Minecraft 文件夹、库、资源（assets）、natives、临时/缓存目录和配置文件等路径处理的健壮性和可读性。
- 在采用新的路径构建方式的同时，移除或调整部分冗余的 `using` 和字面量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor filesystem path handling across Minecraft download, instance, modpack, crash, and launch modules to use Path.Combine and related helpers instead of manual string concatenation.

Enhancements:
- Standardize construction of file and directory paths using Path.Combine and related utilities throughout download, launch, instance management, modpack installation, crash reporting, and component/resource management code.
- Improve robustness and readability of path handling for Minecraft folders, libraries, assets, natives, temp/cache directories, and configuration files.
- Remove or adjust a few redundant usings and literals while aligning code with the new path-building approach.

</details>