### PR TITLE
fix(mod-download): 修复 LiteLoader BMCLAPI 版本列表 timestamp 解析失败

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -1733,7 +1733,7 @@ public static class ModDownload
                     FileName = "liteloader-installer-" + Pair.Key +
                                (Pair.Key == "1.8" || Pair.Key == "1.9" ? ".0" : "") + "-00-SNAPSHOT.jar",
                     MD5 = (string)RealEntry["md5"],
-                    ReleaseTime = TimeUtils.FormatUnixTimestamp((long)RealEntry["timestamp"]),
+                    ReleaseTime = TimeUtils.FormatUnixTimestamp(long.Parse((string)RealEntry["timestamp"])),
                     JsonToken = RealEntry
                 });
             }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过在转换之前将时间戳视为字符串值，解决 LiteLoader BMCLAPI 版本条目的时间戳解析失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve timestamp parsing failures for LiteLoader BMCLAPI version entries by treating timestamps as string values before conversion.

</details>