### PR TITLE
fix(mod-launch): add clientToken to refresh and authenticate requests

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1619,6 +1619,7 @@ public static class ModLaunch
                 { { "name", ModProfile.SelectedProfile.Username }, { "id", ModProfile.SelectedProfile.Uuid } };
             RefreshInfo.Add("selectedProfile", SelectProfile);
             RefreshInfo.Add(new JProperty("accessToken", ModProfile.SelectedProfile.AccessToken));
+            RefreshInfo.Add(new JProperty("clientToken", ModProfile.SelectedProfile.ClientToken));
             RefreshInfo.Add(new JProperty("requestUser", true));
             ModProfile.ProfileLog("刷新登录开始（Refresh, Authlib");
             var LoginJson = (JObject)ModBase.GetJson(Requester.Fetch(Data.Input.BaseUrl + "/refresh",
@@ -1666,6 +1667,7 @@ public static class ModLaunch
             var RequestData = new JObject(
                 new JProperty("agent", new JObject(new JProperty("name", "Minecraft"), new JProperty("version", 1))),
                 new JProperty("username", Data.Input.UserName), new JProperty("password", Data.Input.Password),
+                new JProperty("clientToken", ModProfile.SelectedProfile?.ClientToken ?? ""),
                 new JProperty("requestUser", true));
             var LoginJson = (JObject)ModBase.GetJson(Requester.Fetch(Data.Input.BaseUrl + "/authenticate",
                 new FetchParam


### PR DESCRIPTION
## Summary by Sourcery

在刷新和认证 Minecraft 登录请求中都包含客户端令牌，以符合预期的身份验证负载格式。

Bug Fixes:
- 在刷新登录请求中添加客户端令牌，以确保其包含所有必需的身份验证字段。
- 在初始认证登录请求中添加客户端令牌，以确保会话能够被正确关联。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include the client token in both refresh and authenticate Minecraft login requests to align with expected authentication payloads.

Bug Fixes:
- Add the client token to refresh login requests so they include all required authentication fields.
- Add the client token to initial authenticate login requests to ensure proper session association.

</details>