### PR TITLE
chore: remove .vb from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿[*.{cs,vb}]
+﻿[*.cs]
 
 # IDE0028: 简化集合初始化
 dotnet_style_collection_initializer = true:silent


### PR DESCRIPTION
## Summary by Sourcery

杂务：
- 从 `.editorconfig` 中移除特定于 `.vb` 的配置项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove .vb-specific configuration entries from .editorconfig.

</details>