### PR TITLE
fix(tools-game-link): Correct port validation range

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -743,7 +743,7 @@ public partial class PageToolsGameLink
             BtnInputPort.IsEnabled = false;
             if (!ModLink.LobbyPrecheck()) return;
             var input = ModMain.MyMsgBoxInput("请输入端口",
-                ValidateRules: [new IntValidator(1024, 65535)]);
+                ValidateRules: [new IntValidator(65535,1024)]);
             int port;
             if (int.TryParse(input, out port))
                 using (var ping = McPingServiceFactory.CreateService("127.0.0.1", port, 5000))


### PR DESCRIPTION
## Summary by Sourcery

Bug 修复：
- 更正游戏链接工具中端口输入时整数验证器使用的端口范围，确保接受 1024 到 65535 之间的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the port range used by the integer validator when entering a port in the game link tool, ensuring values between 1024 and 65535 are accepted.

</details>