### PR TITLE
fix(instance-export): 修复漏转换的 VB 代码

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -837,8 +837,8 @@ public partial class PageInstanceExport : IRefreshable
             // 复制 PCL 实例设置
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
-                        '复制 PCL 本体
-                        If IncludePCL Then CopyFile(ExePathWithName, CacheFolder & "Plain Craft Launcher.exe")
+                        // 复制 PCL 本体
+                        if (IncludePCL) File.Copy(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"), true);
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -838,7 +838,7 @@ public partial class PageInstanceExport : IRefreshable
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
                         // 复制 PCL 本体
-                        if (IncludePCL) File.Copy(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"), true);
+                        if (IncludePCL) ModBase.CopyFile(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修正导出逻辑，在发布构建中使用 C# 而不是遗留的 VB 代码来复制 PCL 可执行文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the export logic to copy the PCL executable using C# instead of leftover VB code in release builds.

</details>