### PR TITLE
fix(local-comp): 修复组件列表路径对比末尾反斜杠不一致

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -2005,7 +2005,7 @@ public static class ModLocalComp
                         foreach (var File in ModBase.EnumerateFiles(Loader.Input.CompPath))
                             try
                             {
-                                if ((File.DirectoryName.ToLower() + @"\" ?? "") != (RawName ?? ""))
+                                if ((File.DirectoryName.ToLower() ?? "") != (RawName.TrimEnd('\\') ?? ""))
                                     if (!(PageInstanceLeft.Instance is not null &&
                                           PageInstanceLeft.Instance.Info.HasForge &&
                                           PageInstanceLeft.Instance.Info.Drop < 130 && (File.Directory.Name ?? "") ==


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复由于路径比较中尾部反斜杠不匹配而导致组件目录过滤不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect filtering of component directories caused by mismatched trailing backslashes in path comparisons.

</details>