### PR TITLE
fix: 在弹出mc更新提示弹窗时使用ESC键会打开Wiki

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2510,7 +2510,7 @@ public static class ModComp
                     Item = res,
                     SearchSource = new List<ModBase.SearchSource>
                     {
-                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries), 1),
                         new(res.Description, 0.05)
                     }
                 });

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2472,59 +2472,59 @@ public static class ModComp
 
         #region 排序与最终输出
 
-        if (request.Sort == CompSortType.Default)
-        {   
-            var scores = new Dictionary<CompProject, double>();
-            Func<CompProject, double> getDownloadCountMult = p =>
-            {
-                switch (request.Type)
-                {
-                    case CompType.Mod:
-                    case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
-                    case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
-                    case CompType.ResourcePack:
-                    case CompType.Shader: return p.FromCurseForge ? 1 : 5;
-                    default: return 1;
-                }
-            };
-
-            if (string.IsNullOrEmpty(rawFilter))
-            {
-                foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
-            }
-            else
-            {
-                var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
-                foreach (var res in realResults)
-                {
-                    scores.Add(res,
-                        (res.WikiId > 0 ? 0.2 : 0) +
-                        Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
-                    searchEntries.Add(new ModBase.SearchEntry<CompProject>
-                    {
-                        Item = res,
-                        SearchSource = new List<ModBase.SearchSource>
-                        {
-                            new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
-                            new(res.Description, 0.05)
-                        }
-                    });
-                }
-
-                var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
-                foreach (var item in searchRes)
-                    scores[item.Item] +=
-                        (item.AbsoluteRight ? 10 : item.Similarity) /
-                        (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
-            }
-
+        if (request.Sort != CompSortType.Default)
+        {
             if (task.IsAborted) throw new ThreadInterruptedException();
-            storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
+            storage.Results.AddRange(realResults); // 遵从API返回顺序
+            return;
+        }
+        
+        var scores = new Dictionary<CompProject, double>();
+        Func<CompProject, double> getDownloadCountMult = p =>
+        {
+            switch (request.Type)
+            {
+                case CompType.Mod:
+                case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
+                case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
+                case CompType.ResourcePack:
+                case CompType.Shader: return p.FromCurseForge ? 1 : 5;
+                default: return 1;
+            }
+        };
+
+        if (string.IsNullOrEmpty(rawFilter))
+        {
+            foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
         }
         else
         {
-            storage.Results.AddRange(realResults); // 遵从API返回顺序
+            var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
+            foreach (var res in realResults)
+            {
+                scores.Add(res,
+                    (res.WikiId > 0 ? 0.2 : 0) +
+                    Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
+                searchEntries.Add(new ModBase.SearchEntry<CompProject>
+                {
+                    Item = res,
+                    SearchSource = new List<ModBase.SearchSource>
+                    {
+                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                        new(res.Description, 0.05)
+                    }
+                });
+            }
+
+            var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
+            foreach (var item in searchRes)
+                scores[item.Item] +=
+                    (item.AbsoluteRight ? 10 : item.Similarity) /
+                    (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
         }
+
+        if (task.IsAborted) throw new ThreadInterruptedException();
+        storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
 
         #endregion
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2472,52 +2472,59 @@ public static class ModComp
 
         #region 排序与最终输出
 
-        var scores = new Dictionary<CompProject, double>();
-        Func<CompProject, double> getDownloadCountMult = p =>
-        {
-            switch (request.Type)
+        if (request.Sort == CompSortType.Default)
+        {   
+            var scores = new Dictionary<CompProject, double>();
+            Func<CompProject, double> getDownloadCountMult = p =>
             {
-                case CompType.Mod:
-                case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
-                case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
-                case CompType.ResourcePack:
-                case CompType.Shader: return p.FromCurseForge ? 1 : 5;
-                default: return 1;
-            }
-        };
+                switch (request.Type)
+                {
+                    case CompType.Mod:
+                    case CompType.ModPack: return p.FromCurseForge ? 1 : 7;
+                    case CompType.DataPack: return p.FromCurseForge ? 10 : 1;
+                    case CompType.ResourcePack:
+                    case CompType.Shader: return p.FromCurseForge ? 1 : 5;
+                    default: return 1;
+                }
+            };
 
-        if (string.IsNullOrEmpty(rawFilter))
-        {
-            foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
+            if (string.IsNullOrEmpty(rawFilter))
+            {
+                foreach (var res in realResults) scores.Add(res, res.DownloadCount * getDownloadCountMult(res));
+            }
+            else
+            {
+                var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
+                foreach (var res in realResults)
+                {
+                    scores.Add(res,
+                        (res.WikiId > 0 ? 0.2 : 0) +
+                        Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
+                    searchEntries.Add(new ModBase.SearchEntry<CompProject>
+                    {
+                        Item = res,
+                        SearchSource = new List<ModBase.SearchSource>
+                        {
+                            new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' },StringSplitOptions.RemoveEmptyEntries), 1),
+                            new(res.Description, 0.05)
+                        }
+                    });
+                }
+
+                var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
+                foreach (var item in searchRes)
+                    scores[item.Item] +=
+                        (item.AbsoluteRight ? 10 : item.Similarity) /
+                        (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
+            }
+
+            if (task.IsAborted) throw new ThreadInterruptedException();
+            storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
         }
         else
         {
-            var searchEntries = new List<ModBase.SearchEntry<CompProject>>();
-            foreach (var res in realResults)
-            {
-                scores.Add(res,
-                    (res.WikiId > 0 ? 0.2 : 0) +
-                    Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
-                searchEntries.Add(new ModBase.SearchEntry<CompProject>
-                {
-                    Item = res,
-                    SearchSource = new List<ModBase.SearchSource>
-                    {
-                        new((isChineseSearch ? res.TranslatedName : res.RawName).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries), 1),
-                        new(res.Description, 0.05)
-                    }
-                });
-            }
-
-            var searchRes = ModBase.Search(searchEntries, rawFilter, 101, -1);
-            foreach (var item in searchRes)
-                scores[item.Item] +=
-                    (item.AbsoluteRight ? 10 : item.Similarity) /
-                    (searchRes.First().AbsoluteRight ? 10 : searchRes.First().Similarity);
+            storage.Results.AddRange(realResults); // 遵从API返回顺序
         }
-
-        if (task.IsAborted) throw new ThreadInterruptedException();
-        storage.Results.AddRange(scores.OrderByDescending(s => s.Value).Select(s => s.Key));
 
         #endregion
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -45,9 +45,10 @@ public static class ModMinecraft
                                  ? Lang.Text("Minecraft.Update.UpdateTime") + Lang.Date(time)
                                  : Lang.Text("Minecraft.Update.UpdatedAt") + Lang.TimeSpan(time - DateTime.Now));
             var msgResult = ModMain.MyMsgBox(msgBoxText, Lang.Text("Minecraft.Update.Title"),
-                Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Download"),
                 (DateTime.Now - time).TotalHours > 3d ? Lang.Text("Common.Action.UpdateLog") : "",
-                Button3Action: () => ModDownloadLib.McUpdateLogShow(version));
+                Lang.Text("Common.Action.Download"),
+                Lang.Text("Common.Action.Close"),
+                Button1Action: () => ModDownloadLib.McUpdateLogShow(version));
             // 弹窗结果
             if (msgResult == 2)
                 // 下载


### PR DESCRIPTION
> https://github.com/PCL-Community/PCL-CE/issues/2626#issuecomment-4528964685
> 所以比较妥协的解决方案是交换目前的两个按钮，将确认改成关闭置于第三个

close #2626

## Summary by Sourcery

调整 Minecraft 客户端更新提示行为及搜索结果处理方式。

漏洞修复：
- 通过重新排序并重新命名对话框按钮，防止在 Minecraft 更新提示对话框中按下 ESC 键时触发 Wiki/更新日志操作。
- 确保在请求非默认排序时，模组对比结果按照 API 提供的顺序返回，而不再进行额外评分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Minecraft client update prompt behavior and search result handling.

Bug Fixes:
- Prevent the Minecraft update hint dialog ESC key from triggering the Wiki/update-log action by reordering and relabeling dialog buttons.
- Ensure that when a non-default sort is requested, mod comparison results are returned in the API-provided order without additional scoring.

</details>