### PR TITLE
feat(eventbus): 增加EventBus服务

### DIFF
--- a/PCL.Core.Test/App/EventBus/EventBusServiceTest.cs
+++ b/PCL.Core.Test/App/EventBus/EventBusServiceTest.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PCL.Core.App.EventBus;
+using System;
+using System.Threading.Tasks;
+
+namespace PCL.Core.Test.App.EventBus;
+
+[TestClass]
+public class EventBusServiceTest
+{
+    private record MyEvent(Guid Id, string Name, int Value) : EventDataBase(Id, Name);
+
+    [TestMethod]
+    public async Task Publish_Calls_Delegate_Handler()
+    {
+        var channel = "test-delegate-" + Guid.NewGuid();
+        Assert.IsTrue(EventBusService.AddChannel(channel));
+
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var sub = EventBusService.Subscribe<MyEvent>(channel, ev =>
+        {
+            tcs.TrySetResult(ev.Value == 42);
+            return Task.CompletedTask;
+        });
+
+        await EventBusService.PublishAsync(channel, new MyEvent(Guid.NewGuid(), "x", 42));
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        Assert.AreEqual(tcs.Task, completed, "Handler was not invoked within timeout");
+        Assert.IsTrue(await tcs.Task.ConfigureAwait(false));
+
+        EventBusService.RemoveChannel(channel);
+    }
+
+    private class HandlerObject : IEventHandler<MyEvent>
+    {
+        private readonly TaskCompletionSource<MyEvent> _tcs;
+        public HandlerObject(TaskCompletionSource<MyEvent> tcs) => _tcs = tcs;
+        public void Dispose() { }
+        public Task HandleEventAsync(MyEvent eventData)
+        {
+            _tcs.TrySetResult(eventData);
+            return _tcs.Task;
+        }
+    }
+
+    [TestMethod]
+    public async Task Publish_Calls_IEventHandler_Instance()
+    {
+        var channel = "test-instance-" + Guid.NewGuid();
+        Assert.IsTrue(EventBusService.AddChannel(channel));
+
+        var tcs = new TaskCompletionSource<MyEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new HandlerObject(tcs);
+        using var sub = EventBusService.Subscribe<MyEvent>(channel, handler);
+
+        await EventBusService.PublishAsync(channel, new MyEvent(Guid.NewGuid(), "y", 7));
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        Assert.AreEqual(tcs.Task, completed, "IEventHandler instance was not invoked");
+        Assert.AreEqual(7, (await tcs.Task.ConfigureAwait(false)).Value);
+
+        EventBusService.RemoveChannel(channel);
+    }
+
+    [TestMethod]
+    public async Task Unsubscribe_Prevents_Handler_Call()
+    {
+        var channel = "test-unsub-" + Guid.NewGuid();
+        Assert.IsTrue(EventBusService.AddChannel(channel));
+
+        var called = false;
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sub = EventBusService.Subscribe<MyEvent>(channel, ev =>
+        {
+            called = true;
+            tcs.TrySetResult(true);
+            return Task.CompletedTask;
+        });
+
+        sub.Dispose();
+
+        await EventBusService.PublishAsync(channel, new MyEvent(Guid.NewGuid(), "z", 1));
+
+        var completed = await Task.WhenAny(tcs.Task, Task.Delay(300));
+        Assert.AreNotEqual(tcs.Task, completed, "Handler should not be called after unsubscribe");
+        Assert.IsFalse(called, "Handler flag should remain false");
+
+        EventBusService.RemoveChannel(channel);
+    }
+}

--- a/PCL.Core/App/EventBus/EventBusService.cs
+++ b/PCL.Core/App/EventBus/EventBusService.cs
@@ -188,7 +188,9 @@ public sealed partial class EventBusService
         if (matching.Count == 0)
         {
             Context.Error($"No handler found for event data type {eventType.Name}");
-            throw new InvalidOperationException("No handler found for the given event data type.");
+            return Task.CompletedTask;
+            // will not throw Exception
+            //throw new InvalidOperationException("No handler found for the given event data type.");
         }
 
         var tasks = matching.Select(async h =>

--- a/PCL.Core/App/EventBus/EventBusService.cs
+++ b/PCL.Core/App/EventBus/EventBusService.cs
@@ -14,46 +14,49 @@ namespace PCL.Core.App.EventBus;
 public sealed partial class EventBusService
 {
     private static readonly ConcurrentDictionary<string,
-        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, object? Owner)>>> _Channels = [];
+        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef, bool OwnsOwner)>>> _Channels = [];
+
+    /// <summary>
+    /// 0 = running, 1 = stopping/closed
+    /// </summary>
+    private static int _isStopping;
 
     [LifecycleStop]
     private static Task _StopAsync()
     {
+        Interlocked.Exchange(ref _isStopping, 1);
         try
         {
-            foreach (var channel in _Channels.Values)
-            {
-                foreach (var handlersByType in channel.Values)
-                {
-                    foreach (var entry in handlersByType.Values)
-                    {
-                        if (entry.Owner is IDisposable d)
-                        {
-                            try { d.Dispose(); } catch { /* ignore */ }
-                        }
-                    }
-                }
-            }
-
+            var channelCount = _Channels.Count;
+            var handlerCount = _Channels.Values.Sum(c => c.Values.Sum(h => h.Count));
             _Channels.Clear();
+            Context.Error($"EventBus stopping: cleared {channelCount} channels and {handlerCount} handlers.");
             return Task.CompletedTask;
         }
         catch (Exception exception)
         {
+            Context.Error($"Exception while stopping EventBus: {exception}");
             return Task.FromException(exception);
         }
     }
 
+    /// <exception cref="InvalidOperationException">EventBus is stopping</exception>
     public static Task PublishAsync<TEventData>(string channelName, TEventData data) where TEventData : EventDataBase
-        => _CallChannelAsync(channelName, data);
+    {
+        if (Volatile.Read(ref _isStopping) != 0) throw new InvalidOperationException("EventBus is stopping");
+        return _CallChannelAsync(channelName, data);
+    }
 
     /// <summary>
     /// 订阅使用 <c>IEventHandler{TEventData}</c> 的对象实例。
     /// 返回 <see cref="IDisposable"/> 用于取消订阅。
     /// </summary>
-    public static IDisposable Subscribe<TEventData>(string channel, IEventHandler<TEventData> handler)
+    /// <exception cref="InvalidOperationException">EventBus is stopping</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="channel"/> is <see langword="null"/></exception>
+    public static IDisposable Subscribe<TEventData>(string channel, IEventHandler<TEventData> handler, bool disposeOwnerOnUnsubscribe = false)
         where TEventData : EventDataBase
     {
+        if (Volatile.Read(ref _isStopping) != 0) throw new InvalidOperationException("EventBus is stopping");
         if (string.IsNullOrWhiteSpace(channel)) throw new ArgumentNullException(nameof(channel));
         if (handler == null) throw new ArgumentNullException(nameof(handler));
 
@@ -64,10 +67,12 @@ public sealed partial class EventBusService
         }
 
         var dataType = typeof(TEventData);
-        var handlers = dataHandler.GetOrAdd(dataType, _ => []);
+        var handlers = dataHandler.GetOrAdd(dataType, _ => new ConcurrentDictionary<Guid, (Func<EventDataBase, Task>, WeakReference<object>?, bool)>());
+
+        var ownerRef = new WeakReference<object>(handler);
 
         var id = Guid.NewGuid();
-        handlers.TryAdd(id, (Wrapper, handler));
+        handlers.TryAdd(id, (Wrapper, ownerRef, disposeOwnerOnUnsubscribe));
 
         return new Subscription(() =>
         {
@@ -76,9 +81,27 @@ public sealed partial class EventBusService
             {
                 dataHandler.TryRemove(dataType, out _);
             }
+
+            // disposal responsibility: if this subscription requested owner disposal, try to dispose target if still alive
+            if (disposeOwnerOnUnsubscribe && ownerRef.TryGetTarget(out var tgt) && tgt is IDisposable d)
+            {
+                // check if any remaining subscription in this channel still references the same owner
+                var stillReferenced = dataHandler.Values.Any(dict => dict.Values.Any(e => e.OwnerRef != null && e.OwnerRef.TryGetTarget(out var other) && ReferenceEquals(other, tgt)));
+
+                if (stillReferenced) return;
+
+                try { d.Dispose(); } catch (Exception ex) { Context.Error($"Exception disposing subscription owner: {ex}"); }
+            }
         });
 
-        Task Wrapper(EventDataBase ev) => handler.HandleEventAsync((TEventData)ev);
+        Task Wrapper(EventDataBase ev)
+        {
+            if (ownerRef.TryGetTarget(out var target) && target is IEventHandler<TEventData> typed)
+            {
+                return typed.HandleEventAsync((TEventData)ev);
+            }
+            return Task.CompletedTask;
+        }
     }
 
     /// <summary>
@@ -87,6 +110,7 @@ public sealed partial class EventBusService
     public static IDisposable Subscribe<TEventData>(string channel, Func<TEventData, Task> handler)
         where TEventData : EventDataBase
     {
+        if (Volatile.Read(ref _isStopping) != 0) throw new InvalidOperationException("EventBus is stopping");
         if (string.IsNullOrWhiteSpace(channel)) throw new ArgumentNullException(nameof(channel));
         if (handler == null) throw new ArgumentNullException(nameof(handler));
 
@@ -100,7 +124,7 @@ public sealed partial class EventBusService
         var handlers = dataHandler.GetOrAdd(dataType, _ => []);
 
         var id = Guid.NewGuid();
-        handlers.TryAdd(id, (Wrapper, null));
+        handlers.TryAdd(id, (Wrapper, null, false));
 
         return new Subscription(() =>
         {
@@ -133,7 +157,7 @@ public sealed partial class EventBusService
         return _CallEventHandlerAsync(data, eventHandlers);
     }
 
-    private static Task _CallEventHandlerAsync<TEventData>(TEventData data, ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, object? Owner)>> dataHandlers)
+    private static Task _CallEventHandlerAsync<TEventData>(TEventData data, ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef, bool OwnsOwner)>> dataHandlers)
         where TEventData : EventDataBase
     {
         var eventType = data.GetType();
@@ -143,8 +167,19 @@ public sealed partial class EventBusService
         {
             if (registeredType.IsAssignableFrom(eventType))
             {
-                foreach (var entry in handlers.Values.ToImmutableArray())
+                foreach (var kv in handlers.ToImmutableArray())
                 {
+                    var key = kv.Key;
+                    var entry = kv.Value;
+                    if (entry.OwnerRef != null)
+                    {
+                        if (!entry.OwnerRef.TryGetTarget(out var _))
+                        {
+                            // owner was collected, remove this subscription
+                            handlers.TryRemove(key, out _);
+                            continue;
+                        }
+                    }
                     matching.Add(entry.Handler);
                 }
             }
@@ -170,6 +205,8 @@ public sealed partial class EventBusService
 
         return Task.WhenAll(tasks);
     }
+
+
 
     private sealed class Subscription : IDisposable
     {

--- a/PCL.Core/App/EventBus/EventBusService.cs
+++ b/PCL.Core/App/EventBus/EventBusService.cs
@@ -1,0 +1,184 @@
+using PCL.Core.App.IoC;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PCL.Core.App.EventBus;
+
+[LifecycleService(LifecycleState.BeforeLoading)]
+[LifecycleScope("eventbus", "EventBus")]
+public sealed partial class EventBusService
+{
+    private static readonly ConcurrentDictionary<string,
+        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, object? Owner)>>> _Channels = [];
+
+    [LifecycleStop]
+    private static Task _StopAsync()
+    {
+        try
+        {
+            foreach (var channel in _Channels.Values)
+            {
+                foreach (var handlersByType in channel.Values)
+                {
+                    foreach (var entry in handlersByType.Values)
+                    {
+                        if (entry.Owner is IDisposable d)
+                        {
+                            try { d.Dispose(); } catch { /* ignore */ }
+                        }
+                    }
+                }
+            }
+
+            _Channels.Clear();
+            return Task.CompletedTask;
+        }
+        catch (Exception exception)
+        {
+            return Task.FromException(exception);
+        }
+    }
+
+    public static Task PublishAsync<TEventData>(string channelName, TEventData data) where TEventData : EventDataBase
+        => _CallChannelAsync(channelName, data);
+
+    /// <summary>
+    /// 订阅使用 <c>IEventHandler{TEventData}</c> 的对象实例。
+    /// 返回 <see cref="IDisposable"/> 用于取消订阅。
+    /// </summary>
+    public static IDisposable Subscribe<TEventData>(string channel, IEventHandler<TEventData> handler)
+        where TEventData : EventDataBase
+    {
+        if (string.IsNullOrWhiteSpace(channel)) throw new ArgumentNullException(nameof(channel));
+        if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+        if (!_Channels.TryGetValue(channel, out var dataHandler))
+        {
+            Context.Error($"Channel {channel} not found.");
+            throw new InvalidOperationException("No channel found for the given channel identification.");
+        }
+
+        var dataType = typeof(TEventData);
+        var handlers = dataHandler.GetOrAdd(dataType, _ => []);
+
+        var id = Guid.NewGuid();
+        handlers.TryAdd(id, (Wrapper, handler));
+
+        return new Subscription(() =>
+        {
+            handlers.TryRemove(id, out _);
+            if (handlers.IsEmpty)
+            {
+                dataHandler.TryRemove(dataType, out _);
+            }
+        });
+
+        Task Wrapper(EventDataBase ev) => handler.HandleEventAsync((TEventData)ev);
+    }
+
+    /// <summary>
+    /// 订阅一个委托（更轻量）
+    /// </summary>
+    public static IDisposable Subscribe<TEventData>(string channel, Func<TEventData, Task> handler)
+        where TEventData : EventDataBase
+    {
+        if (string.IsNullOrWhiteSpace(channel)) throw new ArgumentNullException(nameof(channel));
+        if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+        if (!_Channels.TryGetValue(channel, out var dataHandler))
+        {
+            Context.Error($"Channel {channel} not found.");
+            throw new InvalidOperationException("No channel found for the given channel identification.");
+        }
+
+        var dataType = typeof(TEventData);
+        var handlers = dataHandler.GetOrAdd(dataType, _ => []);
+
+        var id = Guid.NewGuid();
+        handlers.TryAdd(id, (Wrapper, null));
+
+        return new Subscription(() =>
+        {
+            handlers.TryRemove(id, out _);
+            if (handlers.IsEmpty)
+            {
+                dataHandler.TryRemove(dataType, out _);
+            }
+        });
+
+        Task Wrapper(EventDataBase ev) => handler((TEventData)ev);
+    }
+
+    /// <summary>
+    /// 创建 channel（显式）
+    /// </summary>
+    public static bool AddChannel(string name) => !string.IsNullOrWhiteSpace(name) && _Channels.TryAdd(name, []);
+
+    public static bool RemoveChannel(string name) => _Channels.TryRemove(name, out _);
+
+    private static Task _CallChannelAsync<TEventData>(string channel, TEventData data)
+        where TEventData : EventDataBase
+    {
+        if (!_Channels.TryGetValue(channel, out var eventHandlers))
+        {
+            Context.Error($"Channel {channel} not found.");
+            throw new InvalidOperationException("No channel found for the given channel identification.");
+        }
+
+        return _CallEventHandlerAsync(data, eventHandlers);
+    }
+
+    private static Task _CallEventHandlerAsync<TEventData>(TEventData data, ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, object? Owner)>> dataHandlers)
+        where TEventData : EventDataBase
+    {
+        var eventType = data.GetType();
+
+        var matching = new List<Func<EventDataBase, Task>>();
+        foreach (var (registeredType, handlers) in dataHandlers)
+        {
+            if (registeredType.IsAssignableFrom(eventType))
+            {
+                foreach (var entry in handlers.Values.ToImmutableArray())
+                {
+                    matching.Add(entry.Handler);
+                }
+            }
+        }
+
+        if (matching.Count == 0)
+        {
+            Context.Error($"No handler found for event data type {eventType.Name}");
+            throw new InvalidOperationException("No handler found for the given event data type.");
+        }
+
+        var tasks = matching.Select(async h =>
+        {
+            try
+            {
+                await h(data).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Context.Error($"Event handler threw an exception: {ex}");
+            }
+        }).ToImmutableArray();
+
+        return Task.WhenAll(tasks);
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private Action? _dispose;
+        public Subscription(Action dispose) => _dispose = dispose ?? throw new ArgumentNullException(nameof(dispose));
+        public void Dispose()
+        {
+            var d = Interlocked.Exchange(ref _dispose, null);
+            d?.Invoke();
+        }
+    }
+}

--- a/PCL.Core/App/EventBus/EventBusService.cs
+++ b/PCL.Core/App/EventBus/EventBusService.cs
@@ -14,7 +14,7 @@ namespace PCL.Core.App.EventBus;
 public sealed partial class EventBusService
 {
     private static readonly ConcurrentDictionary<string,
-        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef, bool OwnsOwner)>>> _Channels = [];
+        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef)>>> _Channels = [];
 
     /// <summary>
     /// 0 = running, 1 = stopping/closed
@@ -30,7 +30,7 @@ public sealed partial class EventBusService
             var channelCount = _Channels.Count;
             var handlerCount = _Channels.Values.Sum(c => c.Values.Sum(h => h.Count));
             _Channels.Clear();
-            Context.Error($"EventBus stopping: cleared {channelCount} channels and {handlerCount} handlers.");
+            Context.Info($"EventBus stopping: cleared {channelCount} channels and {handlerCount} handlers.");
             return Task.CompletedTask;
         }
         catch (Exception exception)
@@ -40,6 +40,9 @@ public sealed partial class EventBusService
         }
     }
 
+    /// <summary>
+    /// Publish an event to a channel. All handlers subscribed to this channel with compatible event data type will be invoked.
+    /// </summary>
     /// <exception cref="InvalidOperationException">EventBus is stopping</exception>
     public static Task PublishAsync<TEventData>(string channelName, TEventData data) where TEventData : EventDataBase
     {
@@ -52,6 +55,7 @@ public sealed partial class EventBusService
     /// 返回 <see cref="IDisposable"/> 用于取消订阅。
     /// </summary>
     /// <exception cref="InvalidOperationException">EventBus is stopping</exception>
+    /// <exception cref="InvalidOperationException">Failed to create channel</exception>
     /// <exception cref="ArgumentNullException"><paramref name="channel"/> is <see langword="null"/></exception>
     public static IDisposable Subscribe<TEventData>(string channel, IEventHandler<TEventData> handler, bool disposeOwnerOnUnsubscribe = false)
         where TEventData : EventDataBase
@@ -62,17 +66,26 @@ public sealed partial class EventBusService
 
         if (!_Channels.TryGetValue(channel, out var dataHandler))
         {
-            Context.Error($"Channel {channel} not found.");
-            throw new InvalidOperationException("No channel found for the given channel identification.");
+            Context.Trace($"Channel {channel} not found.");
+            //throw new InvalidOperationException("No channel found for the given channel identification.");
+
+            // create channel if not exist
+            var success = AddChannel(channel);
+            if (!success)
+            {
+                throw new InvalidOperationException("Failed to create channel.");
+            }
         }
 
+        dataHandler ??= _Channels[channel]; // ensure dataHandler is not null here
+
         var dataType = typeof(TEventData);
-        var handlers = dataHandler.GetOrAdd(dataType, _ => new ConcurrentDictionary<Guid, (Func<EventDataBase, Task>, WeakReference<object>?, bool)>());
+        var handlers = dataHandler.GetOrAdd(dataType, _ => []);
 
         var ownerRef = new WeakReference<object>(handler);
 
         var id = Guid.NewGuid();
-        handlers.TryAdd(id, (Wrapper, ownerRef, disposeOwnerOnUnsubscribe));
+        handlers.TryAdd(id, (Wrapper, ownerRef));
 
         return new Subscription(() =>
         {
@@ -83,7 +96,9 @@ public sealed partial class EventBusService
             }
 
             // disposal responsibility: if this subscription requested owner disposal, try to dispose target if still alive
-            if (disposeOwnerOnUnsubscribe && ownerRef.TryGetTarget(out var tgt) && tgt is IDisposable d)
+            if (disposeOwnerOnUnsubscribe &&
+                ownerRef.TryGetTarget(out var tgt) &&
+                tgt is IDisposable d)
             {
                 // check if any remaining subscription in this channel still references the same owner
                 var stillReferenced = dataHandler.Values.Any(dict => dict.Values.Any(e => e.OwnerRef != null && e.OwnerRef.TryGetTarget(out var other) && ReferenceEquals(other, tgt)));
@@ -105,8 +120,11 @@ public sealed partial class EventBusService
     }
 
     /// <summary>
-    /// 订阅一个委托（更轻量）
+    /// 订阅一个委托
     /// </summary>
+    /// <exception cref="InvalidOperationException">EventBus is stopping</exception>
+    /// <exception cref="InvalidOperationException">Failed to create channel</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="channel"/> is <see langword="null"/></exception>
     public static IDisposable Subscribe<TEventData>(string channel, Func<TEventData, Task> handler)
         where TEventData : EventDataBase
     {
@@ -116,15 +134,25 @@ public sealed partial class EventBusService
 
         if (!_Channels.TryGetValue(channel, out var dataHandler))
         {
-            Context.Error($"Channel {channel} not found.");
-            throw new InvalidOperationException("No channel found for the given channel identification.");
+            Context.Trace($"Channel {channel} not found.");
+            //throw new InvalidOperationException("No channel found for the given channel identification.");
+
+            // create channel if not exist
+            var success = AddChannel(channel);
+            if (!success)
+            {
+                throw new InvalidOperationException("Failed to create channel.");
+            }
+
         }
+
+        dataHandler ??= _Channels[channel]; // ensure dataHandler is not null here
 
         var dataType = typeof(TEventData);
         var handlers = dataHandler.GetOrAdd(dataType, _ => []);
 
         var id = Guid.NewGuid();
-        handlers.TryAdd(id, (Wrapper, null, false));
+        handlers.TryAdd(id, (Wrapper, null));
 
         return new Subscription(() =>
         {
@@ -143,6 +171,11 @@ public sealed partial class EventBusService
     /// </summary>
     public static bool AddChannel(string name) => !string.IsNullOrWhiteSpace(name) && _Channels.TryAdd(name, []);
 
+    /// <summary>
+    /// Remove a channel and all its handlers. Use with caution.
+    /// </summary>
+    /// <param name="name">Channel name.</param>
+    /// <returns><see langword="true"/> if the channel was removed; otherwise, <see langword="false"/>.</returns>
     public static bool RemoveChannel(string name) => _Channels.TryRemove(name, out _);
 
     private static Task _CallChannelAsync<TEventData>(string channel, TEventData data)
@@ -157,7 +190,8 @@ public sealed partial class EventBusService
         return _CallEventHandlerAsync(data, eventHandlers);
     }
 
-    private static Task _CallEventHandlerAsync<TEventData>(TEventData data, ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef, bool OwnsOwner)>> dataHandlers)
+    private static Task _CallEventHandlerAsync<TEventData>(TEventData data,
+        ConcurrentDictionary<Type, ConcurrentDictionary<Guid, (Func<EventDataBase, Task> Handler, WeakReference<object>? OwnerRef)>> dataHandlers)
         where TEventData : EventDataBase
     {
         var eventType = data.GetType();
@@ -171,7 +205,7 @@ public sealed partial class EventBusService
                 {
                     var key = kv.Key;
                     var entry = kv.Value;
-                    if (entry.OwnerRef != null)
+                    if (entry.OwnerRef is not null)
                     {
                         if (!entry.OwnerRef.TryGetTarget(out var _))
                         {
@@ -187,7 +221,7 @@ public sealed partial class EventBusService
 
         if (matching.Count == 0)
         {
-            Context.Error($"No handler found for event data type {eventType.Name}");
+            Context.Trace($"No handler found for event data type {eventType.Name}");
             return Task.CompletedTask;
             // will not throw Exception
             //throw new InvalidOperationException("No handler found for the given event data type.");
@@ -213,7 +247,11 @@ public sealed partial class EventBusService
     private sealed class Subscription : IDisposable
     {
         private Action? _dispose;
+
+        /// <exception cref="ArgumentNullException">The dispose action is null.</exception>
         public Subscription(Action dispose) => _dispose = dispose ?? throw new ArgumentNullException(nameof(dispose));
+
+        /// <exception cref="Exception">A delegate callback throws an exception.</exception>
         public void Dispose()
         {
             var d = Interlocked.Exchange(ref _dispose, null);

--- a/PCL.Core/App/EventBus/EventDataBase.cs
+++ b/PCL.Core/App/EventBus/EventDataBase.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace PCL.Core.App.EventBus;
+
+public record EventDataBase(Guid Id, string Name);

--- a/PCL.Core/App/EventBus/IEventHandler.cs
+++ b/PCL.Core/App/EventBus/IEventHandler.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace PCL.Core.App.EventBus;
+
+public interface IEventHandler<in TEventData> : IDisposable
+    where TEventData : EventDataBase
+{
+    /// <summary>
+    /// Handle a event with the data, and the event is published by a publisher.
+    /// </summary>
+    /// <param name="eventData">The data that published by a publisher.</param>
+    Task HandleEventAsync(TEventData eventData);
+}

--- a/PCL.Core/App/EventBus/IResponsibleEventHandler.cs
+++ b/PCL.Core/App/EventBus/IResponsibleEventHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace PCL.Core.App.EventBus;
+
+// I think this is too hard to implement. So this is Obsolete.
+public interface IResponsibleEventHandler<TResponse>
+{
+    /// <summary>
+    /// Handle a event with the data, and the event is published by a publisher, and return a response to the publisher.
+    /// </summary>
+    /// <param name="eventData">The event data that published by a publisher</param>
+    Task<TResponse> HandleEventAsync(EventDataBase eventData);
+}


### PR DESCRIPTION
这个PR新增了EventBus服务，用来实现Core和UI等组件间的通讯。所有测试已通过（除`Unsubscribe_Prevents_Handler_Call`因为LifeCycle的限制无法初始化Context会触发Exception，但这是预期行为）

使用方法可以直接看单侧中的内容

## Summary by Sourcery

引入一个由生命周期管理的 EventBus 服务，用于在应用组件之间进行类型安全、基于通道的通信。

新特性：
- 添加 `EventBusService`，用于在命名通道上发布和订阅强类型事件，并支持感知生命周期的关闭以及自动处理程序清理。
- 引入 `EventDataBase`，作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>`，用于可释放的异步事件处理程序，并引入实验性接口 `IResponsibleEventHandler<TResponse>`，用于基于响应的处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，并确保在取消订阅后处理程序不会被调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lifecycle-managed EventBus service for typed, channel-based communication between application components.

New Features:
- Add EventBusService to publish and subscribe to strongly typed events on named channels with lifecycle-aware shutdown and automatic handler cleanup.
- Introduce EventDataBase as a common base record type for event payloads.
- Define IEventHandler<TEventData> for disposable, asynchronous event handlers and an experimental IResponsibleEventHandler<TResponse> interface for response-based handling.

Tests:
- Add unit tests covering delegate-based subscriptions, IEventHandler-based subscriptions, and ensuring handlers are not invoked after unsubscribing.

</details>

新功能：
- 添加 `EventBusService`，用于在命名通道上发布强类型事件，并通过与生命周期关联的清理机制管理订阅。
- 引入 `EventDataBase` 作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>` 和实验性的 `IResponsibleEventHandler<TResponse>` 接口，用于异步事件处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，以及取消订阅后处理程序不再被调用的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个由生命周期管理的 EventBus 服务，用于在应用组件之间进行类型安全、基于通道的通信。

新特性：
- 添加 `EventBusService`，用于在命名通道上发布和订阅强类型事件，并支持感知生命周期的关闭以及自动处理程序清理。
- 引入 `EventDataBase`，作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>`，用于可释放的异步事件处理程序，并引入实验性接口 `IResponsibleEventHandler<TResponse>`，用于基于响应的处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，并确保在取消订阅后处理程序不会被调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lifecycle-managed EventBus service for typed, channel-based communication between application components.

New Features:
- Add EventBusService to publish and subscribe to strongly typed events on named channels with lifecycle-aware shutdown and automatic handler cleanup.
- Introduce EventDataBase as a common base record type for event payloads.
- Define IEventHandler<TEventData> for disposable, asynchronous event handlers and an experimental IResponsibleEventHandler<TResponse> interface for response-based handling.

Tests:
- Add unit tests covering delegate-based subscriptions, IEventHandler-based subscriptions, and ensuring handlers are not invoked after unsubscribing.

</details>

</details>

新功能：
- 添加 `EventBusService`，用于在命名通道上发布和订阅类型化事件，并支持随生命周期自动清理。
- 引入 `EventDataBase` 作为事件负载的通用基础记录类型。
- 添加 `IEventHandler` 接口，用于可释放（disposable）、异步的事件处理程序，以及实验性的基于响应的处理程序接口 `IResponsibleEventHandler`。

测试：
- 添加单元测试，覆盖基于委托的订阅和基于 `IEventHandler` 的订阅，并确保取消订阅后不会再触发处理程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个由生命周期管理的 EventBus 服务，用于在应用组件之间进行类型安全、基于通道的通信。

新特性：
- 添加 `EventBusService`，用于在命名通道上发布和订阅强类型事件，并支持感知生命周期的关闭以及自动处理程序清理。
- 引入 `EventDataBase`，作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>`，用于可释放的异步事件处理程序，并引入实验性接口 `IResponsibleEventHandler<TResponse>`，用于基于响应的处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，并确保在取消订阅后处理程序不会被调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lifecycle-managed EventBus service for typed, channel-based communication between application components.

New Features:
- Add EventBusService to publish and subscribe to strongly typed events on named channels with lifecycle-aware shutdown and automatic handler cleanup.
- Introduce EventDataBase as a common base record type for event payloads.
- Define IEventHandler<TEventData> for disposable, asynchronous event handlers and an experimental IResponsibleEventHandler<TResponse> interface for response-based handling.

Tests:
- Add unit tests covering delegate-based subscriptions, IEventHandler-based subscriptions, and ensuring handlers are not invoked after unsubscribing.

</details>

新功能：
- 添加 `EventBusService`，用于在命名通道上发布强类型事件，并通过与生命周期关联的清理机制管理订阅。
- 引入 `EventDataBase` 作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>` 和实验性的 `IResponsibleEventHandler<TResponse>` 接口，用于异步事件处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，以及取消订阅后处理程序不再被调用的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个由生命周期管理的 EventBus 服务，用于在应用组件之间进行类型安全、基于通道的通信。

新特性：
- 添加 `EventBusService`，用于在命名通道上发布和订阅强类型事件，并支持感知生命周期的关闭以及自动处理程序清理。
- 引入 `EventDataBase`，作为事件负载的通用基础记录类型。
- 定义 `IEventHandler<TEventData>`，用于可释放的异步事件处理程序，并引入实验性接口 `IResponsibleEventHandler<TResponse>`，用于基于响应的处理。

测试：
- 添加单元测试，覆盖基于委托的订阅、基于 `IEventHandler` 的订阅，并确保在取消订阅后处理程序不会被调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lifecycle-managed EventBus service for typed, channel-based communication between application components.

New Features:
- Add EventBusService to publish and subscribe to strongly typed events on named channels with lifecycle-aware shutdown and automatic handler cleanup.
- Introduce EventDataBase as a common base record type for event payloads.
- Define IEventHandler<TEventData> for disposable, asynchronous event handlers and an experimental IResponsibleEventHandler<TResponse> interface for response-based handling.

Tests:
- Add unit tests covering delegate-based subscriptions, IEventHandler-based subscriptions, and ensuring handlers are not invoked after unsubscribing.

</details>

</details>

</details>