### PR TITLE
fix(i18n): 修复资源保存对话框筛选器格式无效导致的崩溃

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1045,7 +1045,7 @@
     <sys:String x:Key="Download.Comp.Detail.SelectWorldInstallLocation">Select world install location (saves folder)</sys:String>
     <sys:String x:Key="Download.Comp.Detail.WorldFile.Filter">World file|*.zip</sys:String>
     <sys:String x:Key="Download.Comp.Detail.SelectSaveLocation">Select save location</sys:String>
-    <sys:String x:Key="Download.Comp.Detail.ResourceFile.Filter">{0} file|*.*</sys:String>
+    <sys:String x:Key="Download.Comp.Detail.ResourceFile.Filter">{0} file</sys:String>
     <sys:String x:Key="Download.Comp.Detail.InstanceFilter">Instance: </sys:String>
     <sys:String x:Key="Download.Comp.Detail.LoaderFilter">Mod loader: </sys:String>
     <sys:String x:Key="Download.Comp.Detail.SelectedVersion">Selected version: {0}{1}</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1045,7 +1045,7 @@
     <sys:String x:Key="Download.Comp.Detail.SelectWorldInstallLocation">选择世界安装位置 (saves 文件夹)</sys:String>
     <sys:String x:Key="Download.Comp.Detail.WorldFile.Filter">世界文件|*.zip</sys:String>
     <sys:String x:Key="Download.Comp.Detail.SelectSaveLocation">选择保存位置</sys:String>
-    <sys:String x:Key="Download.Comp.Detail.ResourceFile.Filter">{0}文件|*.*</sys:String>
+    <sys:String x:Key="Download.Comp.Detail.ResourceFile.Filter">{0}文件</sys:String>
     <sys:String x:Key="Download.Comp.Detail.InstanceFilter">实例筛选：</sys:String>
     <sys:String x:Key="Download.Comp.Detail.LoaderFilter">模组加载器筛选：</sys:String>
     <sys:String x:Key="Download.Comp.Detail.SelectedVersion">所选版本：{0}{1}</sys:String>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 更正资源保存对话框中使用的 en-US 和 zh-CN 本地化资源里的文件筛选器格式，以防止应用程序崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the file filter format in the en-US and zh-CN localization resources used by the resource save dialog to prevent application crashes.

</details>