### PR TITLE
fix(comp): 修复 Modrinth 依赖项缺少 project_id 时导致的空引用崩溃

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2860,6 +2860,7 @@ public static class ModComp
                     {
                         RawDependencies = Data["dependencies"].AsArray()
                             .Where(d => (string)d["dependency_type"] == "required" &&
+                                        d["project_id"] is not null &&
                                         (string)d["project_id"] != "P7dR8mSH" &&
                                         (string)d["project_id"] != "qvIfYCYJ" && d["project_id"].ToString().Length > 0)
                             .Select(d => d["project_id"].ToString()).ToList(); // 种类为必要依赖
@@ -2867,6 +2868,7 @@ public static class ModComp
                         // 有时候真的会空……
                         RawOptionalDependencies = Data["dependencies"].AsArray()
                             .Where(d => (string)d["dependency_type"] == "optional" &&
+                                        d["project_id"] is not null &&
                                         (string)d["project_id"] != "P7dR8mSH" &&
                                         (string)d["project_id"] != "qvIfYCYJ" && d["project_id"].ToString().Length > 0)
                             .Select(d => d["project_id"].ToString()).ToList(); // 种类为可选依赖


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在构建必需和可选依赖列表时，跳过 `project_id` 为 null 的依赖项，以避免空引用导致的崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip dependencies with null project_id values when building required and optional dependency lists to avoid null reference crashes.

</details>