### PR TITLE
fix(instance): 修复 1.20.x 与 1.21.x 意外遗漏开头 1. 的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -764,6 +764,11 @@ public static class ModMinecraft
 
                 VersionSearchFinish: ;
 
+                if (_info.VanillaName.StartsWithF("20.") || _info.VanillaName.StartsWithF("21."))
+                {
+                    _info.VanillaName = "1." + _info.VanillaName;
+                }
+                
                 _info.VanillaName = _info.VanillaName.Replace("_unobfuscated", "").Replace(" Unobfuscated", "");
                 // 获取版本号
                 if (_info.VanillaName.StartsWithF("1."))


### PR DESCRIPTION
我也不知道为啥会漏掉，但反正这样能 work

Resolved #2806

## Summary by Sourcery

Bug Fixes:
- 修复在检测 Minecraft 1.20.x 和 1.21.x 版本时，`VanillaName` 中缺少前导 `"1."` 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct missing leading "1." in VanillaName when detecting Minecraft 1.20.x and 1.21.x versions.

</details>