### PR TITLE
feat(homepage): 支持自定义主页局部更新

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -1,5 +1,12 @@
 using System.IO;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Newtonsoft.Json.Linq;
 using PCL.Core.App;
 using PCL.Core.Logging;
 using PCL.Core.UI;
@@ -17,6 +24,7 @@ public partial class PageLaunchRight : IRefreshable
             { ReloadTimeout = 10 * 60 * 1000 };
         Loaded += (_, _) => Init();
         Loaded += (_, _) => Refresh();
+        Unloaded += (_, _) => _DisposeHomepageLiveWatcher();
     }
 
     private void Init()
@@ -30,6 +38,7 @@ public partial class PageLaunchRight : IRefreshable
             : Visibility.Collapsed;
         LabHint1.Text = Lang.Text("Launch.Right.CommunityHint.Message");
         LabHint2.Text = Lang.Text("Launch.Right.CommunityHint.HidePrompt");
+        _EnsureHomepageLiveWatcher();
     }
 
     // 暂时关闭快照版提示
@@ -400,7 +409,10 @@ public partial class PageLaunchRight : IRefreshable
             // 如果加载目标内容一致则不加载
             var Hash = Content.GetHashCode();
             if (Hash == LoadedContentHash)
+            {
+                _ApplyHomepageLivePatchesFromFile();
                 return;
+            }
             LoadedContentHash = Hash;
             // 实际加载内容
             PanCustom.Children.Clear();
@@ -421,6 +433,7 @@ public partial class PageLaunchRight : IRefreshable
                     $"<StackPanel xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xmlns:sys=\"clr-namespace:System;assembly=System.Runtime\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:local=\"clr-namespace:PCL;assembly=Plain Craft Launcher 2\">{Content}</StackPanel>";
                 ModBase.Log($"[Page] 实例化：加载主页 UI 开始，最终内容长度：{Content.Count()}");
                 PanCustom.Children.Add((UIElement)ModBase.GetObjectFromXML(Content));
+                _ApplyHomepageLivePatchesFromFile();
             }
             catch (Exception ex)
             {
@@ -458,6 +471,350 @@ public partial class PageLaunchRight : IRefreshable
 
     private int LoadedContentHash = -1;
     private readonly object LoadContentLock = new();
+    private const string HomepageLivePatchFileName = "CustomLive.json";
+    private const string HomepageLiveSupportFileName = "CustomLive.supported.json";
+    // Keep the reflection patch surface explicit because patch files are written by external tools.
+    private static readonly Dictionary<string, string> _homepageLiveAllowedProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = "Text",
+        ["title"] = "Title",
+        ["info"] = "Info",
+        ["tooltip"] = "ToolTip",
+        ["visibility"] = "Visibility",
+        ["isEnabled"] = "IsEnabled",
+        ["opacity"] = "Opacity"
+    };
+    private FileSystemWatcher? _homepageLiveWatcher;
+    private DispatcherTimer? _homepageLivePatchTimer;
+
+    private void _EnsureHomepageLiveWatcher()
+    {
+        if (_homepageLiveWatcher != null) return;
+        if ((int)Config.Preference.Homepage.Type != 1) return;
+
+        try
+        {
+            var directory = _GetHomepageLiveDirectory();
+            Directory.CreateDirectory(directory);
+            _WriteHomepageLiveSupportMarker(directory);
+
+            _homepageLiveWatcher = new FileSystemWatcher(directory, HomepageLivePatchFileName)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName
+            };
+            _homepageLiveWatcher.Changed += (_, _) => _QueueHomepageLivePatchApply();
+            _homepageLiveWatcher.Created += (_, _) => _QueueHomepageLivePatchApply();
+            _homepageLiveWatcher.Renamed += (_, _) => _QueueHomepageLivePatchApply();
+            _homepageLiveWatcher.EnableRaisingEvents = true;
+            _QueueHomepageLivePatchApply();
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to start custom homepage live patch watcher", ModBase.LogLevel.Developer);
+        }
+    }
+
+    private void _DisposeHomepageLiveWatcher()
+    {
+        try
+        {
+            _homepageLiveWatcher?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to dispose custom homepage live patch watcher", ModBase.LogLevel.Developer);
+        }
+
+        _homepageLiveWatcher = null;
+
+        try
+        {
+            if (_homepageLivePatchTimer != null)
+            {
+                _homepageLivePatchTimer.Stop();
+                _homepageLivePatchTimer.Tick -= _HomepageLivePatchTimerTick;
+                _homepageLivePatchTimer = null;
+            }
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to dispose custom homepage live patch debounce timer", ModBase.LogLevel.Developer);
+        }
+
+        _DeleteHomepageLiveSupportMarker();
+    }
+
+    private void _QueueHomepageLivePatchApply()
+    {
+        ModBase.RunInUi(() =>
+        {
+            _homepageLivePatchTimer ??= new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(120)
+            };
+            _homepageLivePatchTimer.Tick -= _HomepageLivePatchTimerTick;
+            _homepageLivePatchTimer.Tick += _HomepageLivePatchTimerTick;
+            _homepageLivePatchTimer.Stop();
+            _homepageLivePatchTimer.Start();
+        });
+    }
+
+    private void _HomepageLivePatchTimerTick(object? sender, EventArgs e)
+    {
+        _homepageLivePatchTimer?.Stop();
+        _ApplyHomepageLivePatchesFromFile();
+    }
+
+    private void _ApplyHomepageLivePatchesFromFile()
+    {
+        if (PanCustom.Children.Count == 0) return;
+        if ((int)Config.Preference.Homepage.Type != 1) return;
+
+        var file = Path.Combine(_GetHomepageLiveDirectory(), HomepageLivePatchFileName);
+        if (!File.Exists(file)) return;
+
+        try
+        {
+            var token = JToken.Parse(_ReadHomepageLivePatchFile(file));
+            foreach (var patch in _EnumerateHomepageLivePatches(token))
+                _ApplyHomepageLivePatch(patch);
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to apply custom homepage live patches", ModBase.LogLevel.Developer);
+        }
+    }
+
+    private static string _ReadHomepageLivePatchFile(string file)
+    {
+        Exception? lastException = null;
+        for (var i = 0; i < 3; i++)
+        {
+            try
+            {
+                using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var reader = new StreamReader(stream);
+                return reader.ReadToEnd();
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                Thread.Sleep(50);
+            }
+        }
+
+        throw lastException ?? new IOException("Unable to read custom homepage live patch file.");
+    }
+
+    private static string _GetHomepageLiveDirectory()
+    {
+        return Path.Combine(ModBase.ExePath, "PCL");
+    }
+
+    private static void _WriteHomepageLiveSupportMarker(string directory)
+    {
+        try
+        {
+            var marker = new JObject
+            {
+                ["processId"] = Environment.ProcessId,
+                ["processPath"] = Environment.ProcessPath ?? "",
+                ["patchFile"] = HomepageLivePatchFileName,
+                ["startedAt"] = DateTime.Now.ToString("O", CultureInfo.InvariantCulture)
+            };
+            File.WriteAllText(Path.Combine(directory, HomepageLiveSupportFileName), marker.ToString(Newtonsoft.Json.Formatting.None));
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to write custom homepage live patch support marker", ModBase.LogLevel.Developer);
+        }
+    }
+
+    private static void _DeleteHomepageLiveSupportMarker()
+    {
+        try
+        {
+            var file = Path.Combine(_GetHomepageLiveDirectory(), HomepageLiveSupportFileName);
+            if (!File.Exists(file)) return;
+
+            var marker = JObject.Parse(_ReadHomepageLivePatchFile(file));
+            if (marker["processId"]?.Value<int?>() == Environment.ProcessId)
+                File.Delete(file);
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "[Page] Failed to delete custom homepage live patch support marker", ModBase.LogLevel.Developer);
+        }
+    }
+
+    private static IEnumerable<JObject> _EnumerateHomepageLivePatches(JToken token)
+    {
+        if (token is JObject obj)
+        {
+            if (obj["patches"] is JArray patches)
+            {
+                foreach (var patch in patches.OfType<JObject>())
+                    yield return patch;
+                yield break;
+            }
+
+            if (_TryGetString(obj, "target", "tag", "name") != null)
+            {
+                yield return obj;
+                yield break;
+            }
+
+            foreach (var property in obj.Properties())
+            {
+                if (property.Value is not JObject patch) continue;
+                patch = (JObject)patch.DeepClone();
+                patch["target"] ??= property.Name;
+                yield return patch;
+            }
+        }
+        else if (token is JArray array)
+        {
+            foreach (var patch in array.OfType<JObject>())
+                yield return patch;
+        }
+    }
+
+    private void _ApplyHomepageLivePatch(JObject patch)
+    {
+        var target = _TryGetString(patch, "target", "tag", "name");
+        if (string.IsNullOrWhiteSpace(target)) return;
+
+        foreach (var element in _FindElementsByTag(PanCustom, target))
+            _ApplyHomepageLivePatchToElement(element, patch);
+    }
+
+    private void _ApplyHomepageLivePatchToElement(FrameworkElement element, JObject patch)
+    {
+        _SetPropertyIfPresent(element, patch, "text", "Text");
+        _SetPropertyIfPresent(element, patch, "title", "Title");
+        _SetPropertyIfPresent(element, patch, "info", "Info");
+        _SetPropertyIfPresent(element, patch, "tooltip", "ToolTip");
+        _SetPropertyIfPresent(element, patch, "toolTip", "ToolTip");
+        _SetPropertyIfPresent(element, patch, "visibility", "Visibility");
+        _SetPropertyIfPresent(element, patch, "isEnabled", "IsEnabled");
+        _SetPropertyIfPresent(element, patch, "opacity", "Opacity");
+
+        if (patch["properties"] is JObject properties)
+        {
+            foreach (var property in properties.Properties())
+                _TrySetElementProperty(element, property.Name, property.Value?.ToString() ?? "");
+        }
+
+        var childrenXaml = _TryGetString(patch, "childrenXaml", "ChildrenXaml");
+        if (!string.IsNullOrEmpty(childrenXaml) && element is Panel panel)
+            _ReplacePanelChildren(panel, childrenXaml);
+    }
+
+    private static void _SetPropertyIfPresent(FrameworkElement element, JObject patch, string jsonName, string propertyName)
+    {
+        if (patch.TryGetValue(jsonName, StringComparison.OrdinalIgnoreCase, out var value))
+            _TrySetElementProperty(element, propertyName, value?.ToString() ?? "");
+    }
+
+    private static bool _TrySetElementProperty(FrameworkElement element, string propertyName, string value)
+    {
+        if (!_homepageLiveAllowedProperties.TryGetValue(propertyName, out var allowedPropertyName))
+        {
+            ModBase.Log($"[Page] Skipped unsupported live patch property {propertyName}", ModBase.LogLevel.Developer);
+            return false;
+        }
+
+        propertyName = allowedPropertyName;
+        var property = element.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        if (property == null || !property.CanWrite) return false;
+
+        try
+        {
+            var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+            var trimmedValue = value.Trim();
+            object convertedValue;
+            if (propertyType == typeof(string))
+                convertedValue = value;
+            else if (propertyType == typeof(object))
+                convertedValue = value;
+            else if (propertyType == typeof(bool) && bool.TryParse(trimmedValue, out var boolValue))
+                convertedValue = boolValue;
+            else if (propertyType == typeof(int) && int.TryParse(trimmedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+                convertedValue = intValue;
+            else if (propertyType == typeof(double) && double.TryParse(trimmedValue, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
+                convertedValue = doubleValue;
+            else if (propertyType == typeof(Visibility))
+            {
+                if (!Enum.TryParse(trimmedValue, true, out Visibility visibilityValue))
+                    return false;
+                convertedValue = visibilityValue;
+            }
+            else if (propertyType.IsEnum && Enum.TryParse(propertyType, trimmedValue, true, out var enumValue))
+                convertedValue = enumValue;
+            else
+                return false;
+
+            property.SetValue(element, convertedValue);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, $"[Page] Failed to set live patch property {propertyName}", ModBase.LogLevel.Developer);
+            return false;
+        }
+    }
+
+    private static void _ReplacePanelChildren(Panel panel, string childrenXaml)
+    {
+        var content = ModMain.ArgumentReplace(childrenXaml);
+        while (content.Contains("xmlns"))
+            content = content.RegexReplace("xmlns[^\"']*(\"|')[^\"']*(\"|')", "").Replace("xmlns", "");
+
+        var wrapped =
+            $"<StackPanel xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xmlns:sys=\"clr-namespace:System;assembly=System.Runtime\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:local=\"clr-namespace:PCL;assembly=Plain Craft Launcher 2\">{content}</StackPanel>";
+
+        if (ModBase.GetObjectFromXML(wrapped) is not Panel parsedPanel) return;
+
+        var children = parsedPanel.Children.OfType<UIElement>().ToList();
+        parsedPanel.Children.Clear();
+        panel.Children.Clear();
+        foreach (var child in children)
+            panel.Children.Add(child);
+    }
+
+    private static IEnumerable<FrameworkElement> _FindElementsByTag(DependencyObject root, string tag)
+    {
+        if (root is FrameworkElement element &&
+            string.Equals(element.Tag?.ToString(), tag, StringComparison.OrdinalIgnoreCase))
+            yield return element;
+
+        int count;
+        try
+        {
+            count = VisualTreeHelper.GetChildrenCount(root);
+        }
+        catch
+        {
+            yield break;
+        }
+
+        for (var i = 0; i < count; i++)
+        {
+            foreach (var child in _FindElementsByTag(VisualTreeHelper.GetChild(root, i), tag))
+                yield return child;
+        }
+    }
+
+    private static string? _TryGetString(JObject obj, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (obj.TryGetValue(name, StringComparison.OrdinalIgnoreCase, out var value))
+                return value?.ToString();
+        }
+
+        return null;
+    }
 
     #endregion
 }


### PR DESCRIPTION
﻿## 概述

本 PR 为本地自定义主页增加一个轻量的 live patch 机制，让外部辅助程序可以在不刷新整个主页的情况下更新指定控件内容。

主要变化：

- 在本地 `Custom.xaml` 主页启用时监听 `PCL/CustomLive.json`。
- 写入 `CustomLive.supported.json`，用于让外部程序判断当前启动器是否支持局部更新。
- 支持通过控件 `Tag` 匹配目标元素。
- 支持更新白名单内的常见属性：`Text`、`Title`、`Info`、`ToolTip`、`Visibility`、`IsEnabled`、`Opacity`。
- 支持通过 `childrenXaml` 替换目标 `Panel` 的子元素。
- 在主页内容未变化时，也会尝试应用 live patch，避免必须整页刷新。

## 适用场景

该机制适合需要动态更新自定义主页局部内容的场景，例如：

- 只刷新某个提示文本。
- 更新某张卡片的状态信息。
- 替换某个面板内的局部 XAML 内容。

相比直接触发整页刷新，这可以减少主页跳动、折叠状态丢失、滚动位置变化等问题。

## Review 反馈处理

根据反馈已补充以下调整：

- 数值解析使用 `CultureInfo.InvariantCulture` 和 `TryParse`，枚举解析使用 `Enum.TryParse`，避免外部工具传入异常格式时受区域设置影响或直接抛出。
- `FileSystemWatcher` 的变更防抖改为 UI 线程上的 `DispatcherTimer`，避免每轮文件变更额外创建后台线程。
- `DisposeHomepageLiveWatcher` 与 `DeleteHomepageLiveSupportMarker` 不再静默吞掉异常，会将释放 watcher / 删除支持标记失败写入 Developer 日志，方便诊断 live patch 问题。
- 反射写属性增加白名单限制，仅允许写入明确支持的轻量 UI 属性，避免外部 patch 文件绕过编译期约束修改任意公开属性。
- 新提交已使用 SSH signing key 签名，并已在 GitHub 上验证为 Verified。

## 验证

已执行：

```powershell
..\.dotnet-sdk-10\dotnet.exe build "Plain Craft Launcher 2\Plain Craft Launcher 2.csproj" -c Release -p:Platform=x64 -p:DefineConstants=TRACE -p:UseSharedCompilation=false
```

结果：构建通过，0 个错误。项目现有 warning 仍存在。

## Summary by Sourcery

为自定义主页添加实时补丁支持，使外部工具可以在不重新加载整个页面的情况下更新特定的 UI 元素。

New Features:
- 监听本地 JSON 文件的实时补丁，并在自定义主页处于激活状态时将其应用到主页上。
- 暴露一个支持标记文件，用于描述实时补丁的能力以及供外部工具使用的过程元数据。
- 允许通过 Tag 定位首页元素，并通过 JSON 补丁更新常见 UI 属性白名单以及面板子元素。

Enhancements:
- 在 UI 线程上对文件系统变更事件进行防抖处理，并为实时补丁操作添加更健壮的文件读取和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add live patch support for the custom homepage so external tools can update specific UI elements without reloading the entire page.

New Features:
- Watch a local JSON file for live patches and apply them to the custom homepage when it is active.
- Expose a support marker file describing the live patch capabilities and process metadata for external tools.
- Allow targeting homepage elements by Tag and updating a whitelist of common UI properties and panel children via JSON patches.

Enhancements:
- Debounce filesystem change events on the UI thread and add robust file reading and logging for live patch operations.

</details>