### PR TITLE
fix(instance-export): 修复无法导出光影配置文件

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -180,6 +180,22 @@ public partial class PageInstanceExport : IRefreshable
                         GetExportOption(NewCheckBox).Description =
                             Lang.Date(SubFolder.LastWriteTime, "g");
                     Panel.Children.Add(NewCheckBox);
+                    if (Folder == "shaderpacks") // 处理文件夹形式光影包的配置文件
+                    {
+                        var shaderConfig = new FileInfo(Path.Combine(TargetFolder.FullName,
+                            $"{SubFolder.Name}.txt"));
+                        if (shaderConfig.Exists)
+                            Panel.Children.Add(new MyCheckBox
+                            {
+                                Margin = new Thickness(30, 0, 0, 0),
+                                Tag = new ExportOption
+                                {
+                                    Title = $"{shaderConfig.Name}", DefaultChecked = true,
+                                    Description = "光影配置文件",
+                                    Rules = ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}")
+                                }
+                            });
+                    }
                 }
         }
     }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -156,7 +156,8 @@ public partial class PageInstanceExport : IRefreshable
                                 Margin = new Thickness(30, 0, 0, 0),
                                 Tag = new ExportOption
                                 {
-                                    Title = $"{shaderConfig.Name} (光影配置文件)", DefaultChecked = true,
+                                    Title = $"{shaderConfig.Name}", DefaultChecked = true,
+                                    Description = "光影配置文件",
                                     Rules = ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}")
                                 }
                             });

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -153,6 +153,7 @@ public partial class PageInstanceExport : IRefreshable
                             GetExportOption(shaderCheckBox).Rules += "|" + ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}");
                             Panel.Children.Add(new MyCheckBox
                             {
+                                Margin = new Thickness(30, 0, 0, 0),
                                 Tag = new ExportOption
                                 {
                                     Title = $"{shaderConfig.Name} (光影配置文件)", DefaultChecked = true,

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -135,21 +135,22 @@ public partial class PageInstanceExport : IRefreshable
                 {
                     if (SubOptionBlackList.Any(b => File.Name.ContainsF(b)))
                         continue;
-                    Panel.Children.Add(new MyCheckBox
+                    var shaderCheckBox = new MyCheckBox
                     {
                         Tag = new ExportOption
                         {
                             Title = File.Name, DefaultChecked = true,
                             Rules = ModBase.EscapeLikePattern($"{Folder}/{File.Name}")
                         }
-                    });
+                    };
+                    Panel.Children.Add(shaderCheckBox);
                     if (Folder == "shaderpacks") // 处理光影包的配置文件
                     {
                         var shaderConfig = new FileInfo(Path.Combine(File.Directory.FullName,
                             $"{File.Name}.txt"));
                         if (shaderConfig.Exists)
                         {
-                            GetExportOption((MyCheckBox)Panel.Children[^1]).Rules += "|" + ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}");
+                            GetExportOption(shaderCheckBox).Rules += "|" + ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}");
                             Panel.Children.Add(new MyCheckBox
                             {
                                 Tag = new ExportOption

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -135,22 +135,19 @@ public partial class PageInstanceExport : IRefreshable
                 {
                     if (SubOptionBlackList.Any(b => File.Name.ContainsF(b)))
                         continue;
-                    var shaderCheckBox = new MyCheckBox
+                    Panel.Children.Add(new MyCheckBox
                     {
                         Tag = new ExportOption
                         {
                             Title = File.Name, DefaultChecked = true,
                             Rules = ModBase.EscapeLikePattern($"{Folder}/{File.Name}")
                         }
-                    };
-                    Panel.Children.Add(shaderCheckBox);
+                    });
                     if (Folder == "shaderpacks") // 处理光影包的配置文件
                     {
                         var shaderConfig = new FileInfo(Path.Combine(File.Directory.FullName,
                             $"{File.Name}.txt"));
                         if (shaderConfig.Exists)
-                        {
-                            GetExportOption(shaderCheckBox).Rules += "|" + ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}");
                             Panel.Children.Add(new MyCheckBox
                             {
                                 Margin = new Thickness(30, 0, 0, 0),
@@ -161,7 +158,6 @@ public partial class PageInstanceExport : IRefreshable
                                     Rules = ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}")
                                 }
                             });
-                        }
                     }
                 }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -146,8 +146,10 @@ public partial class PageInstanceExport : IRefreshable
                     if (Folder == "shaderpacks") // 处理光影包的配置文件
                     {
                         var shaderConfig = new FileInfo(Path.Combine(File.Directory.FullName,
-                            $"{Path.GetFileNameWithoutExtension(File.Name)}.txt"));
+                            $"{File.Name}.txt"));
                         if (shaderConfig.Exists)
+                        {
+                            GetExportOption((MyCheckBox)Panel.Children[^1]).Rules += "|" + ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}");
                             Panel.Children.Add(new MyCheckBox
                             {
                                 Tag = new ExportOption
@@ -156,6 +158,7 @@ public partial class PageInstanceExport : IRefreshable
                                     Rules = ModBase.EscapeLikePattern($"{Folder}/{shaderConfig.Name}")
                                 }
                             });
+                        }
                     }
                 }
 


### PR DESCRIPTION
close #2895

顺便加了点 Margin 以方便区分

<img width="367" height="186" alt="PixPin_2026-05-26_19-56-06" src="https://github.com/user-attachments/assets/ff573239-807f-4a86-a6c9-2153c37e371e" />

## Summary by Sourcery

Bug Fixes:
- 修正着色器包配置导出逻辑：通过完整文件名查找配置文件，并在存在时将其包含到导出规则中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct shaderpack config export to look up configuration files by full filename and include them in the export rules when present.

</details>

## Summary by Sourcery

修复着色器包配置文件导出问题，并改进其实例导出界面的呈现方式。

Bug 修复：
- 通过匹配完整的着色器包文件名，确保可以正确检测并导出着色器包配置文件。

功能增强：
- 改进导出界面中的着色器包配置项，使用更清晰的标签，并增加缩进以在视觉上进行分隔。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix shaderpack configuration file export and improve its presentation in the instance export UI.

Bug Fixes:
- Ensure shaderpack configuration files are detected and exported by matching against the full shaderpack filename.

Enhancements:
- Improve the shaderpack configuration entry in the export UI with clearer labeling and additional indentation for visual separation.

</details>