### PR TITLE
fix(cache): 修复对缓存是否有效的校验方法

### DIFF
--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
@@ -186,7 +186,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
     {
         var cacheFile = Path.Combine(ModBase.PathTemp, "Cache", "Update", path);
         var fileInfo = new FileInfo(cacheFile);
-        return fileInfo.Exists && (DateTime.Now - fileInfo.LastWriteTime).Hours < 1 &&
+        return fileInfo.Exists && (DateTime.Now - fileInfo.LastWriteTime).TotalHours < 1 &&
                (ModBase.GetFileMD5(cacheFile) ?? "") == (hash ?? "");
     }
 


### PR DESCRIPTION
原缓存对时间的校验使用 `Hours`，其返回值始终在 -23 ~ 23 之间（[官方文档](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.hours?view=netframework-4.8.1#definition)），对于以前（若干天前）的缓存，只要小时的间隔在 1 以内都被认为有效

通过修改为 `TotalHours` 返回总小时数修复

## Summary by Sourcery

Bug Fixes:
- 修正缓存过期逻辑：在验证更新缓存文件时，使用总共经过的小时数，而不是时间跨度中的小时组件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct cache expiration logic to use total elapsed hours instead of the hour component of the time span when validating update cache files.

</details>