### PR TITLE
fix: 社区资源排序不正确

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2510,7 +2510,7 @@ public static class ModComp
                     Item = res,
                     SearchSource = new List<ModBase.SearchSource>
                     {
-                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries), 1),
                         new(res.Description, 0.05)
                     }
                 });

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2472,59 +2472,59 @@ public static class ModComp
 
         #region 排序与最终输出
 
-        if (request.Sort == CompSortType.Default)
-        {   
-            var scores = new Dictionary<CompProject, double>();
-            Func<CompProject, double> getDownloadCountMult = p =>
-            {
-                switch (request.Type)
-                {
-                    case CompType.Mod:
-                    case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
-                    case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
-                    case CompType.ResourcePack:
-                    case CompType.Shader: return p.FromCurseForge ? 1 : 5;
-                    default: return 1;
-                }
-            };
-
-            if (string.IsNullOrEmpty(rawFilter))
-            {
-                foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
-            }
-            else
-            {
-                var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
-                foreach (var res in realResults)
-                {
-                    scores.Add(res,
-                        (res.WikiId > 0 ? 0.2 : 0) +
-                        Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
-                    searchEntries.Add(new ModBase.SearchEntry<CompProject>
-                    {
-                        Item = res,
-                        SearchSource = new List<ModBase.SearchSource>
-                        {
-                            new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
-                            new(res.Description, 0.05)
-                        }
-                    });
-                }
-
-                var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
-                foreach (var item in searchRes)
-                    scores[item.Item] +=
-                        (item.AbsoluteRight ? 10 : item.Similarity) /
-                        (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
-            }
-
+        if (request.Sort != CompSortType.Default)
+        {
             if (task.IsAborted) throw new ThreadInterruptedException();
-            storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
+            storage.Results.AddRange(realResults); // 遵从API返回顺序
+            return;
+        }
+        
+        var scores = new Dictionary<CompProject, double>();
+        Func<CompProject, double> getDownloadCountMult = p =>
+        {
+            switch (request.Type)
+            {
+                case CompType.Mod:
+                case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
+                case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
+                case CompType.ResourcePack:
+                case CompType.Shader: return p.FromCurseForge ? 1 : 5;
+                default: return 1;
+            }
+        };
+
+        if (string.IsNullOrEmpty(rawFilter))
+        {
+            foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
         }
         else
         {
-            storage.Results.AddRange(realResults); // 遵从API返回顺序
+            var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
+            foreach (var res in realResults)
+            {
+                scores.Add(res,
+                    (res.WikiId > 0 ? 0.2 : 0) +
+                    Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
+                searchEntries.Add(new ModBase.SearchEntry<CompProject>
+                {
+                    Item = res,
+                    SearchSource = new List<ModBase.SearchSource>
+                    {
+                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                        new(res.Description, 0.05)
+                    }
+                });
+            }
+
+            var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
+            foreach (var item in searchRes)
+                scores[item.Item] +=
+                    (item.AbsoluteRight ? 10 : item.Similarity) /
+                    (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
         }
+
+        if (task.IsAborted) throw new ThreadInterruptedException();
+        storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
 
         #endregion
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2472,52 +2472,59 @@ public static class ModComp
 
         #region 排序与最终输出
 
-        var scores = new Dictionary<CompProject, double>();
-        Func<CompProject, double> getDownloadCountMult = p =>
-        {
-            switch (request.Type)
+        if (request.Sort == CompSortType.Default)
+        {   
+            var scores = new Dictionary<CompProject, double>();
+            Func<CompProject, double> getDownloadCountMult = p =>
             {
-                case CompType.Mod:
-                case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
-                case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
-                case CompType.ResourcePack:
-                case CompType.Shader: return p.FromCurseForge ? 1 : 5;
-                default: return 1;
-            }
-        };
+                switch (request.Type)
+                {
+                    case CompType.Mod:
+                    case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
+                    case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
+                    case CompType.ResourcePack:
+                    case CompType.Shader: return p.FromCurseForge ? 1 : 5;
+                    default: return 1;
+                }
+            };
 
-        if (string.IsNullOrEmpty(rawFilter))
-        {
-            foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
+            if (string.IsNullOrEmpty(rawFilter))
+            {
+                foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
+            }
+            else
+            {
+                var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
+                foreach (var res in realResults)
+                {
+                    scores.Add(res,
+                        (res.WikiId > 0 ? 0.2 : 0) +
+                        Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
+                    searchEntries.Add(new ModBase.SearchEntry<CompProject>
+                    {
+                        Item = res,
+                        SearchSource = new List<ModBase.SearchSource>
+                        {
+                            new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                            new(res.Description, 0.05)
+                        }
+                    });
+                }
+
+                var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
+                foreach (var item in searchRes)
+                    scores[item.Item] +=
+                        (item.AbsoluteRight ? 10 : item.Similarity) /
+                        (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
+            }
+
+            if (task.IsAborted) throw new ThreadInterruptedException();
+            storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
         }
         else
         {
-            var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
-            foreach (var res in realResults)
-            {
-                scores.Add(res,
-                    (res.WikiId > 0 ? 0.2 : 0) +
-                    Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
-                searchEntries.Add(new ModBase.SearchEntry<CompProject>
-                {
-                    Item = res,
-                    SearchSource = new List<ModBase.SearchSource>
-                    {
-                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries), 1),
-                        new(res.Description, 0.05)
-                    }
-                });
-            }
-
-            var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
-            foreach (var item in searchRes)
-                scores[item.Item] +=
-                    (item.AbsoluteRight ? 10 : item.Similarity) /
-                    (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
+            storage.Results.AddRange(realResults); // 遵从API返回顺序
         }
-
-        if (task.IsAborted) throw new ThreadInterruptedException();
-        storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
 
         #endregion
     }


### PR DESCRIPTION
修复 其他排序方式仍然会错误地按下载权重排序 的问题
close [#2844](https://github.com/PCL-Community/PCL-CE/issues/2844)

目前的实现是除`默认`外的排序均跳过原有的重排逻辑，按照API取回来的顺序直接扔进去
在每个源内顺序是对的，但是MR的内容会整体在CF的前边
**取决于社区意见，如果要将两个源一起重排的话，我会再改一版**
~因为混一起重排要改的东西多比较麻烦，我懒~

## Summary by Sourcery

Bug Fixes:
- 修复在使用非默认排序选项时，Modrinth 结果会出现在 CurseForge 结果之前的跨来源排序错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect inter-source ordering where Modrinth results appeared before CurseForge results when using non-default sort options.

</details>