### PR TITLE
feat: 添加 AI 崩溃分析功能及相关配置

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -102,6 +102,18 @@ public static partial class Config
         // [ConfigItem<int>("ToolUpdateAlpha", 0, ConfigSource.SharedEncrypt)] public partial int Alpha { get; set; }
         [ConfigItem<bool>("ToolUpdateRelease", false)] public partial bool ReleaseNotification { get; set; }
         [ConfigItem<bool>("ToolUpdateSnapshot", false)] public partial bool SnapshotNotification { get; set; }
+
+        /// <summary>
+        /// AI 崩溃分析配置。
+        /// </summary>
+        [ConfigGroup("AI")] partial class AIConfigGroup
+        {
+            [ConfigItem<bool>("ToolAiAnalysisEnabled", false)] public partial bool Enabled { get; set; }
+            [ConfigItem<int>("ToolAiApiType", 0)] public partial int ApiType { get; set; }
+            [ConfigItem<string>("ToolAiBaseUrl", "https://api.openai.com/v1")] public partial string BaseUrl { get; set; }
+            [ConfigItem<string>("ToolAiModelId", "gpt-5.2")] public partial string ModelId { get; set; }
+            [ConfigItem<string>("ToolAiApiKey", "", ConfigSource.SharedEncrypt)] public partial string ApiKey { get; set; }
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgAiAnalysis.xaml
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgAiAnalysis.xaml
@@ -1,0 +1,62 @@
+<Grid x:Class="PCL.MyMsgAiAnalysis"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="clr-namespace:PCL"
+      xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+      RenderTransformOrigin="0,0.5" UseLayoutRounding="True" SnapsToDevicePixels="True"
+      MinWidth="480" MaxWidth="760" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="25">
+    <Grid.RenderTransform>
+        <TransformGroup>
+            <RotateTransform x:Name="TransformRotate" Angle="-4" />
+            <TranslateTransform x:Name="TransformPos" X="0" Y="40" />
+        </TransformGroup>
+    </Grid.RenderTransform>
+    <Border Name="PanBorder" CornerRadius="7" Background="{DynamicResource ColorBrushBackground}"
+            MouseLeftButtonDown="Drag">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource ColorObjectMsgBoxShadow}" BlurRadius="20" ShadowDepth="2"
+                              RenderingBias="Performance" Opacity="0.8" x:Name="EffectShadow" />
+        </Border.Effect>
+        <Grid Name="PanMain" VerticalAlignment="Top" Margin="22,22,22,23">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="2" />
+                <RowDefinition Height="13" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" FontSize="23" TextTrimming="None" Foreground="{DynamicResource ColorBrush2}"
+                       HorizontalAlignment="Left" Name="LabTitle" Margin="7,-1,70,9" Text="AI 崩溃分析"
+                       VerticalAlignment="Top" SnapsToDevicePixels="False" UseLayoutRounding="False"
+                       MouseLeftButtonDown="Drag" />
+            <Rectangle x:Name="ShapeLine" Grid.Row="1" Height="2" Fill="{Binding Foreground, ElementName=LabTitle}" />
+            <Grid Grid.Row="3" Margin="0,0,0,17">
+                <local:MyLoading x:Name="Loading" Width="280" Height="130" HorizontalAlignment="Center"
+                                 VerticalAlignment="Center" Text="AI 正在分析" TextError="AI 分析失败"
+                                 ShowProgress="False" />
+                <StackPanel x:Name="PanError" Visibility="Collapsed" Margin="7,0,7,0">
+                    <TextBlock Text="AI 分析失败" FontSize="16" Foreground="{DynamicResource ColorBrushRedLight}"
+                               Margin="0,0,0,8" />
+                    <TextBlock x:Name="LabError" TextWrapping="Wrap" Foreground="{DynamicResource ColorBrush1}"
+                               FontSize="14" LineHeight="18" />
+                </StackPanel>
+                <local:MyScrollViewer x:Name="PanResult" Visibility="Collapsed" MaxHeight="480"
+                                      Padding="0,0,7,0" VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled" DeltaMult="0.7">
+                    <markdig:MarkdownViewer VerticalAlignment="Top" Name="LabResult"
+                                            Foreground="{DynamicResource ColorBrush1}" FontWeight="Normal" />
+                </local:MyScrollViewer>
+            </Grid>
+            <StackPanel Grid.Row="4" Name="PanBtn" VerticalAlignment="Top" HorizontalAlignment="Right"
+                        Margin="150,0,8,0" Orientation="Horizontal">
+                <local:MyButton ColorType="Normal" x:FieldModifier="public" Text="关闭" x:Name="BtnClose"
+                                Margin="12,0,0,0" Click="BtnClose_Click" TextPadding="7"
+                                SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False" />
+                <local:MyButton ColorType="Normal" x:FieldModifier="public" Text="复制结果" x:Name="BtnCopy"
+                                Margin="12,0,0,0" Click="BtnCopy_Click" TextPadding="7"
+                                SnapsToDevicePixels="False" Padding="5,0" UseLayoutRounding="False"
+                                Visibility="Collapsed" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Grid>

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgAiAnalysis.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgAiAnalysis.xaml.cs
@@ -1,0 +1,154 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using PCL.Core.UI.Controls;
+
+namespace PCL;
+
+public partial class MyMsgAiAnalysis
+{
+    private readonly ModMain.MyMsgBoxConverter MyConverter;
+    private readonly ModLoader.LoaderTask<string, string> Task;
+    private readonly int Uuid = ModBase.GetUuid();
+    private bool IsStarted;
+    private string ResultText = "";
+
+    public MyMsgAiAnalysis(ModMain.MyMsgBoxConverter converter)
+    {
+        InitializeComponent();
+        BtnClose.Name += ModBase.GetUuid();
+        BtnCopy.Name += ModBase.GetUuid();
+        MyConverter = converter;
+        LabTitle.Text = converter.Title;
+        ShapeLine.StrokeThickness = ModBase.GetWPFSize(1d);
+
+        Task = new ModLoader.LoaderTask<string, string>("AI 崩溃分析", loader =>
+        {
+            loader.Progress = 0.05d;
+            loader.Output = CrashAiAnalyzer.Analyze(loader.Input);
+            loader.Progress = 1d;
+        }, Priority: ThreadPriority.BelowNormal);
+        Task.OnStateChangedUi += Task_OnStateChangedUi;
+        Loading.State = Task;
+
+        Loaded += Load;
+    }
+
+    private void Load(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            BtnClose.Focus();
+            Opacity = 0d;
+            ModAnimation.AniStart(
+                ModAnimation.AaColor(ModMain.FrmMain.PanMsgBackground, BlurBorder.BackgroundProperty,
+                    new ModBase.MyColor(90d, 0d, 0d, 0d) - ModMain.FrmMain.PanMsgBackground.Background, 200),
+                "PanMsgBackground Background");
+            ModAnimation.AniStart(
+                new[]
+                {
+                    ModAnimation.AaOpacity(this, 1d, 120, 60),
+                    ModAnimation.AaDouble(i => TransformPos.Y += (double)i,
+                        -TransformPos.Y, 300, 60, new ModAnimation.AniEaseOutBack(ModAnimation.AniEasePower.Weak)),
+                    ModAnimation.AaDouble(i => TransformRotate.Angle += (double)i,
+                        -TransformRotate.Angle, 300, 60,
+                        new ModAnimation.AniEaseOutFluent(ModAnimation.AniEasePower.Weak))
+                }, "MyMsgBox " + Uuid);
+
+            if (!IsStarted)
+            {
+                IsStarted = true;
+                Task.Start(MyConverter.Content?.ToString() ?? "");
+            }
+
+            ModBase.Log("[Control] AI 崩溃分析弹窗：" + CrashAiAnalyzer.ApiTypeName);
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "AI 崩溃分析弹窗加载失败", ModBase.LogLevel.Hint);
+        }
+    }
+
+    private void Task_OnStateChangedUi(ModLoader.LoaderBase loader, ModBase.LoadState newState,
+        ModBase.LoadState oldState)
+    {
+        if (newState == ModBase.LoadState.Finished)
+        {
+            ResultText = Task.Output;
+            LabResult.Markdown = ResultText;
+            Loading.Visibility = Visibility.Collapsed;
+            PanError.Visibility = Visibility.Collapsed;
+            PanResult.Visibility = Visibility.Visible;
+            BtnCopy.Visibility = Visibility.Visible;
+        }
+        else if (newState == ModBase.LoadState.Failed)
+        {
+            var ex = loader.Error;
+            while (ex?.InnerException is not null)
+                ex = ex.InnerException;
+
+            LabError.Text = ex?.Message ?? "未知错误";
+            Loading.Visibility = Visibility.Collapsed;
+            PanResult.Visibility = Visibility.Collapsed;
+            PanError.Visibility = Visibility.Visible;
+        }
+    }
+
+    private void Close()
+    {
+        MyConverter.IsExited = true;
+        try
+        {
+            ComponentDispatcher.PopModal();
+        }
+        catch
+        {
+        }
+
+        ModAnimation.AniStart(new[]
+        {
+            ModAnimation.AaCode(() =>
+            {
+                if (!ModMain.WaitingMyMsgBox.Any())
+                    ModAnimation.AniStart(ModAnimation.AaColor(ModMain.FrmMain.PanMsgBackground,
+                        BlurBorder.BackgroundProperty,
+                        new ModBase.MyColor(0d, 0d, 0d, 0d) - ModMain.FrmMain.PanMsgBackground.Background, 200,
+                        Ease: new ModAnimation.AniEaseOutFluent(ModAnimation.AniEasePower.Weak)));
+            }, 30),
+            ModAnimation.AaOpacity(this, -Opacity, 80, 20),
+            ModAnimation.AaDouble(i => TransformPos.Y += (double)i, 20d - TransformPos.Y,
+                150, 0, new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaDouble(i => TransformRotate.Angle += (double)i,
+                6d - TransformRotate.Angle, 150, 0, new ModAnimation.AniEaseInFluent(ModAnimation.AniEasePower.Weak)),
+            ModAnimation.AaCode(() => ((Grid)Parent).Children.Remove(this), After: true)
+        }, "MyMsgBox " + Uuid);
+    }
+
+    public void BtnClose_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (MyConverter.IsExited)
+            return;
+        Close();
+    }
+
+    public void BtnCopy_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(ResultText))
+            return;
+        ModBase.ClipboardSet(ResultText);
+    }
+
+    private void Drag(object sender, MouseButtonEventArgs e)
+    {
+        try
+        {
+            if (e.LeftButton == MouseButtonState.Pressed && e.GetPosition(ShapeLine).Y <= 2d)
+                ModMain.FrmMain.DragMove();
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "拖拽移动失败", ModBase.LogLevel.Hint);
+        }
+    }
+}

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -1478,6 +1478,7 @@ public partial class FormMain
         SetupUpdate = 8,
         SetupJava = 9,
         SetupLauncherMisc = 10,
+        SetupAI = 11,
 
         ToolsGameLink = 1,
         ToolsLauncherHelp = 2,

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -1186,21 +1186,71 @@ public class CrashAnalyzer
         return AnalyzeModName(Keywords) ?? Keywords;
     }
 
+    private string BuildAiAnalysisText(string resultText)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("PCL 已完成的本地崩溃分析：");
+        builder.AppendLine(resultText);
+        builder.AppendLine();
+        if (_version is not null)
+        {
+            builder.AppendLine("实例信息：");
+            builder.AppendLine("Name: " + _version.Name);
+            builder.AppendLine("PathIndie: " + _version.PathIndie);
+            builder.AppendLine();
+        }
+
+        AppendAiLogPart(builder, "Minecraft 日志", LogMc);
+        AppendAiLogPart(builder, "Minecraft Debug 日志", LogMcDebug);
+        AppendAiLogPart(builder, "崩溃报告", LogCrash);
+        AppendAiLogPart(builder, "JVM hs_err 日志", LogHs);
+        return FilterAiLog(builder.ToString());
+    }
+
+    private static void AppendAiLogPart(StringBuilder builder, string title, string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return;
+        builder.AppendLine("===== " + title + " =====");
+        builder.AppendLine(content);
+        builder.AppendLine();
+    }
+
+    private static string FilterAiLog(string raw)
+    {
+        try
+        {
+            raw = ModMinecraft.FilterAccessToken(raw, '*');
+            raw = ModMinecraft.FilterUserName(raw, '*');
+        }
+        catch
+        {
+        }
+
+        raw = Regex.Replace(raw, @"(?i)(authorization\s*:\s*bearer\s+)[^\s]+", "$1********");
+        raw = Regex.Replace(raw, @"(?i)((access[_-]?token|refresh[_-]?token)\s*[:=]\s*)[^\s,;]+", "$1********");
+        return raw;
+    }
+
     /// <summary>
-    ///     弹出崩溃弹窗，并指导导出崩溃报告。
+    ///     Shows the crash dialog and guides exporting the crash report.
     /// </summary>
     public void Output(bool IsHandAnalyze, List<string> ExtraFiles = null)
     {
-        // 弹窗提示
+        // Dialog prompt
         ModMain.FrmMain.ShowWindowToTop();
         var resultText = GetAnalyzeResult(IsHandAnalyze);
-        // 确定是否是加载器版本不兼容问题
-        var isModLoaderIncompatible = _version is not null && resultText.StartsWith("Mod 加载器版本与 Mod 不兼容");
-        // 弹窗选择：查看日志
-        switch (ModMain.MyMsgBox(resultText, IsHandAnalyze ? "错误报告分析结果" : "Minecraft 出现错误", "确定",
-                    IsHandAnalyze || DirectFile is null ? "" : isModLoaderIncompatible ? "前往修改" : "查看日志",
+        var isModLoaderIncompatible = _version is not null &&
+                                      resultText.StartsWith("Mod \u52a0\u8f7d\u5668\u7248\u672c\u4e0e Mod \u4e0d\u517c\u5bb9");
+        var isAiEnabled = CrashAiAnalyzer.IsEnabled;
+        var button1 = isAiEnabled ? "AI 分析" : "确定";
+        var button2 = isAiEnabled && (IsHandAnalyze || DirectFile is null)
+            ? "确定"
+            : IsHandAnalyze || DirectFile is null ? "" : isModLoaderIncompatible ? "前往修改" : "查看日志";
+        switch (ModMain.MyMsgBox(resultText, IsHandAnalyze ? "错误报告分析结果" : "Minecraft 出现错误", button1,
+                    button2,
                     IsHandAnalyze ? "" : "导出错误报告",
-                    Button2Action: IsHandAnalyze || DirectFile is null || isModLoaderIncompatible
+                    Button2Action: button2 != "查看日志"
                         ? null
                         : new Action(() =>
                         {
@@ -1216,8 +1266,15 @@ public class CrashAnalyzer
                             }
                         })))
         {
+            case 1 when isAiEnabled:
+            {
+                CrashAiAnalyzer.Start(BuildAiAnalysisText(resultText));
+                break;
+            }
             case 2:
             {
+                if (isAiEnabled && (IsHandAnalyze || DirectFile is null))
+                    break;
                 // 弹窗选择：前往修改
                 PageInstanceLeft.Instance = _version;
                 ModBase.RunInUi(() =>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrashAi.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrashAi.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PCL.Core.App;
+using PCL.Network;
+
+namespace PCL;
+
+public static class CrashAiAnalyzer
+{
+    private const int MaxLogLength = 90000;
+    private const string SystemPrompt = """
+        你是 Minecraft 崩溃日志分析助手。请用简体中文回答，语气清晰克制。
+        先给出最可能结论，再列出证据、建议操作和仍需补充的信息。
+        不要编造日志中没有的事实；如果信息不足，请明确说明。
+        优先识别 Mod 冲突、缺失依赖、Java/显卡/内存问题、启动参数问题和版本不兼容。
+        """;
+
+    public static bool IsEnabled => Config.Tool.AI.Enabled;
+
+    public static void Start(string logText)
+    {
+        if (!Config.Tool.AI.Enabled)
+            return;
+
+        if (string.IsNullOrWhiteSpace(Config.Tool.AI.ApiKey))
+        {
+            ModMain.MyMsgBox("请先在 设置 → 工具 → AI 中填写 API Key。", "AI 分析未配置");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Config.Tool.AI.BaseUrl) || string.IsNullOrWhiteSpace(Config.Tool.AI.ModelId))
+        {
+            ModMain.MyMsgBox("请先在 设置 → 工具 → AI 中填写 Base URL 和 Model ID。", "AI 分析未配置");
+            return;
+        }
+
+        ModMain.ShowCrashAiAnalysis(TrimLog(logText));
+    }
+
+    public static string Analyze(string logText)
+    {
+        return Config.Tool.AI.ApiType switch
+        {
+            1 => AnalyzeWithChatCompletions(logText),
+            _ => AnalyzeWithResponses(logText)
+        };
+    }
+
+    public static string ApiTypeName => Config.Tool.AI.ApiType == 1 ? "Chat Completions API" : "Responses API";
+
+    private static string AnalyzeWithResponses(string logText)
+    {
+        var payload = new JObject
+        {
+            ["model"] = Config.Tool.AI.ModelId.Trim(),
+            ["instructions"] = SystemPrompt,
+            ["input"] = logText,
+            ["max_output_tokens"] = 1800
+        };
+
+        var json = RequestJson(GetEndpoint(Config.Tool.AI.BaseUrl, "responses"), payload);
+        var text = json["output_text"]?.ToString();
+        if (!string.IsNullOrWhiteSpace(text))
+            return text;
+
+        var parts = json["output"]?
+            .SelectMany(item => item["content"] ?? new JArray())
+            .Where(content => content["type"]?.ToString() == "output_text")
+            .Select(content => content["text"]?.ToString())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+        if (parts is { Count: > 0 })
+            return string.Join("\n\n", parts);
+
+        throw new Exception("OpenAI 返回中没有可显示的文本内容。");
+    }
+
+    private static string AnalyzeWithChatCompletions(string logText)
+    {
+        var payload = new JObject
+        {
+            ["model"] = Config.Tool.AI.ModelId.Trim(),
+            ["messages"] = new JArray
+            {
+                new JObject
+                {
+                    ["role"] = "system",
+                    ["content"] = SystemPrompt
+                },
+                new JObject
+                {
+                    ["role"] = "user",
+                    ["content"] = logText
+                }
+            },
+            ["max_tokens"] = 1800
+        };
+
+        var json = RequestJson(GetEndpoint(Config.Tool.AI.BaseUrl, "chat/completions"), payload);
+        var content = json["choices"]?.FirstOrDefault()?["message"]?["content"];
+        if (content?.Type == JTokenType.String && !string.IsNullOrWhiteSpace(content.ToString()))
+            return content.ToString();
+
+        if (content is JArray parts)
+        {
+            var text = parts
+                .Select(part => part["text"]?.ToString())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+            if (text.Count > 0)
+                return string.Join("\n\n", text);
+        }
+
+        throw new Exception("OpenAI 兼容接口返回中没有可显示的文本内容。");
+    }
+
+    private static JObject RequestJson(string endpoint, JObject payload)
+    {
+        try
+        {
+            var response = Requester.Fetch(endpoint, new FetchParam
+            {
+                Method = "POST",
+                Content = payload.ToString(Formatting.None),
+                ContentType = "application/json",
+                Accept = "application/json",
+                Encoding = Encoding.UTF8,
+                Timeout = 120000,
+                Headers = new Dictionary<string, string>
+                {
+                    ["Authorization"] = "Bearer " + Config.Tool.AI.ApiKey.Trim()
+                }
+            });
+
+            return JObject.Parse(response);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"请求 {ApiTypeName} 失败（{endpoint}）", ex);
+        }
+    }
+
+    private static string GetEndpoint(string baseUrl, string relativeEndpoint)
+    {
+        var url = baseUrl.Trim().TrimEnd('/');
+        url = RemoveEndpointSuffix(url, "/responses");
+        url = RemoveEndpointSuffix(url, "/chat/completions");
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            uri.Host.Equals("api.openai.com", StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(uri.AbsolutePath.Trim('/')))
+            url += "/v1";
+
+        return $"{url}/{relativeEndpoint}";
+    }
+
+    private static string RemoveEndpointSuffix(string url, string suffix)
+    {
+        return url.EndsWith(suffix, StringComparison.OrdinalIgnoreCase) ? url[..^suffix.Length] : url;
+    }
+
+    private static string TrimLog(string logText)
+    {
+        if (logText.Length <= MaxLogLength)
+            return logText;
+        return logText[..(MaxLogLength / 2)] +
+               "\n\n...... 日志过长，中间部分已省略 ......\n\n" +
+               logText[^((MaxLogLength / 2) - 100)..];
+    }
+}

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -64,6 +64,7 @@ public static class ModMain
     public static PageSetupLog? FrmSetupLog;
     public static PageSetupFeedback? FrmSetupFeedback;
     public static PageSetupGameLink? FrmSetupGameLink;
+    public static PageSetupAI? FrmSetupAI;
     public static PageSetupLauncherMisc? FrmSetupLauncherMisc;
     public static PageLoginAuth? FrmLoginAuth;
     public static PageLoginMs? FrmLoginMs;
@@ -546,7 +547,20 @@ public static class ModMain
         Select,
         Input,
         Login,
-        Markdown
+        Markdown,
+        AiAnalysis
+    }
+
+    public static void ShowCrashAiAnalysis(string logText)
+    {
+        WaitingMyMsgBox.Add(new MyMsgBoxConverter
+        {
+            Type = MyMsgBoxType.AiAnalysis,
+            Title = "AI 崩溃分析",
+            Content = logText
+        });
+        if (ModBase.RunInUi())
+            MyMsgBoxTick();
     }
 
     /// <summary>
@@ -845,6 +859,11 @@ public static class ModMain
                     case MyMsgBoxType.Markdown:
                     {
                         FrmMain.PanMsg.Children.Add(new MyMsgMarkdown(WaitingMyMsgBox[0]));
+                        break;
+                    }
+                    case MyMsgBoxType.AiAnalysis:
+                    {
+                        FrmMain.PanMsg.Children.Add(new MyMsgAiAnalysis(WaitingMyMsgBox[0]));
                         break;
                     }
                 }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -837,8 +837,9 @@ public partial class PageInstanceExport : IRefreshable
             // 复制 PCL 实例设置
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
-                        '复制 PCL 本体
-                        If IncludePCL Then CopyFile(ExePathWithName, CacheFolder & "Plain Craft Launcher.exe")
+            // 复制 PCL 本体
+            if (IncludePCL)
+                ModBase.CopyFile(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -837,9 +837,8 @@ public partial class PageInstanceExport : IRefreshable
             // 复制 PCL 实例设置
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
-            // 复制 PCL 本体
-            if (IncludePCL)
-                ModBase.CopyFile(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
+                        '复制 PCL 本体
+                        If IncludePCL Then CopyFile(ExePathWithName, CacheFolder & "Plain Craft Launcher.exe")
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAI.xaml
@@ -1,0 +1,71 @@
+<local:MyPageRight
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:PCL"
+    xmlns:val="https://ce.pclc.cc/core/utils/validate"
+    x:Class="PCL.PageSetupAI"
+    PanScroll="{Binding ElementName=PanBack}">
+    <local:MyScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
+        <StackPanel x:Name="PanMain" Margin="25,10">
+            <local:MyCard Margin="0,15" Title="AI 分析">
+                <StackPanel Margin="25,40,25,15" Orientation="Vertical">
+                    <local:MyHint Text="启用后，游戏崩溃分析弹窗会显示 AI 分析按钮。点击后会把脱敏后的崩溃日志发送到你配置的 OpenAI 兼容 API。"
+                                  Theme="Yellow" Margin="0,0,0,12" />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Name" />
+                            <ColumnDefinition Width="1*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="28" />
+                            <RowDefinition Height="8" />
+                            <RowDefinition Height="28" />
+                            <RowDefinition Height="8" />
+                            <RowDefinition Height="28" />
+                            <RowDefinition Height="8" />
+                            <RowDefinition Height="28" />
+                            <RowDefinition Height="8" />
+                            <RowDefinition Height="28" />
+                        </Grid.RowDefinitions>
+
+                        <local:MyCheckBox x:Name="CheckAiAnalysis" Grid.Row="0" Grid.ColumnSpan="2"
+                                          Text="启用 AI 崩溃分析" Tag="ToolAiAnalysisEnabled"
+                                          Change="CheckBoxChange" />
+
+                        <TextBlock Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="API 类型" Margin="0,0,25,0" />
+                        <local:MyComboBox x:Name="ComboAiApiType" Grid.Row="2" Grid.Column="1"
+                                          Tag="ToolAiApiType" SelectionChanged="ComboChange">
+                            <local:MyComboBoxItem Content="Responses API (/responses)" IsSelected="True" />
+                            <local:MyComboBoxItem Content="Chat Completions API (/chat/completions)" />
+                        </local:MyComboBox>
+
+                        <TextBlock Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="Base URL" Margin="0,0,25,0" />
+                        <local:MyTextBox x:Name="TextAiBaseUrl" Grid.Row="4" Grid.Column="1"
+                                         Tag="ToolAiBaseUrl" HintText="https://api.openai.com/v1"
+                                         TextChanged="TextBoxChange"
+                                         ToolTip="填写 OpenAI 或兼容服务的 API 根地址，不需要包含 /responses 或 /chat/completions。">
+                            <local:MyTextBox.ValidateRules>
+                                <val:HttpValidator />
+                            </local:MyTextBox.ValidateRules>
+                        </local:MyTextBox>
+
+                        <TextBlock Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="Model ID" Margin="0,0,25,0" />
+                        <local:MyTextBox x:Name="TextAiModelId" Grid.Row="6" Grid.Column="1"
+                                         Tag="ToolAiModelId" HintText="gpt-5.2"
+                                         TextChanged="TextBoxChange" />
+
+                        <TextBlock Grid.Row="8" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="API Key" Margin="0,0,25,0" />
+                        <local:MyTextBox x:Name="TextAiApiKey" Grid.Row="8" Grid.Column="1"
+                                         Tag="ToolAiApiKey" HintText="sk-..."
+                                         TextChanged="TextBoxChange"
+                                         ToolTip="此项会保存到加密配置中，但仍会在输入框中明文显示。" />
+                    </Grid>
+                </StackPanel>
+            </local:MyCard>
+        </StackPanel>
+    </local:MyScrollViewer>
+</local:MyPageRight>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAI.xaml.cs
@@ -1,0 +1,76 @@
+using System.Windows;
+using System.Windows.Controls;
+using PCL.Core.App;
+
+namespace PCL;
+
+public partial class PageSetupAI
+{
+    private new bool IsLoaded;
+
+    public PageSetupAI()
+    {
+        InitializeComponent();
+        Loaded += PageSetupAI_Loaded;
+        Loaded += (_, _) => Reload();
+    }
+
+    private void PageSetupAI_Loaded(object sender, RoutedEventArgs e)
+    {
+        PanBack.ScrollToHome();
+        if (IsLoaded)
+            return;
+        IsLoaded = true;
+
+        ModAnimation.AniControlEnabled += 1;
+        Reload();
+        ModAnimation.AniControlEnabled -= 1;
+    }
+
+    public void Reload()
+    {
+        CheckAiAnalysis.Checked = Config.Tool.AI.Enabled;
+        ComboAiApiType.SelectedIndex = Config.Tool.AI.ApiType == 1 ? 1 : 0;
+        TextAiBaseUrl.Text = Config.Tool.AI.BaseUrl;
+        TextAiModelId.Text = Config.Tool.AI.ModelId;
+        TextAiApiKey.Text = Config.Tool.AI.ApiKey;
+    }
+
+    public void Reset()
+    {
+        try
+        {
+            Config.Tool.AI.Reset();
+            ModBase.Log("[Setup] 已初始化 AI 分析页设置");
+            ModMain.Hint("已初始化 AI 分析页设置！", ModMain.HintType.Finish, false);
+            Reload();
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "初始化 AI 分析页设置失败", ModBase.LogLevel.Msgbox);
+        }
+
+        Reload();
+    }
+
+    private void CheckBoxChange(object senderRaw, bool user)
+    {
+        var sender = (MyCheckBox)senderRaw;
+        if (ModAnimation.AniControlEnabled == 0)
+            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+    }
+
+    private void TextBoxChange(object senderRaw, TextChangedEventArgs e)
+    {
+        var sender = (MyTextBox)senderRaw;
+        if (ModAnimation.AniControlEnabled == 0)
+            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Text);
+    }
+
+    private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
+    {
+        var sender = (MyComboBox)senderRaw;
+        if (ModAnimation.AniControlEnabled == 0)
+            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+    }
+}

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml
@@ -67,6 +67,22 @@
                 </local:MyListItem.Buttons>
             </local:MyListItem>
 
+            <local:MyListItem x:Name="ItemAI" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="11"
+                              Check="PageCheck"
+                              MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="AI"
+                              LogoScale="0.95"
+                              Logo="M12 2l1.8 5.2L19 9l-5.2 1.8L12 16l-1.8-5.2L5 9l5.2-1.8L12 2z M5.5 14l1 2.8L9.3 18l-2.8 1-1 3-1-3-2.8-1 2.8-1 1-3z M18.5 14l0.8 2.2 2.2 0.8-2.2 0.8-0.8 2.2-0.8-2.2-2.2-0.8 2.2-0.8 0.8-2.2z">
+                <local:MyListItem.Buttons>
+                    <x:Array Type="{x:Type local:MyIconButton}">
+                        <local:MyIconButton Tag="11" ToolTip="初始化本页设置" ToolTipService.Placement="Right"
+                                            ToolTipService.InitialShowDelay="200" ToolTipService.VerticalOffset="-1"
+                                            Click="Reset"
+                                            Logo="M530 0c287 0 521 229 521 511s-233 511-521 511c-233 0-436-151-500-368a63 63 0 0 1 44-79 65 65 0 0 1 80 43c48 162 200 276 375 276 215 0 390-171 390-383s-174-383-390-383c-103 0-199 39-270 106l21-5a63 63 0 0 1 33 123l-157 42a65 65 0 0 1-90-42l-49-183a65 65 0 1 1 126-33l6 26A524 524 0 0 1 530 0z"
+                                            LogoScale="0.9" />
+                    </x:Array>
+                </local:MyListItem.Buttons>
+            </local:MyListItem>
+
             <TextBlock Text="启动器" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextLauncherCategory" />
 
             <local:MyListItem x:Name="ItemUI" IsScaleAnimationEnabled="False" Tag="1" MinPaddingRight="35" Height="36"

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLeft.xaml.cs
@@ -46,6 +46,8 @@ public partial class PageSetupLeft
             ItemGameManage.SetChecked(true, false, false);
         else if (!hideCfg.SetupGameLink) 
             ItemGameLink.SetChecked(true, false, false);    
+        else if (ItemAI.Visibility == Visibility.Visible)
+            ItemAI.SetChecked(true, false, false);
         else if (!hideCfg.SetupUi) 
             ItemUI.SetChecked(true, false, false);
         else if (!hideCfg.SetupLauncherMisc) 
@@ -119,6 +121,18 @@ public partial class PageSetupLeft
                         ModMain.FrmSetupGameLink = new PageSetupGameLink();
                     ModMain.FrmSetupGameLink.Reset();
                     ItemGameLink.Checked = true;
+                }
+
+                break;
+            }
+            case (double)FormMain.PageSubType.SetupAI:
+            {
+                if (ModMain.MyMsgBox("是否要初始化 工具-AI 页面的所有设置？该操作不可撤销。", "初始化确认", Button2: "取消", IsWarn: true) == 1)
+                {
+                    if (ModMain.FrmSetupAI is null)
+                        ModMain.FrmSetupAI = new PageSetupAI();
+                    ModMain.FrmSetupAI.Reset();
+                    ItemAI.Checked = true;
                 }
 
                 break;
@@ -205,7 +219,16 @@ public partial class PageSetupLeft
             PageID = FormMain.PageSubType.SetupGameManage;
         else if (!hideCfg.SetupGameLink)
             PageID = FormMain.PageSubType.SetupGameLink;    
-        else if (!hideCfg.SetupUi)
+        else
+            PageID = FormMain.PageSubType.SetupAI;
+        if (PageID == FormMain.PageSubType.SetupAI)
+        {
+            AnimatedControl = PanItem;
+            Loaded += PageSetupLeft_Loaded;
+            Unloaded += PageOtherLeft_Unloaded;
+            return;
+        }
+        if (!hideCfg.SetupUi)
             PageID = FormMain.PageSubType.SetupUI;
         else if (!hideCfg.SetupLauncherMisc)
             PageID = FormMain.PageSubType.SetupLauncherMisc;
@@ -291,6 +314,12 @@ public partial class PageSetupLeft
                 if (ModMain.FrmSetupGameLink is null)
                     ModMain.FrmSetupGameLink = new PageSetupGameLink();
                 return ModMain.FrmSetupGameLink;
+            }
+            case FormMain.PageSubType.SetupAI:
+            {
+                if (ModMain.FrmSetupAI is null)
+                    ModMain.FrmSetupAI = new PageSetupAI();
+                return ModMain.FrmSetupAI;
             }
             case FormMain.PageSubType.SetupLauncherMisc:
             {


### PR DESCRIPTION
喵喵喵

## Summary by Sourcery

添加可配置的 AI 驱动崩溃分析功能，用于 Minecraft 日志，并通过专用对话框和设置页面呈现结果。

新功能：
- 引入基于 AI 的崩溃分析器，将过滤后的 Minecraft 崩溃日志发送到可配置的、兼容 OpenAI 的 API，并在自定义对话框中显示分析结果。
- 在“工具”下新增 AI 设置页面，提供启用崩溃分析以及配置 API 类型、基础 URL、模型 ID 和 API 密钥等选项。
- 将 AI 崩溃分析接入现有崩溃处理流程，在启用时于崩溃对话框中提供 AI 分析按钮。

增强项：
- 在共享配置系统中持久化 AI 工具配置，并将其集成到安装向导导航和重置逻辑中。
- 限制导出的实例可选择性包含 PCL 可执行文件，使用现有的复制工具代替已被注释掉的旧代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable AI-powered crash analysis for Minecraft logs and surface it through a dedicated dialog and settings page.

New Features:
- Introduce an AI-based crash analyzer that sends filtered Minecraft crash logs to a configurable OpenAI-compatible API and displays the analysis in a custom dialog.
- Add a new AI settings page under Tools with options to enable crash analysis and configure API type, base URL, model ID, and API key.
- Wire AI crash analysis into the existing crash handling flow, offering an AI analysis button in crash dialogs when enabled.

Enhancements:
- Persist AI tool configuration in the shared config system and integrate it into the setup navigation and reset logic.
- Limit exported instances to optionally include the PCL executable using the existing copy utility instead of commented legacy code.

</details>