### PR TITLE
chore: 打包时忽略mcef模组相关文件

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
@@ -83,7 +83,7 @@
                                 <local:ExportOption
                                     Title="Mod"
                                     Description="模组"
-                                    Rules="mods/|!mods/*.disabled|!mods/*.old|!mods/.connector/|coremods/|lib/"
+                                    Rules="mods/|!mods/*.disabled|!mods/*.old|!mods/.connector/|coremods/|lib/|!mods/mcef-libraries/|!mods/mcef-cache/"
                                     DefaultChecked="True"
                                     RequireModLoader="True" />
                             </local:MyCheckBox.Tag>


### PR DESCRIPTION
添加了在打包整合包时默认忽略"mods/mcef-cache"和"mods/mcef-libraries"文件夹
在打包整合包时忽略这些文件夹可节省约500MB大小,且对游戏无影响