### PR TITLE
fix(ui): 修复 MyListItem 选中时动画条的高度问题

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
@@ -832,7 +832,7 @@ public partial class MyListItem : IMyRadio
                 }
             }
 
-            double customHeight = 20d; // 修改左侧神秘动画条的高度
+            var customHeight = 20d; // 修改左侧神秘动画条的高度
 
             if (IsLoaded && ModAnimation.AniControlEnabled == 0 && anime) // 防止默认属性变更触发动画
             {
@@ -840,7 +840,7 @@ public partial class MyListItem : IMyRadio
                 if (Checked)
                 {
                     // 由无变有
-                    if (RectCheck != null)
+                    if (RectCheck is not null)
                     {
                         // 统一静态属性：固定高度、居中对齐、无额外边距
                         RectCheck.Height = customHeight;
@@ -868,7 +868,7 @@ public partial class MyListItem : IMyRadio
                 else
                 {
                     // 由有变无
-                    if (RectCheck != null)
+                    if (RectCheck is not null)
                     {
                         if (!(RectCheck.RenderTransform is ScaleTransform))
                         {

--- a/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
@@ -832,7 +832,7 @@ public partial class MyListItem : IMyRadio
                 }
             }
 
-            // 更改动画
+            double customHeight = 20d; // 修改左侧神秘动画条的高度
 
             if (IsLoaded && ModAnimation.AniControlEnabled == 0 && anime) // 防止默认属性变更触发动画
             {
@@ -840,16 +840,26 @@ public partial class MyListItem : IMyRadio
                 if (Checked)
                 {
                     // 由无变有
-                    if (!(RectCheck == null))
+                    if (RectCheck != null)
                     {
-                        var Delta = 20;
-                        Anim.Add(ModAnimation.AaHeight(RectCheck, Delta * 0.4d, 200,
-                            Ease: new ModAnimation.AniEaseOutFluent(ModAnimation.AniEasePower.Weak)));
-                        Anim.Add(ModAnimation.AaHeight(RectCheck, Delta * 0.6d, 300,
-                            Ease: new ModAnimation.AniEaseOutBack(ModAnimation.AniEasePower.Weak)));
-                        Anim.Add(ModAnimation.AaOpacity(RectCheck, 1d - RectCheck.Opacity, 30));
+                        // 统一静态属性：固定高度、居中对齐、无额外边距
+                        RectCheck.Height = customHeight;
                         RectCheck.VerticalAlignment = VerticalAlignment.Center;
                         RectCheck.Margin = new Thickness(-1, 0d, 0d, 0d);
+                        RectCheck.Opacity = 1d;
+
+                        // 初始化缩放中心为正中心
+                        var scale = new ScaleTransform(1d, 0d);
+                        RectCheck.RenderTransformOrigin = new Point(0.5d, 0.5d);
+                        RectCheck.RenderTransform = scale;
+
+                        // 动画：让 ScaleY 从 0 弹性放大到 1
+                        Anim.Add(ModAnimation.AaDouble(
+                            i => scale.ScaleY = Math.Max(0d, scale.ScaleY + (double)i),
+                            1d - scale.ScaleY,
+                            300,
+                            Ease: new ModAnimation.AniEaseOutBack(ModAnimation.AniEasePower.Weak)
+                        ));
                     }
 
                     Anim.Add(ModAnimation.AaColor(this, ForegroundProperty,
@@ -858,13 +868,24 @@ public partial class MyListItem : IMyRadio
                 else
                 {
                     // 由有变无
-                    if (!(RectCheck == null))
+                    if (RectCheck != null)
                     {
-                        // Anim.Add(AaWidth(RectCheck, -RectCheck.Width, 120,, New AniEaseInFluent))
-                        Anim.Add(ModAnimation.AaHeight(RectCheck, -RectCheck.ActualHeight, 120,
-                            Ease: new ModAnimation.AniEaseInFluent(ModAnimation.AniEasePower.Weak)));
+                        if (!(RectCheck.RenderTransform is ScaleTransform))
+                        {
+                            RectCheck.RenderTransformOrigin = new Point(0.5d, 0.5d);
+                            RectCheck.RenderTransform = new ScaleTransform(1d, 1d);
+                        }
+
+                        var scale = (ScaleTransform)RectCheck.RenderTransform;
+
+                        // 动画：让 ScaleY 从当前值缩减到 0
+                        Anim.Add(ModAnimation.AaDouble(
+                            i => scale.ScaleY = Math.Max(0d, scale.ScaleY + (double)i),
+                            -scale.ScaleY,
+                            120,
+                            Ease: new ModAnimation.AniEaseInFluent(ModAnimation.AniEasePower.Weak)
+                        ));
                         Anim.Add(ModAnimation.AaOpacity(RectCheck, -RectCheck.Opacity, 70, 40));
-                        RectCheck.VerticalAlignment = VerticalAlignment.Center;
                     }
 
                     Anim.Add(ModAnimation.AaColor(this, ForegroundProperty, "ColorBrush1", 120));
@@ -878,31 +899,32 @@ public partial class MyListItem : IMyRadio
                 ModAnimation.AniStop("MyListItem Checked " + Uuid);
                 if (Checked)
                 {
-                    if (!(RectCheck == null))
+                    if (RectCheck != null)
                     {
-                        RectCheck.Height = double.NaN;
-                        RectCheck.Margin = new Thickness(-1, 6d, 0d, 6d);
+                        RectCheck.Height = customHeight; // 应用自定义固定高度
+                        RectCheck.Margin = new Thickness(-1, 0d, 0d, 0d);
                         RectCheck.Opacity = 1d;
-                        RectCheck.VerticalAlignment = VerticalAlignment.Stretch;
+                        RectCheck.VerticalAlignment = VerticalAlignment.Center; // 居中
+                        RectCheck.RenderTransform = null; // 清除缩放
                     }
 
                     SetResourceReference(ForegroundProperty, Height < 40d ? "ColorBrush3" : "ColorBrush2");
                 }
                 else
                 {
-                    if (!(RectCheck == null))
+                    if (RectCheck != null)
                     {
                         RectCheck.Height = 0d;
                         RectCheck.Margin = new Thickness(-1, 0d, 0d, 0d);
                         RectCheck.Opacity = 0d;
                         RectCheck.VerticalAlignment = VerticalAlignment.Center;
+                        RectCheck.RenderTransform = null;
                     }
 
                     SetResourceReference(ForegroundProperty, "ColorBrush1");
                 }
             }
         }
-
         catch (Exception ex)
         {
             ModBase.Log(ex, "设置 Checked 失败");


### PR DESCRIPTION
| 旧 | 新 |
| --- | --- |
| <img width="788" height="71" alt="image" src="https://github.com/user-attachments/assets/9cf2f9b4-ffdf-407e-ae47-f3be52486b29" /> |  <img width="696" height="62" alt="image" src="https://github.com/user-attachments/assets/7e015639-c66d-47fe-b3c3-9a68511011f2" /> |

让他的高度能够固定。在旧版，默认的高度和选中的高度不一致

## Summary by Sourcery

修复并统一 MyListItem 选中指示条的视觉行为，确保其具有一致的固定高度，并提供更流畅的显示/隐藏动画。

Bug 修复：
- 确保 MyListItem 左侧选中指示条在正常和选中状态之间保持一致的固定高度。

增强优化：
- 通过切换为居中的缩放变换来改进选中指示条的动画效果，从而获得更平滑的展开/收起动画以及更一致的对齐方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix and standardize the visual behavior of the MyListItem selection indicator bar, ensuring a consistent fixed height and smoother show/hide animation.

Bug Fixes:
- Ensure the MyListItem left selection indicator keeps a consistent fixed height between normal and selected states.

Enhancements:
- Improve the selection indicator animation by switching to a centered scale transform for smoother expand/collapse effects and consistent alignment.

</details>