### PR TITLE
fix(Tools-Game-Link): 修复大厅公告获取时 JsonValue 转型失败

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -422,7 +422,7 @@ public partial class PageToolsGameLink
                 LobbyInfoProvider.RequiresLogin = (bool)jObj["requireLogin"];
                 LobbyInfoProvider.RequiresRealName = (bool)jObj["requireRealname"];
 
-                if (Convert.ToDouble(jObj["version"]) > LobbyInfoProvider.ProtocolVersion)
+                if (jObj["version"]?.GetValue<double>() > LobbyInfoProvider.ProtocolVersion)
                 {
                     ModBase.RunInUi(() =>
                     {
@@ -444,8 +444,8 @@ public partial class PageToolsGameLink
                     if (string.IsNullOrWhiteSpace(content)) continue;
 
                     // 版本过滤
-                    var minVer = Convert.ToDouble(notice["minVer"]);
-                    var maxVer = Convert.ToDouble(notice["maxVer"]);
+                    var minVer = notice["minVer"]?.GetValue<double>() ?? 0;
+                    var maxVer = notice["maxVer"]?.GetValue<double>() ?? double.MaxValue;
                     if (ModBase.VersionCode < minVer || ModBase.VersionCode > maxVer) continue;
 
                     // 类型映射

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -422,7 +422,7 @@ public partial class PageToolsGameLink
                 LobbyInfoProvider.RequiresLogin = (bool)jObj["requireLogin"];
                 LobbyInfoProvider.RequiresRealName = (bool)jObj["requireRealname"];
 
-                if (jObj["version"]?.GetValue<double>() > LobbyInfoProvider.ProtocolVersion)
+                if (jObj["version"].GetValue<double>() > LobbyInfoProvider.ProtocolVersion)
                 {
                     ModBase.RunInUi(() =>
                     {
@@ -444,8 +444,8 @@ public partial class PageToolsGameLink
                     if (string.IsNullOrWhiteSpace(content)) continue;
 
                     // 版本过滤
-                    var minVer = notice["minVer"]?.GetValue<double>() ?? 0;
-                    var maxVer = notice["maxVer"]?.GetValue<double>() ?? double.MaxValue;
+                    var minVer = notice["minVer"].GetValue<double>();
+                    var maxVer = notice["maxVer"].GetValue<double>();
                     if (ModBase.VersionCode < minVer || ModBase.VersionCode > maxVer) continue;
 
                     // 类型映射


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过使用具备默认值的可空安全转换，防止在读取大厅公告协议和公告版本范围时出现 `JsonValue` 类型转换失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent JsonValue cast failures when reading lobby announcement protocol and notice version ranges by using nullable-safe conversion with defaults.

</details>