### PR TITLE
fix(local-mod-item): 修复更新资源时因页面未初始化导致的空引用崩溃

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/MyLocalModItem.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/MyLocalModItem.xaml.cs
@@ -309,21 +309,25 @@ public partial class MyLocalCompItem
                 {
                     case ModComp.CompType.Mod:
                     {
+                        ModMain.FrmInstanceMod ??= new PageInstanceCompResource(ModComp.CompType.Mod);
                         ModMain.FrmInstanceMod.UpdateResource(new[] { Entry });
                         break;
                     }
                     case ModComp.CompType.ResourcePack:
                     {
+                        ModMain.FrmInstanceResourcePack ??= new PageInstanceCompResource(ModComp.CompType.ResourcePack);
                         ModMain.FrmInstanceResourcePack.UpdateResource(new[] { Entry });
                         break;
                     }
                     case ModComp.CompType.Shader:
                     {
+                        ModMain.FrmInstanceShader ??= new PageInstanceCompResource(ModComp.CompType.Shader);
                         ModMain.FrmInstanceShader.UpdateResource(new[] { Entry });
                         break;
                     }
                     case ModComp.CompType.DataPack:
                     {
+                        ModMain.FrmInstanceSavesDatapack ??= new PageInstanceSavesDatapack();
                         ModMain.FrmInstanceSavesDatapack.UpdateResource(new[] { Entry });
                         break;
                     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过在使用前延迟初始化模组、资源包、着色器或数据包对应的实例页面，防止在更新这些内容时由于空引用导致的崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent null reference crashes when updating mods, resource packs, shaders, or datapacks by lazily initializing their corresponding instance pages before use.

</details>