### PR TITLE
refactor: 使用配置系统全面取代 ModBase.Setup

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.cs
+++ b/Plain Craft Launcher 2/Application.xaml.cs
@@ -102,14 +102,14 @@ public partial class Application
                     Lang.Text("Application.EnvironmentWarning.IKnow"),
                     IsWarn: true);
             // 设置初始化
-            ModBase.Setup.Load("SystemDebugMode");
-            ModBase.Setup.Load("SystemDebugAnim");
-            ModBase.Setup.Load("SystemHttpProxy");
-            ModBase.Setup.Load("SystemHttpProxyCustomUsername");
-            ModBase.Setup.Load("SystemHttpProxyType");
-            ModBase.Setup.Load("ToolDownloadThread");
-            ModBase.Setup.Load("ToolDownloadSpeed");
-            ModBase.Setup.Load("UiFont");
+            _ = Config.Debug.Enabled;
+            _ = Config.Debug.AnimationSpeed;
+            _ = Config.Network.HttpProxy.CustomAddress;
+            _ = Config.Network.HttpProxy.CustomUsername;
+            _ = Config.Network.HttpProxy.Type;
+            _ = Config.Download.ThreadLimit;
+            _ = Config.Download.SpeedLimit;
+            _ = Config.Preference.Font;
             var updateBranchCfg = Config.Update.UpdateChannelConfig;
             if (updateBranchCfg.IsDefault())
                 updateBranchCfg.SetValue(ModBase.VersionBaseName.Contains("beta")

--- a/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
@@ -2,8 +2,8 @@ using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Markup;
-
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.UI.Theme;
 using System.Windows.Controls;
 
@@ -135,13 +135,14 @@ public partial class MyHint
     private void MyHint_Loaded(object sender, RoutedEventArgs e)
     {
         ThemeService.ColorModeChanged += (v, theme) => _ThemeChanged(v, theme);
-        if (CanClose && ModBase.Setup.Get(RelativeSetup) != null)
+        if (CanClose && ConfigService.TryGetConfigItemNoType(RelativeSetup, out var item) && !item.IsDefault())
             Visibility = Visibility.Collapsed;
     }
 
     private void BtnClose_Click(object sender, EventArgs e)
     {
-        ModBase.Setup.Set(RelativeSetup, true);
+        if (ConfigService.TryGetConfigItemNoType(RelativeSetup, out var item))
+            item.SetValueNoType(true);
         ModAnimation.AniDispose(this, false);
     }
 

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -86,14 +86,14 @@ public partial class FormMain
             // 触发降级
             DowngradeSub(LastVersion);
         // 版本隔离设置迁移
-        if (ModBase.Setup.IsUnset("LaunchArgumentIndieV2"))
+        if (Config.Launch.IndieSolutionV2Config.IsDefault())
         {
-            if (!ModBase.Setup.IsUnset("LaunchArgumentIndie"))
+            if (!Config.Launch.IndieSolutionV1Config.IsDefault())
             {
                 ModBase.Log("[Start] 从老 PCL 迁移版本隔离");
                 Config.Launch.IndieSolutionV2 = Config.Launch.IndieSolutionV1;
             }
-            else if (!ModBase.Setup.IsUnset("WindowHeight"))
+            else if (!States.UI.WindowHeightConfig.IsDefault())
             {
                 ModBase.Log("[Start] 从老 PCL 升级，但此前未调整版本隔离，使用老的版本隔离默认值");
                 Config.Launch.IndieSolutionV2Config.Reset(Config.Launch.IndieSolutionV1Config.DefaultValue);
@@ -105,7 +105,7 @@ public partial class FormMain
             }
         }
 
-        ModBase.Setup.Load("UiLauncherTheme");
+        _ = Config.Preference.Theme.ThemeSelected;
         // 注册拖拽事件（不能直接加 Handles，否则没用；#6340）
         AddHandler(DragDrop.DragEnterEvent, new DragEventHandler(HandleDrag), true);
         AddHandler(DragDrop.DragOverEvent, new DragEventHandler(HandleDrag), true);
@@ -169,11 +169,11 @@ public partial class FormMain
         ModBase.ApplicationStartTick = TimeUtils.GetTimeTick();
         ModBase.FrmHandle = new WindowInteropHelper(this).Handle;
         // 读取设置
-        ModBase.Setup.Load("UiBackgroundOpacity");
-        ModBase.Setup.Load("UiBackgroundBlur");
-        ModBase.Setup.Load("UiLogoType");
-        ModBase.Setup.Load("UiHiddenPageDownload");
-        ModBase.Setup.Load("UiAutoPauseVideo"); // 智能暂停视频背景
+        _ = Config.Preference.Background.WallpaperOpacity;
+        _ = Config.Preference.Background.WallpaperBlurRadius;
+        _ = Config.Preference.WindowTitleType;
+        _ = Config.Preference.Hide.PageDownload;
+        _ = Config.Preference.Background.AutoPauseVideo; // 智能暂停视频背景
         PageSetupUI.HiddenRefresh();
         PageSetupUI.BackgroundRefresh(false, true);
         ModMusic.MusicRefreshPlay(false, true);
@@ -375,7 +375,7 @@ public partial class FormMain
         // 迁移旧版用户档案
         if (LastVersionCode <= 368) ModBase.RunInNewThread(() => ModProfile.MigrateOldProfile());
         // Mod 命名设置迁移
-        if (!ModBase.Setup.IsUnset("ToolDownloadTranslate") && ModBase.Setup.IsUnset("ToolDownloadTranslateV2"))
+        if (!Config.Download.Comp.NameFormatV1Config.IsDefault() && Config.Download.Comp.NameFormatV2Config.IsDefault())
         {
             Config.Download.Comp.NameFormatV2 += 1;
             ModBase.Log("[Start] 已从老版本迁移 Mod 命名设置");

--- a/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModSetup.cs
@@ -505,7 +505,7 @@ public class ModSetup : IConfigScope
                     ModMain.FrmSetupUI.PanLogoChange.Visibility = Visibility.Collapsed;
                 }
 
-                ModBase.Setup.Load("UiLogoText", true);
+                UiLogoText(Config.Preference.WindowTitleCustomText);
                 break;
             }
             case 3: // 图片
@@ -551,7 +551,7 @@ public class ModSetup : IConfigScope
                 break;
         }
 
-        ModBase.Setup.Load("UiLogoLeft", true);
+        UiLogoLeft(Config.Preference.TopBarLeftAlign);
         if (ModMain.FrmSetupUI != null)
             ModMain.FrmSetupUI.CardLogo.TriggerForceResize();
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -2335,7 +2335,7 @@ public static class ModDownload
 
             default:
             {
-                ModBase.Setup.Reset("ToolDownloadMod");
+                Config.Download.Comp.CompSourceSolutionConfig.Reset();
                 res.Add(original);
                 break;
             }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -290,7 +290,7 @@ public static class ModJava
         {
             ModBase.Log(ex, "检查 Java 类别时出错", ModBase.LogLevel.Feedback);
             if (RelatedVersion is not null)
-                ModBase.Setup.Reset("VersionArgumentJavaSelect", instance: RelatedVersion);
+                Config.Instance.SelectedJavaConfig.Reset(RelatedVersion.PathInstance);
             Config.Launch.SelectedJava = "";
         }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -3042,8 +3042,7 @@ public static class ModMinecraft
             Path.Combine(ModBase.PathPure, "mesa-loader-windows", mesaLoaderWindowsVersion, "Loader.jar");
         var renderer = -1;
         if (McInstanceSelected is not null)
-            renderer = Conversions.ToInteger(
-                Operators.SubtractObject(ModBase.Setup.Get("VersionAdvanceRenderer", McInstanceSelected), 1));
+            renderer = Config.Instance.Renderer[McInstanceSelected.PathInstance] - 1;
         if (renderer == -1) renderer = Conversions.ToInteger(Config.Launch.Renderer);
 
         if (renderer != 0 && !File.Exists(mesaLoaderWindowsTargetFile))
@@ -3239,8 +3238,8 @@ public static class ModMinecraft
     /// </summary>
     public static object ShouldIgnoreFileCheck(McInstance Version)
     {
-        return (bool)ModBase.Setup.Get("VersionAdvanceAssetsV2", Version) ||
-               Operators.ConditionalCompareObjectEqual(ModBase.Setup.Get("VersionAdvanceAssets", Version), 2, false);
+        return Config.Instance.DisableAssetVerifyV2[Version.PathInstance] ||
+               Config.Instance.AssetVerifySolutionV1[Version.PathInstance] == 2;
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
@@ -77,7 +77,7 @@ public static class ModProfile
 
             SaveProfile();
             ProfileLog("旧版正版档案迁移完成");
-            ModBase.Setup.Reset("LoginMsJson");
+            States.Game.LegacyProfile.LoginMsJsonConfig.Reset();
         }
         else
         {
@@ -102,7 +102,7 @@ public static class ModProfile
 
             SaveProfile();
             ProfileLog("旧版离线档案迁移完成");
-            ModBase.Setup.Reset("LoginLegacyName");
+            States.Game.LegacyProfile.LoginLegacyNameConfig.Reset();
         }
         else
         {
@@ -131,11 +131,11 @@ public static class ModProfile
             SaveProfile();
             ProfileLog("旧版第三方验证档案迁移完成");
             profileCount += 1;
-            ModBase.Setup.Reset("CacheAuthName");
-            ModBase.Setup.Reset("CacheAuthUuid");
-            ModBase.Setup.Reset("CacheAuthServerServer");
-            ModBase.Setup.Reset("CacheAuthUsername");
-            ModBase.Setup.Reset("CacheAuthPass");
+            States.Game.LegacyProfile.AuthUserNameConfig.Reset();
+            States.Game.LegacyProfile.AuthUuidConfig.Reset();
+            States.Game.LegacyProfile.AuthServerAddressConfig.Reset();
+            States.Game.LegacyProfile.AuthThirdPartyUserNameConfig.Reset();
+            States.Game.LegacyProfile.AuthPasswordConfig.Reset();
         }
         else
         {

--- a/Plain Craft Launcher 2/Modules/ModEvent.cs
+++ b/Plain Craft Launcher 2/Modules/ModEvent.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Markup;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Exts;
 using PCL.Core.Utils.OS;
@@ -318,7 +319,13 @@ namespace PCL
                     case EventType.写入设置:
                         if (args.Length == 1)
                             throw new Exception($"EventType {type} 需要至少 2 个以 | 分割的参数，例如 UiLauncherTransparent|400");
-                        ModBase.Setup.SetSafe(args[0], args[1], instance: ModMinecraft.McInstanceSelected);
+                        var key = args[0];
+                        if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                        {
+                            if (item.Source == ConfigSource.SharedEncrypt)
+                                throw new InvalidOperationException("禁止写入加密设置项：" + key);
+                            item.SetValueNoType(args[1], ModMinecraft.McInstanceSelected?.PathInstance);
+                        }
                         if (args.Length == 2)
                             ModMain.Hint($"已写入设置：{args[0]} → {args[1]}", ModMain.HintType.Finish);
                         break;
@@ -429,7 +436,7 @@ namespace PCL
 
         private static bool EventSafetyConfirm(string message)
         {
-            if (ModBase.Setup.Get("HintCustomCommand") == "True")
+            if (States.Hint.HomepageCommand)
                 return true;
 
             switch (ModMain.MyMsgBox(
@@ -442,7 +449,7 @@ namespace PCL
                 case 1:
                     return true;
                 case 2:
-                    ModBase.Setup.Set("HintCustomCommand", "True");
+                    States.Hint.HomepageCommand = true;
                     return true;
                 default:
                     return false;

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualBasic;
 using Microsoft.Win32;
 using Newtonsoft.Json.Linq;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
 using PCL.Core.Utils;
@@ -902,38 +903,6 @@ public static class ModMain
 
     #endregion
 
-    #region 页面声明
-
-    // 在最后进行页面声明，避免颜色尚未加载完毕
-
-    // 窗体声明
-
-
-    // 页面声明（出于单元测试考虑，初始化页面已转入 FormMain 中）
-
-
-    // 工具页面声明
-
-
-    // 下载页面声明
-
-
-    // 设置页面声明
-
-
-    // 登录页面声明
-
-
-    // 实例设置页面声明
-
-
-    // 实例存档页面
-
-
-    // 资源信息分页声明
-    
-    #endregion
-
     #region 帮助
 
     public class HelpEntry
@@ -1542,7 +1511,7 @@ public static class ModMain
     // 高级
     text = ModBase.RegexReplaceEach(text, @"\{hint\}", m => replacer(PageToolsTest.GetRandomHint()));
     text = ModBase.RegexReplaceEach(text, @"\{cave\}", m => replacer(PageToolsTest.GetRandomCave()));
-    text = ModBase.RegexReplaceEach(text, @"\{setup:([a-zA-Z0-9]+)\}", m => replacer(ModBase.Setup.GetSafe(m.Groups[1].Value, ModMinecraft.McInstanceSelected)?.ToString() ?? ""));
+    text = ModBase.RegexReplaceEach(text, @"\{setup:([a-zA-Z0-9]+)\}", m => replacer(GetSetupValue(m.Groups[1].Value)?.ToString() ?? ""));
     text = ModBase.RegexReplaceEach(text, @"\{varible:([^:\}]+)(?::([^\}]+))?\}", m => replacer(CustomEvent.GetCustomVariable(m.Groups[1].Value, m.Groups[2].Value)));
     text = ModBase.RegexReplaceEach(text, @"\{variable:([^:\}]+)(?::([^\}]+))?\}", m => replacer(CustomEvent.GetCustomVariable(m.Groups[1].Value, m.Groups[2].Value)));
     
@@ -1639,5 +1608,16 @@ public static class ModMain
                 foreach (var e in events)
                     e.Raise();
             }, $"执行自定义事件 {ModBase.GetUuid()}");
+    }
+
+    private static object? GetSetupValue(string key)
+    {
+        if (ConfigService.TryGetConfigItemNoType(key, out var item))
+        {
+            if (item.Source == ConfigSource.SharedEncrypt)
+                throw new InvalidOperationException("禁止读取加密设置项：" + key);
+            return item.GetValueNoType(ModMinecraft.McInstanceSelected?.PathInstance);
+        }
+        return null;
     }
 }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -106,7 +106,7 @@ public partial class PageInstanceSetup
 
             // 游戏内存
             ((MyRadioBox)FindName(Conversions.ToString(Operators.ConcatenateObject("RadioRamType",
-                ModBase.Setup.Load("VersionRamType", instance: PageInstanceLeft.Instance))))).Checked = true;
+                Config.Instance.MemorySolution[PageInstanceLeft.Instance.PathInstance])))).Checked = true;
             SliderRamCustom.Value = Config.Instance.CustomMemorySize[PageInstanceLeft.Instance.PathInstance];
 
             // 服务器
@@ -128,10 +128,10 @@ public partial class PageInstanceSetup
             CheckAdvanceDisableLwjglUnsafeAgent.Checked = Config.Instance.DisableLwjglUnsafeAgent[PageInstanceLeft.Instance.PathInstance];
             if (Conversions.ToBoolean(
                     Operators.ConditionalCompareObjectEqual(
-                        ModBase.Setup.Get("VersionAdvanceAssets", PageInstanceLeft.Instance), 2, false)))
+                        Config.Instance.AssetVerifySolutionV1[PageInstanceLeft.Instance.PathInstance], 2, false)))
             {
                 ModBase.Log("[Setup] 已迁移老版本的关闭文件校验设置");
-                ModBase.Setup.Reset("VersionAdvanceAssets", instance: PageInstanceLeft.Instance);
+                Config.Instance.AssetVerifySolutionV1Config.Reset(PageInstanceLeft.Instance.PathInstance);
                 Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.Instance.PathInstance] = true;
             }
 
@@ -185,7 +185,10 @@ public partial class PageInstanceSetup
         var sender = (MyRadioBox)o;
         var gotCfg = sender.Tag.ToString().Split("/");
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(gotCfg[0], int.Parse(gotCfg[1]), instance: PageInstanceLeft.Instance);
+        {
+            if (ConfigService.TryGetConfigItemNoType(gotCfg[0], out var item))
+                item.SetValueNoType(int.Parse(gotCfg[1]), PageInstanceLeft.Instance.PathInstance);
+        }
     }
 
     private void TextBoxChange(object o, TextChangedEventArgs textChangedEventArgs)
@@ -218,14 +221,19 @@ public partial class PageInstanceSetup
     {
         var sender = (MySlider)o;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(Conversions.ToString(sender.Tag), sender.Value, instance: PageInstanceLeft.Instance);
+        {
+            if (ConfigService.TryGetConfigItemNoType(Conversions.ToString(sender.Tag), out var item))
+                item.SetValueNoType(sender.Value, PageInstanceLeft.Instance.PathInstance);
+        }
     }
 
     private static void ComboChange(MyComboBox sender, object e)
     {
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(Conversions.ToString(sender.Tag), sender.SelectedIndex,
-                instance: PageInstanceLeft.Instance);
+        {
+            if (ConfigService.TryGetConfigItemNoType(Conversions.ToString(sender.Tag), out var item))
+                item.SetValueNoType(sender.SelectedIndex, PageInstanceLeft.Instance.PathInstance);
+        }
     }
 
     private void CheckBoxChange(object sender, bool user)
@@ -457,8 +465,7 @@ public partial class PageInstanceSetup
     public static double GetRam(ModMinecraft.McInstance Version, bool? Is32BitJava = default)
     {
         // 跟随全局设置
-        if (Conversions.ToBoolean(
-                Operators.ConditionalCompareObjectEqual(ModBase.Setup.Get("VersionRamType", Version), 2, false)))
+        if (Config.Instance.MemorySolution[Version.PathInstance] == 2)
             return PageSetupLaunch.GetRam(Version, true, Is32BitJava);
 
         // ------------------------------------------
@@ -467,8 +474,7 @@ public partial class PageInstanceSetup
 
         // 使用当前实例的设置
         var RamGive = default(double);
-        if (Conversions.ToBoolean(
-                Operators.ConditionalCompareObjectEqual(ModBase.Setup.Get("VersionRamType", Version), 0, false)))
+        if (Config.Instance.MemorySolution[Version.PathInstance] == 0)
         {
             // 自动配置
             var RamAvailable =
@@ -540,7 +546,7 @@ public partial class PageInstanceSetup
         else
         {
             // 手动配置
-            var Value = Conversions.ToInteger(ModBase.Setup.Get("VersionRamCustom", Version));
+            var Value = Config.Instance.CustomMemorySize[Version.PathInstance];
             if (Value <= 12)
                 RamGive = Value * 0.1d + 0.3d;
             else if (Value <= 25)
@@ -625,7 +631,7 @@ public partial class PageInstanceSetup
             BtnServerAuthLock.Visibility = Visibility.Collapsed;
         else
             BtnServerAuthLock.Visibility = Visibility.Visible;
-        if (Conversions.ToBoolean(ModBase.Setup.Get("VersionServerLoginLock", PageInstanceLeft.Instance)))
+        if (Config.InstanceAuth.AuthLocked[PageInstanceLeft.Instance.PathInstance])
         {
             HintServerLoginLock.Visibility = Visibility.Visible;
             ComboServerLoginRequire.IsEnabled = false;

--- a/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.UI;
 using System.Globalization;
 
@@ -126,7 +127,9 @@ public partial class PageLogRight
     private void SliderMaxLog_ValueChanged(object o, bool user)
     {
         var sender = (MySlider)o;
-        ModBase.Setup.Set(sender.Tag.ToString(), sender.Value);
+        var key = (string)sender.Tag;
+        if (ConfigService.TryGetConfigItemNoType(key, out var item))
+            item.SetValueNoType(sender.Value);
         if (ModMain.FrmSetupLauncherMisc is null)
             return;
         ModMain.FrmSetupLauncherMisc.SliderMaxLog.Value = sender.Value;

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameLink.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.Link.Scaffolding.EasyTier;
 
 namespace PCL;
@@ -92,7 +93,11 @@ public partial class PageSetupGameLink
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Text);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Text);
+        }
     }
 
     private static void
@@ -100,14 +105,22 @@ public partial class PageSetupGameLink
             object e) // Handles ComboRelayType.SelectionChanged, ComboServerType.SelectionChanged
     {
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
+        }
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Checked);
+        }
     }
 
     private void LinkProtocolPerferenceChange(object sender, SelectionChangedEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 
 namespace PCL;
@@ -79,21 +80,33 @@ public partial class PageSetupGameManage
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Checked);
+        }
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Value);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Value);
+        }
     }
 
     private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
+        }
     }
 
     // 滑动条

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.Utils.OS;
 using PCL.Core.App.Localization;
 
@@ -63,7 +64,7 @@ public partial class PageSetupLaunch
             // CheckArgumentJavaTraversal.Checked = Setup.Get("LaunchArgumentJavaTraversal")
 
             // 游戏内存
-            ((MyRadioBox)FindName("RadioRamType" + ModBase.Setup.Load("LaunchRamType"))).Checked = true;
+            ((MyRadioBox)FindName("RadioRamType" + Config.Launch.MemoryAllocationMode)).Checked = true;
             SliderRamCustom.Value = Config.Launch.CustomMemorySize;
 
             // 高级设置
@@ -122,42 +123,65 @@ public partial class PageSetupLaunch
         var sender = (MyRadioBox)senderRaw;
         var gotCfg = sender.Tag?.ToString()?.Split("/") ?? Array.Empty<string>();
         if (ModAnimation.AniControlEnabled == 0 && gotCfg.Length >= 2)
-            ModBase.Setup.Set(gotCfg[0], int.Parse(gotCfg[1]));
+        {
+            if (ConfigService.TryGetConfigItemNoType(gotCfg[0], out var item))
+                item.SetValueNoType(int.Parse(gotCfg[1]));
+        }
     }
 
     private void TextBoxChange(object senderRaw, RoutedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Text);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Text);
+        }
     }
 
     private void TextArgumentTitle_OnTextChanged(object senderRaw, TextChangedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Text);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Text);
+        }
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Value);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Value);
+        }
     }
 
     private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
+        }
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Checked);
+        }
     }
 
     // 切换到实例独立设置
@@ -537,14 +561,14 @@ public partial class PageSetupLaunch
     private void TextAdvanceJvm_TextChanged(object sender, TextChangedEventArgs e)
     {
         BtnAdvanceJvmReset.Visibility =
-            TextAdvanceJvm.Text == (string)ModBase.Setup.GetDefault("LaunchAdvanceJvm")
+            TextAdvanceJvm.Text == (string)Config.Launch.JvmArgsConfig.DefaultValue
                 ? Visibility.Hidden
                 : Visibility.Visible;
     }
 
     private void BtnAdvanceJvmReset_Click(object sender, EventArgs e)
     {
-        ModBase.Setup.Reset("LaunchAdvanceJvm");
+        Config.Launch.JvmArgsConfig.Reset();
         Reload();
     }
 
@@ -564,13 +588,17 @@ public partial class PageSetupLaunch
             }
             else
             {
-                ModBase.Setup.Set((string)sender.Tag, sender.SelectedIndex);
+                var key = (string)sender.Tag;
+                if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                    item.SetValueNoType(sender.SelectedIndex);
                 States.Hint.Renderer = true;
             }
         }
         else
         {
-            ModBase.Setup.Set((string)sender.Tag, sender.SelectedIndex);
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
@@ -86,7 +86,11 @@ public partial class PageSetupLauncherMisc
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
+        }
     }
 
     private void RadioBoxChange(object senderRaw, ModBase.RouteEventArgs e)
@@ -94,21 +98,32 @@ public partial class PageSetupLauncherMisc
         var sender = (MyRadioBox)senderRaw;
         var gotCfg = sender.Tag?.ToString()?.Split("/") ?? Array.Empty<string>();
         if (ModAnimation.AniControlEnabled == 0 && gotCfg.Length >= 2)
-            ModBase.Setup.Set(gotCfg[0], int.Parse(gotCfg[1]));
+        {
+            if (ConfigService.TryGetConfigItemNoType(gotCfg[0], out var item))
+                item.SetValueNoType(int.Parse(gotCfg[1]));
+        }
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Checked);
+        }
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Value);
+        {
+            var key = (string)sender.Tag;
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Value);
+        }
     }
 
     // 网络

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.UI;
 using PCL.Core.Utils;
 using PCL.Core.App.Localization;
@@ -108,11 +109,11 @@ public partial class PageSetupUI
             }
             catch
             {
-                ModBase.Setup.Reset("UiCustomPreset");
+                Config.Preference.Homepage.SelectedPresetConfig.Reset();
             }
 
             ((MyRadioBox)FindName(Conversions.ToString(Operators.ConcatenateObject("RadioCustomType",
-                ModBase.Setup.Load("UiCustomType", true))))).Checked = true;
+                Conversions.ToInteger(Config.Preference.Homepage.Type))))).Checked = true;
             TextCustomNet.Text = Conversions.ToString(Config.Preference.Homepage.CustomUrl);
 
             // 功能隐藏
@@ -191,28 +192,45 @@ public partial class PageSetupUI
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Value);
+        {
+            var key = Conversions.ToString(sender.Tag);
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Value);
+        }
     }
 
     private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        {
+            var key = Conversions.ToString(sender.Tag);
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.SelectedIndex);
+        }
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         // 仅在动画未运行或初始化完成时保存设置，防止初始化时的触发导致重复写入
-        if (ModAnimation.AniControlEnabled == 0) ModBase.Setup.Set(sender.Tag?.ToString(), sender.Checked);
+        if (ModAnimation.AniControlEnabled == 0)
+        {
+            var key = Conversions.ToString(sender.Tag);
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Checked);
+        }
     }
 
     private void TextBoxChange(object senderRaw, RoutedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            ModBase.Setup.Set(sender.Tag?.ToString(), sender.Text);
+        {
+            var key = Conversions.ToString(sender.Tag);
+            if (ConfigService.TryGetConfigItemNoType(key, out var item))
+                item.SetValueNoType(sender.Text);
+        }
     }
 
     private void RadioBoxChange(object senderRaw, ModBase.RouteEventArgs e)
@@ -220,7 +238,10 @@ public partial class PageSetupUI
         var sender = (MyRadioBox)senderRaw;
         var gotCfg = sender.Tag?.ToString()?.Split("/") ?? Array.Empty<string>();
         if (ModAnimation.AniControlEnabled == 0 && gotCfg.Length >= 2)
-            ModBase.Setup.Set(gotCfg[0], int.Parse(gotCfg[1]));
+        {
+            if (ConfigService.TryGetConfigItemNoType(gotCfg[0], out var item))
+                item.SetValueNoType(int.Parse(gotCfg[1]));
+        }
     }
 
     private void ComboFontChange(object sender, SelectionChangedEventArgs e)
@@ -361,7 +382,7 @@ public partial class PageSetupUI
                         ModVideoBack.VideoStop();
                         ModBase.Log("[UI] 加载背景内容：" + Address);
                         ModMain.FrmMain.ImgBack.Background = new MyBitmap(Address);
-                        ModBase.Setup.Load("UiBackgroundSuit", true);
+                        _ = Config.Preference.Background.WallpaperSuitMode;
                         ModMain.FrmMain.ImgBack.Visibility = Visibility.Visible;
                         if (IsHint)
                             ModMain.Hint("背景内容已刷新：" + ModBase.GetFileNameFromPath(Address), ModMain.HintType.Finish,
@@ -635,7 +656,9 @@ public partial class PageSetupUI
     private void ThemeColor_Change(object senderRaw, SelectionChangedEventArgs e)
     {
         var sender = (MyComboBox)senderRaw;
-        ModBase.Setup.Set(sender.Tag?.ToString(), sender.SelectedIndex);
+        var key = Conversions.ToString(sender.Tag);
+        if (ConfigService.TryGetConfigItemNoType(key, out var item))
+            item.SetValueNoType(sender.SelectedIndex);
         ThemeManager.ThemeRefresh();
     }
 


### PR DESCRIPTION
## Summary by Sourcery

在启动器、设置页面、实例设置以及相关模块中，将多个直接使用旧版 `ModBase.Setup` API 的地方替换为新的集中式配置系统。

改进内容：
- 在各类 UI 页面和模块中，通过 `Config` 和 `ConfigService` 而非 `ModBase.Setup` 来执行设置的读写操作，包括实例作用域的配置值以及“忽略提示”标记。
- 引入一个辅助工具，通过配置系统安全地解析基于设置的占位符，并禁止访问加密设置。
- 调整迁移和升级流程，使其使用新的配置默认值和重置 API 来处理旧有设置，例如配置文件、版本隔离以及下载命名等。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace various direct uses of the legacy ModBase.Setup API with the new centralized configuration system across launcher, setup pages, instance settings, and supporting modules.

Enhancements:
- Route settings read/write operations in UI pages and modules through Config and ConfigService instead of ModBase.Setup, including instance-scoped values and hint-dismissal flags.
- Introduce a helper for safely resolving setup-backed placeholders via the configuration system, disallowing access to encrypted settings.
- Adjust migration and upgrade paths to use new configuration defaults and reset APIs for legacy settings such as profiles, version isolation, and download naming.

</details>