### PR TITLE
refactor: replace some ModBase references

### DIFF
--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -25,13 +25,7 @@ public static class HardwareInfo
     /// </summary>
     public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
 
-    public class GPUInfo
-    {
-        public string Name { get; init; } = null!;
-        public string DriverVersion { get; init; } = null!;
-        /// <summary> 显存大小，单位 MB </summary>
-        public long Memory { get; init; }
-    }
+    public readonly record struct GPUInfo(string Name, string DriverVersion, long Memory);
 
     /// <summary>
     /// 获取系统信息，例如 CPU 与 GPU，并存储到 CPUName 和 GPUs

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -32,10 +32,10 @@ public static class HardwareInfo
 
     public class GPUInfo
     {
-        public string Name = null!;
-        public string DriverVersion = null!;
+        public string Name { get; init; } = null!;
+        public string DriverVersion { get; init; } = null!;
         /// <summary> 显存大小，单位 MB </summary>
-        public long Memory;
+        public long Memory { get; init; }
     }
 
     /// <summary>
@@ -44,13 +44,14 @@ public static class HardwareInfo
     public static void GetHardwareInfo()
     {
         // CPU
+        var cpuName = (string?)null;
         try
         {
             using var searcher = new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_Processor");
             foreach (ManagementObject queryObj in searcher.Get())
             {
-                CPUName = queryObj["Name"].ToString().Trim();
-                break; // 通常只需要第一个CPU的信息
+                cpuName = queryObj["Name"]?.ToString()?.Trim();
+                break;
             }
         }
         catch (Exception ex)
@@ -58,32 +59,36 @@ public static class HardwareInfo
             LogWrapper.Warn(ex, "获取 CPU 信息时出错");
         }
 
+        // GPU
+        var gpuList = new List<GPUInfo>();
+        try
+        {
+            using var searcher =
+                new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_VideoController");
+            foreach (ManagementObject queryObj in searcher.Get())
+            {
+                var gpuInfo = new GPUInfo
+                {
+                    Name = queryObj["Name"]?.ToString() ?? "",
+                    DriverVersion = queryObj["DriverVersion"]?.ToString() ?? "",
+                    Memory = queryObj["AdapterRAM"] is not null and not DBNull
+                        ? Convert.ToInt64(queryObj["AdapterRAM"]) / (1024 * 1024)
+                        : 0
+                };
+                gpuList.Add(gpuInfo);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogWrapper.Warn(ex, "获取 GPU 信息时出错");
+        }
+
         lock (_lock)
         {
-            // GPU
-            try
-            {
-                GPUs.Clear();
-                using var searcher =
-                    new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_VideoController");
-                foreach (ManagementObject queryObj in searcher.Get())
-                {
-                    var gpuInfo = new GPUInfo();
-
-                    if (queryObj["Name"] is not null)
-                        gpuInfo.Name = queryObj["Name"].ToString();
-                    if (queryObj["AdapterRAM"] is not null and not DBNull)
-                        gpuInfo.Memory = Convert.ToInt64(queryObj["AdapterRAM"]) / (1024 * 1024);
-                    if (queryObj["DriverVersion"] is not null)
-                        gpuInfo.DriverVersion = queryObj["DriverVersion"].ToString();
-
-                    GPUs.Add(gpuInfo);
-                }
-            }
-            catch (Exception ex)
-            {
-                LogWrapper.Warn(ex, "获取 GPU 信息时出错");
-            }
+            if (cpuName is not null)
+                CPUName = cpuName;
+            GPUs.Clear();
+            GPUs.AddRange(gpuList);
         }
         LogWrapper.Info("已获取系统硬件信息");
     }

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -25,11 +25,6 @@ public static class HardwareInfo
     /// </summary>
     public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
 
-    /// <summary>
-    /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0
-    /// </summary>
-    public static string OSInfo = RuntimeInformation.OSDescription + " " + Environment.OSVersion.Version;
-
     public class GPUInfo
     {
         public string Name { get; init; } = null!;

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Management;
+using System.Runtime.InteropServices;
+using PCL.Core.Logging;
+
+namespace PCL.Core.Utils.OS;
+
+public class HardwareInfo
+{
+    private static readonly object _lock = new();
+    
+    /// <summary>
+    /// 系统 CPU 信息
+    /// </summary>
+    public static string CPUName = null!;
+
+    /// <summary>
+    /// 系统 GPU 信息
+    /// </summary>
+    public static List<GPUInfo> GPUs = new();
+
+    /// <summary>
+    /// 已安装物理内存大小，单位 MB
+    /// </summary>
+    public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
+
+    /// <summary>
+    /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0
+    /// </summary>
+    public static string OSInfo = RuntimeInformation.OSDescription + " " + Environment.OSVersion.Version;
+
+    public class GPUInfo
+    {
+        public string Name = null!;
+        public string DriverVersion = null!;
+        /// <summary> 显存大小，单位 MB </summary>
+        public long Memory;
+    }
+
+    /// <summary>
+    /// 获取系统信息，例如 CPU 与 GPU，并存储到 CPUName 和 GPUs
+    /// </summary>
+    public static void GetHardwareInfo()
+    {
+        // CPU
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_Processor");
+            foreach (ManagementObject queryObj in searcher.Get())
+            {
+                CPUName = queryObj["Name"].ToString().Trim();
+                break; // 通常只需要第一个CPU的信息
+            }
+        }
+        catch (Exception ex)
+        {
+            LogWrapper.Warn(ex, "获取 CPU 信息时出错");
+        }
+
+        lock (_lock)
+        {
+            // GPU
+            try
+            {
+                GPUs.Clear();
+                using var searcher =
+                    new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_VideoController");
+                foreach (ManagementObject queryObj in searcher.Get())
+                {
+                    var gpuInfo = new GPUInfo();
+
+                    if (queryObj["Name"] is not null)
+                        gpuInfo.Name = queryObj["Name"].ToString();
+                    if (queryObj["AdapterRAM"] is not null and not DBNull)
+                        gpuInfo.Memory = Convert.ToInt64(queryObj["AdapterRAM"]) / (1024 * 1024);
+                    if (queryObj["DriverVersion"] is not null)
+                        gpuInfo.DriverVersion = queryObj["DriverVersion"].ToString();
+
+                    GPUs.Add(gpuInfo);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWrapper.Warn(ex, "获取 GPU 信息时出错");
+            }
+        }
+        LogWrapper.Info("已获取系统硬件信息");
+    }
+}

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -13,12 +13,12 @@ public static class HardwareInfo
     /// <summary>
     /// 系统 CPU 信息
     /// </summary>
-    public static string CPUName = null!;
+    public static string CPUName = "Unknown";
 
     /// <summary>
     /// 系统 GPU 信息
     /// </summary>
-    public static List<GPUInfo> GPUs = new();
+    public static IReadOnlyList<GPUInfo> GPUs { get; private set; } = [];
 
     /// <summary>
     /// 已安装物理内存大小，单位 MB
@@ -82,8 +82,8 @@ public static class HardwareInfo
         {
             if (cpuName is not null)
                 CPUName = cpuName;
-            GPUs.Clear();
-            GPUs.AddRange(gpuList);
+            if (gpuList.Count > 0)
+                GPUs = gpuList;
         }
         LogWrapper.Info("已获取系统硬件信息");
     }

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -6,7 +6,7 @@ using PCL.Core.Logging;
 
 namespace PCL.Core.Utils.OS;
 
-public class HardwareInfo
+public static class HardwareInfo
 {
     private static readonly object _lock = new();
     

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -9,12 +9,12 @@ public static class SystemInfo
     /// <summary>
     /// 是否为 32 位系统。
     /// </summary>
-    public static bool Is32BitSystem => !Environment.Is64BitOperatingSystem;
+    public static bool Is32BitSystem = !Environment.Is64BitOperatingSystem;
 
     /// <summary>
     /// 是否为 ARM64 架构。
     /// </summary>
-    public static bool IsArm64System => RuntimeInformation.OSArchitecture == Architecture.Arm64;
+    public static bool IsArm64System = RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
     /// <summary>
     /// 是否使用 GBK 编码。

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -20,4 +20,9 @@ public static class SystemInfo
     /// 是否使用 GBK 编码。
     /// </summary>
     public static readonly bool IsGBKEncoding = Encoding.Default.CodePage == 936;
+
+    /// <summary>
+    /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0
+    /// </summary>
+    public static readonly string OSInfo = $"{RuntimeInformation.OSDescription} {Environment.OSVersion.Version}";
 }

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -9,15 +9,15 @@ public static class SystemInfo
     /// <summary>
     /// 是否为 32 位系统。
     /// </summary>
-    public static bool Is32BitSystem = !Environment.Is64BitOperatingSystem;
+    public static readonly bool Is32BitSystem = !Environment.Is64BitOperatingSystem;
 
     /// <summary>
     /// 是否为 ARM64 架构。
     /// </summary>
-    public static bool IsArm64System = RuntimeInformation.OSArchitecture == Architecture.Arm64;
+    public static readonly bool IsArm64System = RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
     /// <summary>
     /// 是否使用 GBK 编码。
     /// </summary>
-    public static bool IsGBKEncoding = Encoding.Default.CodePage == 936;
+    public static readonly bool IsGBKEncoding = Encoding.Default.CodePage == 936;
 }

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -1,90 +1,23 @@
 using System;
-using System.Collections.Generic;
-using System.Management;
 using System.Runtime.InteropServices;
-using PCL.Core.Logging;
+using System.Text;
 
 namespace PCL.Core.Utils.OS;
 
 public static class SystemInfo
 {
-    private static readonly object _lock = new();
-
-    public static string CPUName = null!;
+    /// <summary>
+    /// 是否为 32 位系统。
+    /// </summary>
+    public static bool Is32BitSystem => !Environment.Is64BitOperatingSystem;
 
     /// <summary>
-    /// 系统 GPU 信息
+    /// 是否为 ARM64 架构。
     /// </summary>
-    public static List<GPUInfo> GPUs = new();
+    public static bool IsArm64System => RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
     /// <summary>
-    /// 已安装物理内存大小，单位 MB
+    /// 是否使用 GBK 编码。
     /// </summary>
-    public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
-
-    /// <summary>
-    /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0
-    /// </summary>
-    public static string OSInfo = RuntimeInformation.OSDescription + " " + Environment.OSVersion.Version;
-
-    public class GPUInfo
-    {
-        public string Name = null!;
-      
-        public string DriverVersion = null!;
-
-        /// <summary>
-        /// 显存大小，单位 MB
-        /// </summary>
-        public long Memory;
-    }
-
-    /// <summary>
-    /// 获取系统信息，例如 CPU 与 GPU，并存储到 CPUName 和 GPUs
-    /// </summary>
-    public static void GetSystemInfo()
-    {
-        lock (_lock)
-        {
-            // CPU
-            try
-            {
-                using var searcher = new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_Processor");
-                foreach (ManagementObject queryObj in searcher.Get())
-                {
-                    CPUName = queryObj["Name"].ToString().Trim();
-                    break; // 通常只需要第一个CPU的信息
-                }
-            }
-            catch (Exception ex)
-            {
-                LogWrapper.Warn(ex, "获取 CPU 信息时出错");
-            }
-
-            // GPU
-            try
-            {
-                GPUs.Clear();
-                using var searcher = new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_VideoController");
-                foreach (ManagementObject queryObj in searcher.Get())
-                {
-                    var gpuInfo = new GPUInfo();
-
-                    if (queryObj["Name"] is not null)
-                        gpuInfo.Name = queryObj["Name"].ToString();
-                    if (queryObj["AdapterRAM"] is not null and not DBNull)
-                        gpuInfo.Memory = Convert.ToInt64(queryObj["AdapterRAM"]) / (1024 * 1024);
-                    if (queryObj["DriverVersion"] is not null)
-                        gpuInfo.DriverVersion = queryObj["DriverVersion"].ToString();
-
-                    GPUs.Add(gpuInfo);
-                }
-                LogWrapper.Info("已获取系统环境信息");
-            }
-            catch (Exception ex)
-            {
-                LogWrapper.Warn(ex, "获取 GPU 信息时出错");
-            }
-        }
-    }
+    public static bool IsGBKEncoding = Encoding.Default.CodePage == 936;
 }

--- a/Plain Craft Launcher 2/Application.xaml.cs
+++ b/Plain Craft Launcher 2/Application.xaml.cs
@@ -88,7 +88,7 @@ public partial class Application
             var currentOSVersion = NtInterop.GetCurrentOsVersion();
             if (currentOSVersion.Build < 17763)
                 problemList.Add(Lang.Text("Application.EnvironmentWarning.WindowsVersion"));
-            if (ModBase.Is32BitSystem)
+            if (SystemInfo.Is32BitSystem)
                 problemList.Add(Lang.Text("Application.EnvironmentWarning.System32Bit"));
             if (ModBase.ExePath.Contains(Path.GetTempPath()) || ModBase.ExePath.Contains(@"AppData\Local\Temp\"))
                 problemList.Add(Lang.Text("Application.EnvironmentWarning.TempFolder"));
@@ -130,7 +130,7 @@ public partial class Application
         }
         catch (Exception ex)
         {
-            var FilePath = ModBase.ExePathWithName;
+            var FilePath = Basics.ExecutablePath;
             MessageBox.Show(ex + "\r\n" + Lang.Text("Application.InitializationError.Path",
                     string.IsNullOrEmpty(FilePath) ? Lang.Text("Application.InitializationError.PathUnavailable") : FilePath),
                 Lang.Text("Application.InitializationError.Title"), MessageBoxButton.OK, MessageBoxImage.Error);

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -230,7 +230,7 @@ public partial class FormMain
                 RenderTransform = null;
                 IsWindowLoadFinished = true;
                 ModBase.Log(
-                    $"[System] DPI：{ModBase.DPI}，系统版本：{Environment.OSVersion.VersionString}，PCL 位置：{ModBase.ExePathWithName}");
+                    $"[System] DPI：{ModBase.DPI}，系统版本：{Environment.OSVersion.VersionString}，PCL 位置：{Basics.ExecutablePath}");
             }, After: true)
         }, "Form Show");
         // Timer 启动
@@ -304,7 +304,7 @@ public partial class FormMain
                     ModBase.Log(ex, "初始化加载池运行失败", ModBase.LogLevel.Feedback);
                 }
 
-                SystemInfo.GetSystemInfo();
+                HardwareInfo.GetHardwareInfo();
             }
             catch (Exception ex)
             {

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -2332,7 +2332,7 @@ public static class ModBase
 
         if (PathTemp.IsASCII()) return PathTemp;
 
-        return SystemPaths.DriveLetter + @"ProgramData\PCL\";
+        return Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL");
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -2332,7 +2332,7 @@ public static class ModBase
 
         if (PathTemp.IsASCII()) return PathTemp;
 
-        return  SystemPaths.DriveLetter + @"ProgramData\PCL\";
+        return SystemPaths.DriveLetter + @"ProgramData\PCL\";
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -3522,12 +3522,14 @@ public static class ModBase
             var dpiScale = Math.Round(DPI / 96.0, 2);
 
             // Build diagnostic information string
-            var info = $"[System] Diagnostic Information:{"\r\n"}" +
-                       $"OS: {RuntimeInformation.OSDescription} (32-bit: {SystemInfo.Is32BitSystem}){"\r\n"}" +
-                       $"Memory: {availableMb} MB / {totalMb} MB{"\r\n"}" +
-                       $"DPI: {DPI} ({dpiScale * 100}%){"\r\n"}" +
-                       $"MC Folder: {ModMinecraft.McFolderSelected ?? "Nothing"}{"\r\n"}" +
-                       $"Executable Path: {ExePath}";
+            var info = $"""
+                [System] Diagnostic Information:
+                OS: {RuntimeInformation.OSDescription} (32-bit: {SystemInfo.Is32BitSystem})
+                Memory: {availableMb} MB / {totalMb} MB
+                DPI: {DPI} ({dpiScale * 100}%)
+                MC Folder: {ModMinecraft.McFolderSelected ?? "Nothing"}
+                Executable Path: {ExePath}
+                """;
 
             LogWrapper.Info(info);
         }

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -73,11 +73,6 @@ public static class ModBase
         : Basics.ExecutableDirectory + @"\");
 
     /// <summary>
-    ///     程序可执行文件完整路径。
-    /// </summary>
-    public static readonly string ExePathWithName = Basics.ExecutablePath;
-
-    /// <summary>
     ///     程序内嵌图片文件夹路径，以“/”结尾。
     /// </summary>
     public static readonly string PathImage = "pack://application:,,,/Plain Craft Launcher 2;component/Images/";
@@ -103,35 +98,9 @@ public static class ModBase
     public static DateTime ApplicationOpenTime = DateTime.Now;
 
     /// <summary>
-    ///     识别码。
-    /// </summary>
-    public static string UniqueAddress = Identify.LauncherId;
-
-    /// <summary>
     ///     程序是否已结束。
     /// </summary>
     public static bool IsProgramEnded = false;
-
-    /// <summary>
-    ///     是否为 32 位系统。
-    /// </summary>
-    public static bool Is32BitSystem = !Environment.Is64BitOperatingSystem;
-
-    /// <summary>
-    ///     是否为 ARM64 架构。
-    /// </summary>
-    public static bool IsArm64System = RuntimeInformation.OSArchitecture == Architecture.Arm64;
-
-    /// <summary>
-    ///     是否使用 GBK 编码。
-    /// </summary>
-    public static bool IsGBKEncoding = Encoding.Default.CodePage == 936;
-
-    /// <summary>
-    ///     系统盘盘符，以 \ 结尾。例如 “C:\”。
-    /// </summary>
-    public static string OsDrive =
-        Environment.GetLogicalDrives().Where(p => Directory.Exists(p)).First().ToUpper().First() + @":\"; // #3799
 
     /// <summary>
     ///     程序的缓存文件夹路径，以 \ 结尾。
@@ -2363,7 +2332,7 @@ public static class ModBase
 
         if (PathTemp.IsASCII()) return PathTemp;
 
-        return OsDrive + @"ProgramData\PCL\";
+        return  SystemPaths.DriveLetter + @"ProgramData\PCL\";
     }
 
     /// <summary>
@@ -3554,7 +3523,7 @@ public static class ModBase
 
             // Build diagnostic information string
             var info = $"[System] Diagnostic Information:{"\r\n"}" +
-                       $"OS: {RuntimeInformation.OSDescription} (32-bit: {Is32BitSystem}){"\r\n"}" +
+                       $"OS: {RuntimeInformation.OSDescription} (32-bit: {SystemInfo.Is32BitSystem}){"\r\n"}" +
                        $"Memory: {availableMb} MB / {totalMb} MB{"\r\n"}" +
                        $"DPI: {DPI} ({dpiScale * 100}%){"\r\n"}" +
                        $"MC Folder: {ModMinecraft.McFolderSelected ?? "Nothing"}{"\r\n"}" +

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -1286,38 +1286,37 @@ public class CrashAnalyzer
                     }
 
                     // 输出环境与启动信息
-                    string EnvInfo = null;
-                    string McLauncherLog = null;
-                    McLauncherLog = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "PCL 启动器日志.txt"))
+                    var McLauncherLog = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "PCL 启动器日志.txt"))
                         .AfterLast("[Launch] ~ 基础参数 ~").BeforeFirst("开始 Minecraft 日志监控");
                     var LaunchScript = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "启动脚本.bat"));
-                    EnvInfo += $"PCL CE 版本：{ModBase.VersionBaseName} {"\r\n"}";
-                    EnvInfo += $"识别码：{Identify.LauncherId}{"\r\n"}";
-                    EnvInfo += $"{"\r\n"}- 档案信息 -{"\r\n"}";
-                    EnvInfo +=
-                        $"档案名称：{McLauncherLog.Between("玩家用户名：", "[").TrimEnd('[').Trim()} (验证方式：{McLauncherLog.Between("验证方式：", "[").TrimEnd('[').Trim()}){"\r\n"}";
-                    EnvInfo += $"{"\r\n"}- 实例信息 -{"\r\n"}";
-                    EnvInfo +=
-                        $"选定的 Java 虚拟机：{McLauncherLog.Between("Java 信息：", "[").TrimEnd('[').Trim()}{"\r\n"}";
-                    EnvInfo +=
-                        $"Log4j2 NoLookups：{!LaunchScript.ContainsF("-Dlog4j2.formatMsgNoLookups=false")}{"\r\n"}";
-                    EnvInfo += $"MC 文件夹：{McLauncherLog.Between("MC 文件夹：", "[").TrimEnd('[').Trim()}{"\r\n"}";
-                    EnvInfo += $"{"\r\n"}- 环境信息 -{"\r\n"}";
-                    EnvInfo +=
-                        $"操作系统：{SystemInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）{"\r\n"}";
-                    EnvInfo += $"CPU：{HardwareInfo.CPUName}{"\r\n"}";
-                    EnvInfo +=
-                        $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB){"\r\n"}";
+                    var EnvInfo = new StringBuilder();
+                    EnvInfo.Append($"PCL CE 版本：{ModBase.VersionBaseName}\r\n");
+                    EnvInfo.Append($"识别码：{Identify.LauncherId}\r\n");
+                    EnvInfo.Append($"\r\n- 档案信息 -\r\n");
+                    EnvInfo.Append(
+                        $"档案名称：{McLauncherLog.Between("玩家用户名：", "[").TrimEnd('[').Trim()} (验证方式：{McLauncherLog.Between("验证方式：", "[").TrimEnd('[').Trim()})\r\n");
+                    EnvInfo.Append($"\r\n- 实例信息 -\r\n");
+                    EnvInfo.Append(
+                        $"选定的 Java 虚拟机：{McLauncherLog.Between("Java 信息：", "[").TrimEnd('[').Trim()}\r\n");
+                    EnvInfo.Append(
+                        $"Log4j2 NoLookups：{!LaunchScript.ContainsF("-Dlog4j2.formatMsgNoLookups=false")}\r\n");
+                    EnvInfo.Append($"MC 文件夹：{McLauncherLog.Between("MC 文件夹：", "[").TrimEnd('[').Trim()}\r\n");
+                    EnvInfo.Append($"\r\n- 环境信息 -\r\n");
+                    EnvInfo.Append(
+                        $"操作系统：{SystemInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）\r\n");
+                    EnvInfo.Append($"CPU：{HardwareInfo.CPUName}\r\n");
+                    EnvInfo.Append(
+                        $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB)\r\n");
                     for (int i = 0; i < HardwareInfo.GPUs.Count; i++)
                     {
                         var GPU = HardwareInfo.GPUs[i];
-                        EnvInfo +=
-                            $"显卡 {i}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})";
-                        EnvInfo += "\r\n";
+                        EnvInfo.Append(
+                            $"显卡 {i}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})");
+                        EnvInfo.Append("\r\n");
                     }
 
                     File.CreateText(Path.Combine(TempFolder, "Report", "环境与启动信息.txt")).Close();
-                    ModBase.WriteFile(Path.Combine(TempFolder, "Report", "环境与启动信息.txt"), EnvInfo, Encoding: Encoding.UTF8);
+                    ModBase.WriteFile(Path.Combine(TempFolder, "Report", "环境与启动信息.txt"), EnvInfo.ToString(), Encoding: Encoding.UTF8);
                     // 导出报告
                     ZipFile.CreateFromDirectory(Path.Combine(TempFolder, "Report"), FileAddress);
                     ModBase.DeleteDirectory(Path.Combine(TempFolder, "Report"));

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -1304,7 +1304,7 @@ public class CrashAnalyzer
                     EnvInfo += $"MC 文件夹：{McLauncherLog.Between("MC 文件夹：", "[").TrimEnd('[').Trim()}{"\r\n"}";
                     EnvInfo += $"{"\r\n"}- 环境信息 -{"\r\n"}";
                     EnvInfo +=
-                        $"操作系统：{HardwareInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）{"\r\n"}";
+                        $"操作系统：{SystemInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）{"\r\n"}";
                     EnvInfo += $"CPU：{HardwareInfo.CPUName}{"\r\n"}";
                     EnvInfo +=
                         $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB){"\r\n"}";

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -11,6 +11,7 @@ using PCL.Core.Utils.Exts;
 using PCL.Core.Utils.OS;
 using PCL.Core.App.Localization;
 using System.Globalization;
+using PCL.Core.Utils.Secret;
 
 namespace PCL;
 
@@ -1291,7 +1292,7 @@ public class CrashAnalyzer
                         .AfterLast("[Launch] ~ 基础参数 ~").BeforeFirst("开始 Minecraft 日志监控");
                     var LaunchScript = ModBase.ReadFile(Path.Combine(TempFolder, "Report", "启动脚本.bat"));
                     EnvInfo += $"PCL CE 版本：{ModBase.VersionBaseName} {"\r\n"}";
-                    EnvInfo += $"识别码：{ModBase.UniqueAddress}{"\r\n"}";
+                    EnvInfo += $"识别码：{Identify.LauncherId}{"\r\n"}";
                     EnvInfo += $"{"\r\n"}- 档案信息 -{"\r\n"}";
                     EnvInfo +=
                         $"档案名称：{McLauncherLog.Between("玩家用户名：", "[").TrimEnd('[').Trim()} (验证方式：{McLauncherLog.Between("验证方式：", "[").TrimEnd('[').Trim()}){"\r\n"}";
@@ -1303,14 +1304,14 @@ public class CrashAnalyzer
                     EnvInfo += $"MC 文件夹：{McLauncherLog.Between("MC 文件夹：", "[").TrimEnd('[').Trim()}{"\r\n"}";
                     EnvInfo += $"{"\r\n"}- 环境信息 -{"\r\n"}";
                     EnvInfo +=
-                        $"操作系统：{SystemInfo.OSInfo}（64 位：{!ModBase.Is32BitSystem}, ARM64: {ModBase.IsArm64System}）{"\r\n"}";
-                    EnvInfo += $"CPU：{SystemInfo.CPUName}{"\r\n"}";
+                        $"操作系统：{HardwareInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）{"\r\n"}";
+                    EnvInfo += $"CPU：{HardwareInfo.CPUName}{"\r\n"}";
                     EnvInfo +=
-                        $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(SystemInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(SystemInfo.SystemMemorySize, "N0")} MB){"\r\n"}";
-                    foreach (var GPU in SystemInfo.GPUs)
+                        $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB){"\r\n"}";
+                    foreach (var GPU in HardwareInfo.GPUs)
                     {
                         EnvInfo +=
-                            $"显卡 {SystemInfo.GPUs.IndexOf(GPU)}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})";
+                            $"显卡 {HardwareInfo.GPUs.IndexOf(GPU)}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})";
                         EnvInfo += "\r\n";
                     }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -1308,10 +1308,11 @@ public class CrashAnalyzer
                     EnvInfo += $"CPU：{HardwareInfo.CPUName}{"\r\n"}";
                     EnvInfo +=
                         $"内存分配 (分配的内存 / 已安装物理内存)：{McLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB){"\r\n"}";
-                    foreach (var GPU in HardwareInfo.GPUs)
+                    for (int i = 0; i < HardwareInfo.GPUs.Count; i++)
                     {
+                        var GPU = HardwareInfo.GPUs[i];
                         EnvInfo +=
-                            $"显卡 {HardwareInfo.GPUs.IndexOf(GPU)}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})";
+                            $"显卡 {i}：{GPU.Name} ({(GPU.Memory >= 4095L ? ">= " + GPU.Memory : GPU.Memory)} MB, {GPU.DriverVersion})";
                         EnvInfo += "\r\n";
                     }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -7,6 +7,7 @@ using PCL.Core.Minecraft.Java.UserPreference;
 using PCL.Network;
 using PCL.Network.Loaders;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils.OS;
 
 namespace PCL;
 
@@ -373,7 +374,7 @@ public static class ModJava
         string? targetName = null;
         JsonNode? targetValue = null;
         var Components =
-            (JsonObject)((JsonObject)ModBase.GetJson(IndexFileStr))[$"windows-x{(ModBase.Is32BitSystem ? "86" : "64")}"];
+            (JsonObject)((JsonObject)ModBase.GetJson(IndexFileStr))[$"windows-x{(SystemInfo.Is32BitSystem ? "86" : "64")}"];
         if (Components.ContainsKey(Loader.Input)) // 精确匹配
         {
             targetName = Loader.Input;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -3029,12 +3029,12 @@ public static class ModLaunch
     private static string GetNativesFolder()
     {
         var Result = Path.Combine(ModMinecraft.McInstanceSelected.PathInstance, ModMinecraft.McInstanceSelected.Name + "-natives");
-        if (ModBase.IsGBKEncoding || Result.IsASCII())
+        if (SystemInfo.IsGBKEncoding || Result.IsASCII())
             return Result;
         Result = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft", "bin", "natives");
         if (Result.IsASCII())
             return Result;
-        return Path.Combine(ModBase.OsDrive, "ProgramData", "PCL", "natives");
+        return Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL", "natives");
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -12,6 +12,7 @@ using PCL.Core.App.Localization;
 using PCL.Core.UI;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Exts;
+using PCL.Core.Utils.OS;
 using PCL.Network;
 
 namespace PCL;
@@ -2700,7 +2701,7 @@ public static class ModMinecraft
                 }
 
                 if (Rule["os"]["arch"] is not null) // 操作系统架构
-                    IsRightRule = IsRightRule && Rule["os"]["arch"].ToString() == "x86" == ModBase.Is32BitSystem;
+                    IsRightRule = IsRightRule && Rule["os"]["arch"].ToString() == "x86" == SystemInfo.Is32BitSystem;
             }
 
             if (!(Rule["features"] == null)) // 标签
@@ -3044,7 +3045,7 @@ public static class ModMinecraft
             var downloadAddress =
                 "https://mirrors.cloud.tencent.com/nexus/repository/maven-public/org/glavo/mesa-loader-windows/" +
                 ModLaunch.MesaLoaderWindowsVersion + "/mesa-loader-windows-" + ModLaunch.MesaLoaderWindowsVersion + "-" +
-                (ModBase.Is32BitSystem ? "x86" : ModBase.IsArm64System ? "arm64" : "x64") + ".jar";
+                (SystemInfo.Is32BitSystem ? "x86" : SystemInfo.IsArm64System ? "arm64" : "x64") + ".jar";
             result.Add(new DownloadFile(new[] { downloadAddress }, mesaLoaderWindowsTargetFile));
         }
 

--- a/Plain Craft Launcher 2/Modules/ModLink.cs
+++ b/Plain Craft Launcher 2/Modules/ModLink.cs
@@ -323,7 +323,7 @@ public static class ModLink
                 var loaders = new List<ModLoader.LoaderBase>();
 
                 // Setup download addresses
-                var architecture = ModBase.IsArm64System ? "arm64" : "x86_64";
+                var architecture = SystemInfo.IsArm64System ? "arm64" : "x86_64";
                 var addresses = new List<string>
                 {
                     $"https://staticassets.naids.com/resources/pclce/static/easytier/easytier-windows-{architecture}-v{ETInfoProvider.ETVersion}.zip",

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -1575,7 +1575,7 @@ public static class ModMain
             try
             {
                 ModBase.Log("[System] 开始清理任务缓存文件夹");
-                ModBase.DeleteDirectory($@"{SystemPaths.DriveLetter}ProgramData\PCL\TaskTemp\");
+                ModBase.DeleteDirectory(Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL", "TaskTemp"));
                 ModBase.DeleteDirectory($@"{ModBase.PathTemp}TaskTemp\");
                 ModBase.Log("[System] 已清理任务缓存文件夹");
             }
@@ -1623,7 +1623,7 @@ public static class ModMain
 
         // 使用备用路径
         ResultFolder =
-            $@"{SystemPaths.DriveLetter}ProgramData\PCL\TaskTemp\{ModBase.GetUuid()}-{RandomUtils.NextInt(0, 1000000)}\";
+            Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL", "TaskTemp", $"{ModBase.GetUuid()}-{RandomUtils.NextInt(0, 1000000)}");
         Directory.CreateDirectory(ResultFolder);
         ModBase.CheckPermission(ResultFolder);
         return ResultFolder;

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -16,6 +16,8 @@ using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
 using PCL.Core.Utils;
+using PCL.Core.Utils.OS;
+using PCL.Core.Utils.Secret;
 
 namespace PCL;
 
@@ -1470,7 +1472,7 @@ public static class ModMain
     text = text.Replace("{pcl_version_code}", replacer(ModBase.VersionCode.ToString()));
     text = text.Replace("{pcl_version_branch}", replacer(ModBase.VersionBranchName));
     text = text.Replace("{pcl_branch}", replacer(ModBase.VersionBranchName));
-    text = text.Replace("{identify}", replacer(ModBase.UniqueAddress));
+    text = text.Replace("{identify}", replacer(Identify.LauncherId));
     text = text.Replace("{path}", replacer(Basics.ExecutableDirectory));
     text = text.Replace("{path_with_name}", replacer(Basics.ExecutableName));
     text = text.Replace("{path_temp}", replacer(ModBase.PathTemp));
@@ -1573,7 +1575,7 @@ public static class ModMain
             try
             {
                 ModBase.Log("[System] 开始清理任务缓存文件夹");
-                ModBase.DeleteDirectory($@"{ModBase.OsDrive}ProgramData\PCL\TaskTemp\");
+                ModBase.DeleteDirectory($@"{SystemPaths.DriveLetter}ProgramData\PCL\TaskTemp\");
                 ModBase.DeleteDirectory($@"{ModBase.PathTemp}TaskTemp\");
                 ModBase.Log("[System] 已清理任务缓存文件夹");
             }
@@ -1621,7 +1623,7 @@ public static class ModMain
 
         // 使用备用路径
         ResultFolder =
-            $@"{ModBase.OsDrive}ProgramData\PCL\TaskTemp\{ModBase.GetUuid()}-{RandomUtils.NextInt(0, 1000000)}\";
+            $@"{SystemPaths.DriveLetter}ProgramData\PCL\TaskTemp\{ModBase.GetUuid()}-{RandomUtils.NextInt(0, 1000000)}\";
         Directory.CreateDirectory(ResultFolder);
         ModBase.CheckPermission(ResultFolder);
         return ResultFolder;

--- a/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.Utils;
+using PCL.Core.Utils.OS;
 
 namespace PCL;
 
@@ -39,10 +40,10 @@ public static class UpdateManager
             if (IsCurrentVersionBeta && (int)Config.Update.UpdateChannel != 1)
             {
                 var isNewerThanStable = RemoteServer.IsLatest(UpdateChannel.stable,
-                    ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
+                    SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
                     ModBase.VersionCode);
                 var isBetaLatest = RemoteServer.IsLatest(UpdateChannel.beta,
-                    ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
+                    SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
                     ModBase.VersionCode);
                 return isNewerThanStable && isBetaLatest
                     ? UpdateEnums.VersionStatus.Latest
@@ -51,7 +52,7 @@ public static class UpdateManager
 
             return RemoteServer.IsLatest(
                 IsCurrentVersionBeta ? UpdateChannel.beta : UpdateChannel.stable,
-                ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
+                SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, SemVer.Parse(ModBase.VersionBaseName),
                 ModBase.VersionCode)
                 ? UpdateEnums.VersionStatus.Latest
                 : UpdateEnums.VersionStatus.NotLatest;
@@ -74,7 +75,7 @@ public static class UpdateManager
             {
                 var version = RemoteServer.GetLatestVersion(
                     IsCurrentVersionBeta ? UpdateChannel.beta : UpdateChannel.stable,
-                    ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64
+                    SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64
                 );
 
                 ModBase.WriteFile($"{ModBase.PathTemp}CEUpdateLog.md", version.Changelog);
@@ -98,7 +99,7 @@ public static class UpdateManager
                 // 下载
                 loaders.AddRange(RemoteServer.GetDownloadLoader(
                     IsCurrentVersionBeta ? UpdateChannel.beta : UpdateChannel.stable,
-                    ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, dlTargetPath));
+                    SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, dlTargetPath));
                 loaders.Add(new ModLoader.LoaderTask<int, int>("校验更新", _ =>
                 {
                     var curHash = ModBase.GetFileSHA256(dlTargetPath);
@@ -168,7 +169,7 @@ public static class UpdateManager
 
             // id old new restart
             var text =
-                $"update {Process.GetCurrentProcess().Id} \"{ModBase.ExePathWithName}\" \"{fileName}\" {(triggerRestart ? "true" : "false")}";
+                $"update {Process.GetCurrentProcess().Id} \"{Basics.ExecutablePath}\" \"{fileName}\" {(triggerRestart ? "true" : "false")}";
             ModBase.Log("[System] 更新程序启动，参数：" + text);
             Process.Start(new ProcessStartInfo(fileName)
                 { WindowStyle = ProcessWindowStyle.Hidden, CreateNoWindow = true, Arguments = text });
@@ -197,7 +198,7 @@ public static class UpdateManager
         // 注意：如果要自行实现这个功能，请换用另一个文件路径，以免与官方版本冲突
         var LatestPCLPath = Path.Combine(ModBase.PathTemp, "CE-Latest.exe");
         var target = RemoteServer.GetLatestVersion(UpdateChannel.stable,
-            ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
+            SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
         if (target is null)
             throw new Exception("无法获取更新");
         if (File.Exists(LatestPCLPath) && (ModBase.GetFileSHA256(LatestPCLPath) ?? "") == (target.SHA256 ?? ""))
@@ -206,14 +207,14 @@ public static class UpdateManager
             return;
         }
 
-        if ((ModBase.GetFileSHA256(ModBase.ExePathWithName) ?? "") == (target.SHA256 ?? "")) // 正在使用的版本符合要求，直接拿来用
+        if ((ModBase.GetFileSHA256(Basics.ExecutablePath) ?? "") == (target.SHA256 ?? "")) // 正在使用的版本符合要求，直接拿来用
         {
-            ModBase.CopyFile(ModBase.ExePathWithName, LatestPCLPath);
+            ModBase.CopyFile(Basics.ExecutablePath, LatestPCLPath);
             return;
         }
 
         var loaders = RemoteServer.GetDownloadLoader(UpdateChannel.stable,
-            ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, LatestPCLPath);
+            SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, LatestPCLPath);
         var loader = new ModLoader.LoaderCombo<int>("下载最新稳定版", loaders);
         loader.Start();
         loader.WaitForExit();

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
+using PCL.Core.App;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Diff;
 using PCL.Network;
@@ -79,7 +80,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
                 ?.FirstOrDefault();
             if (deJsonData is null)
                 throw new Exception("No assets can download!");
-            var selfSha256 = ModBase.GetFileSHA256(ModBase.ExePathWithName);
+            var selfSha256 = ModBase.GetFileSHA256(Basics.ExecutablePath);
             var remoteUpdSha256 = deJsonData.sha256;
             var patchFileName = $"{selfSha256}_{remoteUpdSha256}.patch";
             if (deJsonData.patches.Contains(patchFileName))
@@ -104,7 +105,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
             {
                 var diff = new BsDiff();
                 var newFile = diff
-                    .ApplyAsync(ModBase.ReadFileBytes(ModBase.ExePathWithName), ModBase.ReadFileBytes(tempPath))
+                    .ApplyAsync(ModBase.ReadFileBytes(Basics.ExecutablePath), ModBase.ReadFileBytes(tempPath))
                     .GetAwaiter().GetResult();
                 ModBase.WriteFile(output, newFile);
             }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -833,7 +833,7 @@ public partial class PageInstanceExport : IRefreshable
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
                         // 复制 PCL 本体
-                        if (IncludePCL) ModBase.CopyFile(ModBase.ExePathWithName, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
+                        if (IncludePCL) ModBase.CopyFile(Basics.ExecutablePath, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -833,7 +833,7 @@ public partial class PageInstanceExport : IRefreshable
             ModBase.CopyDirectory(Path.Combine(McInstance.PathInstance, "PCL"), Path.Combine(OverridesFolder, "PCL"));
             #if RELEASE
                         // 复制 PCL 本体
-                        if (IncludePCL) ModBase.CopyFile(Basics.ExecutablePath, Path.Combine(CacheFolder, "Plain Craft Launcher.exe"));
+                        if (IncludePCL) ModBase.CopyFile(Basics.ExecutablePath, Path.Combine(CacheFolder, Basics.ExecutableName));
             #endif
             // 复制 PCL 个性化内容
             if (IncludePCLCustom)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -134,7 +134,7 @@ public partial class PageInstanceSetup
             CheckAdvanceAssetsV2.Checked = Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.Instance.PathInstance];
             CheckAdvanceUseProxyV2.Checked = Config.Instance.UseProxy[PageInstanceLeft.Instance.PathInstance];
             CheckAdvanceJava.Checked = Config.Instance.IgnoreJavaCompatibility[PageInstanceLeft.Instance.PathInstance];
-            if (ModBase.IsArm64System)
+            if (SystemInfo.IsArm64System)
             {
                 CheckAdvanceDisableJLW.Checked = true;
                 CheckAdvanceDisableJLW.IsEnabled = false;
@@ -302,7 +302,7 @@ public partial class PageInstanceSetup
         LabRamUsed.Text = $"{Lang.Number(RamUsed, "N1")} GB";
         LabRamTotal.Text = $" / {Lang.Number(RamTotal, "N1")} GB";
         LabRamWarn.Visibility =
-            RamGame == 1d && !ModJava.IsGameSet64BitJava(PageInstanceLeft.Instance) && !ModBase.Is32BitSystem &&
+            RamGame == 1d && !ModJava.IsGameSet64BitJava(PageInstanceLeft.Instance) && !SystemInfo.Is32BitSystem &&
             ModJava.Javas.ExistAnyJava()
                 ? Visibility.Visible
                 : Visibility.Collapsed;

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -75,7 +75,7 @@ public partial class PageSetupLaunch
             CheckAdvanceGraphicCard.Checked = Config.Launch.SetGpuPreference;
             CheckAdvanceNoJavaw.Checked = Config.Launch.NoJavaw;
             CheckAdvanceDisableLwjglUnsafeAgent.Checked = Config.Launch.DisableLwjglUnsafeAgent;
-            if (ModBase.IsArm64System)
+            if (SystemInfo.IsArm64System)
             {
                 CheckAdvanceDisableJLW.Checked = true;
                 CheckAdvanceDisableJLW.IsEnabled = false;
@@ -245,7 +245,7 @@ public partial class PageSetupLaunch
         LabRamUsed.Text = $"{Lang.Number(ramUsed, "N1")} GB";
         LabRamTotal.Text = $" / {Lang.Number(ramTotal, "N1")} GB";
         LabRamWarn.Visibility =
-            ramGame == 1d && !ModJava.IsGameSet64BitJava() && !ModBase.Is32BitSystem && ModJava.Javas.ExistAnyJava()
+            ramGame == 1d && !ModJava.IsGameSet64BitJava() && !SystemInfo.Is32BitSystem && ModJava.Javas.ExistAnyJava()
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         HintRamTooHigh.Visibility = ramGame / ramTotal > 0.75d ? Visibility.Visible : Visibility.Collapsed;

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
@@ -226,7 +226,7 @@ public partial class PageSetupLauncherMisc
             return;
         File.Copy(sourcePath, ConfigService.SharedConfigPath, true);
         ModMain.MyMsgBox(Lang.Text("Setup.Misc.Import.Success.Message"), Button1: Lang.Text("Setup.Misc.Import.Success.Restart"), ForceWait: true);
-        Process.Start(new ProcessStartInfo(ModBase.ExePathWithName));
+        Process.Start(new ProcessStartInfo(Basics.ExecutablePath));
         FormMain.EndProgramForce();
     }
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUpdate.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUpdate.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Input;
 using PCL.Core.App;
 using PCL.Core.Utils;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils.OS;
 
 namespace PCL;
 
@@ -38,7 +39,7 @@ public partial class PageSetupUpdate
             // 或者你可以尝试替换为 PCL.Core.App.SemVer.Parse(ModBase.VersionBaseName)
             if (await UpdateManager.RemoteServer.IsLatestAsync(
                     UpdateManager.IsCurrentVersionBeta ? UpdateChannel.beta : UpdateChannel.stable,
-                    ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64,
+                    SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64,
                     SemVer.Parse(ModBase.VersionBaseName),
                     ModBase.VersionCode))
             {
@@ -73,7 +74,7 @@ public partial class PageSetupUpdate
                     UpdateInfo = UpdateManager.RemoteServer.GetLatestVersion(
                         UpdateManager.IsCurrentVersionBeta
                             ? UpdateChannel.beta
-                            : UpdateChannel.stable, ModBase.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
+                            : UpdateChannel.stable, SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
                     TextUpdateName.Text = "PCL CE " + VersionNameFormat(UpdateInfo.VersionName);
                     var summary = UpdateInfo.Changelog.Between("<summary>", "</summary>");
                     if (!UpdateInfo.Changelog.Contains("<summary>") || string.IsNullOrWhiteSpace(summary.Trim()))
@@ -154,7 +155,7 @@ public partial class PageSetupUpdate
         {
             ModMain.MyMsgBox(
                 Lang.Text("Setup.Update.DotNetMissing.Message", UpdateInfo.VersionName,
-                    ModBase.IsArm64System ? "Arm64" : "x64"),
+                    SystemInfo.IsArm64System ? "Arm64" : "x64"),
                 Lang.Text("Setup.Update.DotNetMissing.Title"),
                 Lang.Text("Setup.Update.DotNetMissing.DownloadRuntime"), Lang.Text("Common.Action.Cancel"),
                 Button1Action: () => ModBase.OpenWebsite("https://get.dot.net/8"), ForceWait: true);

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -255,7 +255,7 @@ public partial class PageToolsTest
                     }
 
                     num += ModBase.DeleteDirectory(ModBase.PathTemp, true);
-                    num += ModBase.DeleteDirectory( SystemPaths.DriveLetter + @"ProgramData\PCL\", true);
+                    num += ModBase.DeleteDirectory(SystemPaths.DriveLetter + @"ProgramData\PCL\", true);
                     if (num != 0)
                     {
                         ModMain.MyMsgBox($"""

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -255,7 +255,7 @@ public partial class PageToolsTest
                     }
 
                     num += ModBase.DeleteDirectory(ModBase.PathTemp, true);
-                    num += ModBase.DeleteDirectory(SystemPaths.DriveLetter + @"ProgramData\PCL\", true);
+                    num += ModBase.DeleteDirectory(Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL"), true);
                     if (num != 0)
                     {
                         ModMain.MyMsgBox($"""

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -255,7 +255,7 @@ public partial class PageToolsTest
                     }
 
                     num += ModBase.DeleteDirectory(ModBase.PathTemp, true);
-                    num += ModBase.DeleteDirectory(ModBase.OsDrive + @"ProgramData\PCL\", true);
+                    num += ModBase.DeleteDirectory( SystemPaths.DriveLetter + @"ProgramData\PCL\", true);
                     if (num != 0)
                     {
                         ModMain.MyMsgBox($"""
@@ -263,7 +263,7 @@ public partial class PageToolsTest
                                            PCL 即将自动重启……
                                            """,
                             "缓存已清理", Lang.Text("Common.Action.Confirm"), "", "", false, true, true);
-                        Process.Start(new ProcessStartInfo(ModBase.ExePathWithName));
+                        Process.Start(new ProcessStartInfo(Basics.ExecutablePath));
                         FormMain.EndProgramForce();
                     }
                     else


### PR DESCRIPTION
## Summary by Sourcery

从 ModBase 中提取系统架构、编码和驱动器信息到专用的核心工具中，并相应地更新所有使用方。

新功能：
- 通过核心 `SystemInfo` 实用工具暴露简单的系统信息标志（32 位、ARM64、GBK 编码）。
- 引入 `HardwareInfo` 实用工具，用于提供 CPU、GPU、内存和操作系统描述数据。

增强内容：
- 在更新、启动、Java 选择以及实例管理流程中，用 `SystemInfo` 和 `SystemPaths` 替换基于 ModBase 的架构检查和路径处理。
- 在启动或更新应用程序时，直接使用 `Basics.ExecutablePath`，而不是 ModBase 特定的封装。
- 优化崩溃报告和诊断逻辑，从 `HardwareInfo` 和 `Identify` 实用工具而非 ModBase 中获取硬件和标识符数据。
- 调整环境警告、内存（RAM）提示和规则检查，使其依赖共享的核心系统信息实用工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract system architecture, encoding, and drive information from ModBase into dedicated core utilities and update all consumers accordingly.

New Features:
- Expose simple system information flags (32-bit, ARM64, GBK encoding) via the core SystemInfo utility.
- Introduce a HardwareInfo utility to provide CPU, GPU, memory, and OS description data.

Enhancements:
- Replace ModBase-based architecture checks and paths with SystemInfo and SystemPaths across update, launch, Java selection, and instance management flows.
- Use Basics.ExecutablePath directly instead of ModBase-specific wrappers when launching or updating the application.
- Refine crash reporting and diagnostics to pull hardware and identifier data from HardwareInfo and Identify utilities instead of ModBase.
- Adjust environment warnings, RAM hints, and rule checks to rely on shared core system information utilities.

</details>