### PR TITLE
imp(http): modify lifetime from 2 minutes to 15 minutes

### DIFF
--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -26,7 +26,7 @@ public partial class NetworkService
     {
         _repo.Initialize();
         var services = new ServiceCollection();
-        services.AddHttpClient("default")
+        services.AddHttpClient("default").SetHandlerLifetime(TimeSpan.FromMinutes(15))
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
                 UseProxy = true,
@@ -40,7 +40,7 @@ public partial class NetworkService
                     : null
             }
         );
-        services.AddHttpClient("cache").ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
+        services.AddHttpClient("cache").SetHandlerLifetime(TimeSpan.FromMinutes(15)).ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
             new SocketsHttpHandler
             {
                 UseProxy = true,

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -16,6 +16,9 @@ namespace PCL.Core.IO.Net;
 [LifecycleScope("network", "网络服务")]
 public partial class NetworkService
 {
+
+    private const int _lifetime = 15;
+    
     private static HttpCacheRepository _repo = new(Path.Combine(Paths.Temp, "cache", "cache.db"), Path.Combine(Paths.Temp, "cache"));
 
     private static ServiceProvider? _provider;
@@ -26,7 +29,7 @@ public partial class NetworkService
     {
         _repo.Initialize();
         var services = new ServiceCollection();
-        services.AddHttpClient("default").SetHandlerLifetime(TimeSpan.FromMinutes(15))
+        services.AddHttpClient("default").SetHandlerLifetime(TimeSpan.FromMinutes(_lifetime))
             .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
                 UseProxy = true,
@@ -40,7 +43,7 @@ public partial class NetworkService
                     : null
             }
         );
-        services.AddHttpClient("cache").SetHandlerLifetime(TimeSpan.FromMinutes(15)).ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
+        services.AddHttpClient("cache").SetHandlerLifetime(TimeSpan.FromMinutes(_lifetime)).ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
             new SocketsHttpHandler
             {
                 UseProxy = true,


### PR DESCRIPTION
Set lifetime from 2 minutes(default) to 15 minutes to impore the performance of http request.

## Summary by Sourcery

增加 HTTP 客户端处理程序的生命周期，以减少连接抖动并提升 HTTP 请求性能。

改进内容：
- 将默认命名的 HTTP 客户端配置为使用 15 分钟的处理程序生命周期。
- 将缓存 HTTP 客户端配置为使用 15 分钟的处理程序生命周期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase HTTP client handler lifetimes to reduce connection churn and improve HTTP request performance.

Enhancements:
- Configure the default named HTTP client to use a 15-minute handler lifetime.
- Configure the cache HTTP client to use a 15-minute handler lifetime.

</details>