### PR TITLE
fix(json): 修复有关 JSON 的一系列问题

### DIFF
--- a/PCL.Core.Test/App/CommandLineTest.cs
+++ b/PCL.Core.Test/App/CommandLineTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PCL.Core.App.Cli;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Test.App;
 
@@ -42,7 +43,7 @@ public sealed class CommandLineTest
         Assert.AreEqual(_correct, modelStr);
     }
 
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonCompat.SerializerOptions)
     {
         WriteIndented = true,
     };
@@ -54,7 +55,7 @@ public sealed class CommandLineTest
         var json = JsonSerializer.Serialize(_model, _jsonSerializerOptions);
         Console.WriteLine(json);
         Console.WriteLine("Deserialization result:");
-        var modelStr = JsonSerializer.Deserialize<CommandLine>(json)?.ToString();
+        var modelStr = JsonSerializer.Deserialize<CommandLine>(json, _jsonSerializerOptions)?.ToString();
         Console.WriteLine(modelStr);
         Assert.AreEqual(_correct, modelStr);
     }

--- a/PCL.Core.Test/DynamicJsonTest.cs
+++ b/PCL.Core.Test/DynamicJsonTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Dynamic;
 using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,11 +13,9 @@ namespace PCL.Core.Test
         public void TestDynamicJson()
         {
             dynamic obj = new { a = 123, b = new { c = this, d = "text" } };
-            var options = new JsonSerializerOptions
+            var options = new JsonSerializerOptions(JsonCompat.SerializerOptions)
             {
-                WriteIndented = true, 
-                Converters = { new ExpandoObjectConverter() },
-                AllowTrailingCommas = true
+                WriteIndented = true
             };
             string json = JsonSerializer.Serialize(obj, options);
             Console.WriteLine(json);

--- a/PCL.Core/App/Basics.cs
+++ b/PCL.Core/App/Basics.cs
@@ -22,7 +22,7 @@ public static class Basics
     /// 启动器元数据。
     /// </summary>
     public static MetadataModel Metadata { get; } = JsonSerializer.Deserialize<MetadataModel>(
-        Assembly.GetEntryAssembly()!.GetManifestResourceStream("PCL.metadata.json")!)!;
+        Assembly.GetEntryAssembly()!.GetManifestResourceStream("PCL.metadata.json")!, JsonCompat.SerializerOptions)!;
 
     /// <summary>
     /// 版本名称。

--- a/PCL.Core/App/Configuration/Storage/ConfigStorage.cs
+++ b/PCL.Core/App/Configuration/Storage/ConfigStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -6,6 +6,7 @@ using System.Text.Json;
 using PCL.Core.App.IoC;
 using PCL.Core.Logging;
 using PCL.Core.Utils.Diagnostics;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Configuration.Storage;
 
@@ -79,7 +80,7 @@ public abstract class ConfigStorage : IConfigProvider
         return hasOutput;
     }
 
-    private static readonly JsonSerializerOptions _SerializerOptions = new()
+    private static readonly JsonSerializerOptions _SerializerOptions = new(JsonCompat.SerializerOptions)
     {
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };

--- a/PCL.Core/App/Configuration/Storage/EncryptedFileConfigStorage.cs
+++ b/PCL.Core/App/Configuration/Storage/EncryptedFileConfigStorage.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using PCL.Core.Logging;
 using PCL.Core.Utils.Secret;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Configuration.Storage;
 
@@ -12,12 +13,10 @@ public class EncryptedFileConfigStorage(ConfigStorage source) : ConfigStorage
 {
     public ConfigStorage Source { get; } = source;
 
-    private static readonly JsonSerializerOptions _SerializerOptions = new()
+    private static readonly JsonSerializerOptions _SerializerOptions = new(JsonCompat.SerializerOptions)
     {
         WriteIndented = false,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true,
         AllowOutOfOrderMetadataProperties = true,
     };
 

--- a/PCL.Core/App/Configuration/Storage/JsonFileProvider.cs
+++ b/PCL.Core/App/Configuration/Storage/JsonFileProvider.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Configuration.Storage;
 
@@ -15,16 +16,11 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
 {
     private readonly JsonObject _rootElement;
 
-    private static readonly JsonDocumentOptions _DocumentOptions = new()
-    {
-        AllowTrailingCommas = true,
-        CommentHandling = JsonCommentHandling.Skip
-    };
+    private static readonly JsonDocumentOptions _DocumentOptions = JsonCompat.DocumentOptions;
 
-    private static readonly JsonSerializerOptions _SerializerOptions = new()
+    private static readonly JsonSerializerOptions _SerializerOptions = new(JsonCompat.SerializerOptions)
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        AllowTrailingCommas = true,
         AllowOutOfOrderMetadataProperties = true,
     };
 
@@ -40,7 +36,7 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
             if (File.Exists(path))
             {
                 using var stream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                var parseResult = JsonNode.Parse(stream, documentOptions: _DocumentOptions);
+                var parseResult = JsonNode.Parse(stream, JsonCompat.NodeOptions, _DocumentOptions);
                 if (parseResult is not JsonObject root)
                     throw new ConfigFileInitException(path,
                         $"Invalid root element type: {parseResult?.GetValueKind().ToString() ?? "Empty"}");
@@ -66,7 +62,7 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
         if (result is null) throw new KeyNotFoundException($"Not found: '{key}'");
         try
         {
-            var r = result.Deserialize<T>();
+            var r = result.Deserialize<T>(_SerializerOptions);
             return r ?? throw GetNullException();
         }
         catch (JsonException)
@@ -76,7 +72,7 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
             if (type == typeof(string)) fallback = (T)(object)result.ToString();
             else
             {
-                var jsonStr = result.Deserialize<string>()!;
+                var jsonStr = result.Deserialize<string>(_SerializerOptions)!;
                 if (type == typeof(bool)) fallback = (T)(object)(jsonStr.ToLowerInvariant() is "true" or "1");
                 else fallback = JsonSerializer.Deserialize<T>(jsonStr, _SerializerOptions) ?? throw GetNullException();
             }
@@ -88,7 +84,7 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
 
     public override void Set<T>(string key, T value)
     {
-        _rootElement[key] = JsonSerializer.SerializeToNode(value);
+        _rootElement[key] = JsonSerializer.SerializeToNode(value, _SerializerOptions);
     }
 
     public override bool Exists(string key)

--- a/PCL.Core/App/Configuration/Storage/JsonToYamlConverter.cs
+++ b/PCL.Core/App/Configuration/Storage/JsonToYamlConverter.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using YamlDotNet.Serialization;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Configuration.Storage;
 
@@ -26,7 +27,7 @@ public static class JsonToYamlConverter
         if (!jsonInput.CanRead) throw new ArgumentException("must be readable", nameof(jsonInput));
         if (!yamlOutput.CanWrite) throw new ArgumentException("must be writable", nameof(yamlOutput));
 
-        using var doc = JsonDocument.Parse(jsonInput);
+        using var doc = JsonDocument.Parse(jsonInput, JsonCompat.DocumentOptions);
         var obj = _ConvertElement(doc.RootElement);
 
         var serializer = new SerializerBuilder().Build();
@@ -48,7 +49,7 @@ public static class JsonToYamlConverter
         if (!jsonInput.CanRead) throw new ArgumentException("jsonInput must be readable", nameof(jsonInput));
         if (!yamlOutput.CanWrite) throw new ArgumentException("yamlOutput must be writable", nameof(yamlOutput));
 
-        using var doc = await JsonDocument.ParseAsync(jsonInput).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(jsonInput, JsonCompat.DocumentOptions).ConfigureAwait(false);
         var obj = _ConvertElement(doc.RootElement);
 
         var serializer = new SerializerBuilder().Build();

--- a/PCL.Core/App/Essentials/PromoteService.cs
+++ b/PCL.Core/App/Essentials/PromoteService.cs
@@ -10,6 +10,7 @@ using PCL.Core.App.IoC;
 using PCL.Core.IO;
 using PCL.Core.Logging;
 using PCL.Core.Utils.OS;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Essentials;
 
@@ -71,7 +72,7 @@ public sealed partial class PromoteService
         return AddOperationFunction(name, arg =>
         {
             if (arg is null) return OperationErrEmpty;
-            var obj = JsonSerializer.Deserialize<TValue>(arg);
+            var obj = JsonSerializer.Deserialize<TValue>(arg, JsonCompat.SerializerOptions);
             return operation(obj);
         });
     }

--- a/PCL.Core/App/Essentials/SingleInstanceService.cs
+++ b/PCL.Core/App/Essentials/SingleInstanceService.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using PCL.Core.App.IoC;
 using PCL.Core.IO;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Essentials;
 
@@ -48,7 +49,7 @@ public sealed partial class SingleInstanceService
                 Context.Info($"发现重复实例 {pid}，尝试传递参数并拉起主窗口");
                 try
                 {
-                    _TryRpc(pid, "REQ cli\n" + JsonSerializer.Serialize(StartupService.UnhandledCommands));
+                    _TryRpc(pid, "REQ cli\n" + JsonSerializer.Serialize(StartupService.UnhandledCommands, JsonCompat.SerializerOptions));
                     _TryRpc(pid, "REQ activate");
                 }
                 catch (Exception ex) { Context.Warn("RPC 通信失败", ex); }

--- a/PCL.Core/App/Essentials/StartupService.cs
+++ b/PCL.Core/App/Essentials/StartupService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +10,7 @@ using PCL.Core.App.Cli;
 using PCL.Core.App.IoC;
 using PCL.Core.Utils.OS;
 using PCL.Core.Utils.Secret;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Essentials;
 
@@ -139,7 +140,7 @@ public sealed partial class StartupService
         if (content is null) return RpcResponse.Err("Must provide valid JSON model");
         try
         {
-            var models = JsonSerializer.Deserialize<Dictionary<string, CommandLine>>(content);
+            var models = JsonSerializer.Deserialize<Dictionary<string, CommandLine>>(content, JsonCompat.SerializerOptions);
             if (models is null) return RpcResponse.Err("Invalid JSON: empty/null content");
             Task.Run(() =>
             {

--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -1,4 +1,4 @@
-using PCL.Core.App.IoC;
+﻿using PCL.Core.App.IoC;
 using PCL.Core.UI;
 using System;
 using System.Diagnostics;
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL.Core.App.Tools;
 
@@ -72,7 +73,7 @@ public sealed partial class DependencyCheckService
         try
         {
             // ConvertTo-Json 结构不一定可靠，不太能 Serialize
-            jnode = await JsonNode.ParseAsync(ps.StandardOutput.BaseStream);
+            jnode = await JsonNode.ParseAsync(ps.StandardOutput.BaseStream, JsonCompat.NodeOptions, JsonCompat.DocumentOptions);
         }
         catch
         {
@@ -103,7 +104,7 @@ public sealed partial class DependencyCheckService
         // 检查当前的 JsonNode 下是否是符合的包
         static bool CheckPackSuit(JsonNode jnode, string id)
         {
-            var findedPackName = jnode["Name"]?.GetValue<string>();
+            var findedPackName = JsonCompat.ToObject<string>(jnode["Name"]);
             return findedPackName is not null && findedPackName.Contains(id);
         }
     }

--- a/PCL.Core/IO/Files.cs
+++ b/PCL.Core/IO/Files.cs
@@ -1,9 +1,10 @@
-﻿using ICSharpCode.SharpZipLib.BZip2;
+using ICSharpCode.SharpZipLib.BZip2;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
 using PCL.Core.Logging;
 using PCL.Core.UI;
+using PCL.Core.Utils;
 using PCL.Core.Utils.Codecs;
 using PCL.Core.Utils.Exts;
 using PCL.Core.Utils.Hash;
@@ -23,10 +24,9 @@ using PCL.Core.App;
 namespace PCL.Core.IO;
 
 public static class Files {
-    public static readonly JsonSerializerOptions PrettierJsonOptions = new() {
+    public static readonly JsonSerializerOptions PrettierJsonOptions = new(JsonCompat.SerializerOptions) {
         WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
     /// <summary>
@@ -803,7 +803,7 @@ public static class Files {
                 var content = await ReadAllTextOrEmptyAsync(localPath);
                 if (string.IsNullOrEmpty(content)) throw new Exception("读取到的文件为空");
                 try {
-                    using var document = JsonDocument.Parse(content);
+                    using var document = JsonDocument.Parse(content, JsonCompat.DocumentOptions);
                     // 简单验证 JSON 有效性
                 } catch (JsonException ex) {
                     throw new Exception(Lang.Text("Common.Error.InvalidJson"), ex);

--- a/PCL.Core/IO/Net/Http/HttpContentExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpContentExtension.cs
@@ -1,7 +1,8 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using PCL.Core.Utils;
 
 namespace PCL.Core.IO.Net.Http;
 
@@ -30,10 +31,10 @@ public static class HttpContentExtension
             return requestMessage;
         }
 
-        public HttpRequestMessage WithJsonContent<T>(T content, string? contentType = null)
+        public HttpRequestMessage WithJsonContent<T>(T content, string? contentType = null, JsonSerializerOptions? options = null)
         {
             requestMessage.Content = new StringContent(
-                JsonSerializer.Serialize(content),
+                JsonSerializer.Serialize(content, options ?? JsonCompat.SerializerOptions),
                 Encoding.UTF8,
                 contentType ?? "application/json");
             return requestMessage;

--- a/PCL.Core/IO/Net/Http/HttpResponseExtension.cs
+++ b/PCL.Core/IO/Net/Http/HttpResponseExtension.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Utils;
 
 namespace PCL.Core.IO.Net.Http;
 
@@ -66,7 +67,7 @@ public static class HttpResponseExtension
             try
             {
                 await using var stream = await responseMessage.AsStreamAsync(cancellationToken).ConfigureAwait(false);
-                return await JsonSerializer.DeserializeAsync<T>(stream, options, cancellationToken)
+                return await JsonSerializer.DeserializeAsync<T>(stream, options ?? JsonCompat.SerializerOptions, cancellationToken)
                     .ConfigureAwait(false);
             } catch(JsonException ex)
             {

--- a/PCL.Core/IO/Net/Http/HttpRouteResponse.cs
+++ b/PCL.Core/IO/Net/Http/HttpRouteResponse.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -136,7 +136,7 @@ public class HttpRouteResponse
     public static HttpRouteResponse Json(object obj, JsonSerializerOptions? options)
     {
         var stream = new MemoryStream();
-        JsonSerializer.Serialize(stream, obj, options);
+        JsonSerializer.Serialize(stream, obj, options ?? JsonCompat.SerializerOptions);
         stream.Position = 0;
         return new HttpRouteResponse
         {
@@ -150,5 +150,5 @@ public class HttpRouteResponse
     /// 响应指定对象序列化得到的 JSON 内容，固定使用 UTF-8 编码
     /// </summary>
     /// <param name="obj">用于序列化的对象</param>
-    public static HttpRouteResponse Json(object obj) => Json(obj, null);
+    public static HttpRouteResponse Json(object obj) => Json(obj, JsonCompat.SerializerOptions);
 }

--- a/PCL.Core/Link/EasyTier/ETInfoProvider.cs
+++ b/PCL.Core/Link/EasyTier/ETInfoProvider.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using PCL.Core.App;
 using PCL.Core.IO;
 using PCL.Core.Logging;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.EasyTier;
 // ReSharper disable InconsistentNaming, CompareOfFloatsByEqualityOperator
@@ -142,11 +143,11 @@ public static class ETInfoProvider
 
             var playerList = new List<ETPlayerInfo>();
             ETPlayerInfo? localInfo = null;
-            if (JsonNode.Parse(output) is not JsonArray json)
+            if (JsonCompat.ParseNode(output) is not JsonArray json)
                 return new Tuple<List<ETPlayerInfo>?, ETPlayerInfo?>(null, null);
             foreach (var p in json)
             {
-                var info = p.Deserialize<ETPeerInfo>();
+                var info = p.Deserialize<ETPeerInfo>(JsonCompat.SerializerOptions);
                 if (info is null) { continue; }
                 if (info.Hostname.StartsWith("PublicServer")) { continue; } // 服务器
                 var hostnameSplit = info.Hostname.Split('|');

--- a/PCL.Core/Link/McPing/McPingService.cs
+++ b/PCL.Core/Link/McPing/McPingService.cs
@@ -1,4 +1,4 @@
-using System.Buffers.Binary;
+﻿using System.Buffers.Binary;
 using PCL.Core.Link.McPing.Model;
 using PCL.Core.Logging;
 using PCL.Core.Utils;
@@ -127,7 +127,7 @@ public class McPingService : IMcPingService
         if (statusPayload is null || statusPayload.Length == 0) throw new InvalidDataException("未返回服务器信息");
         var retCtx = Encoding.UTF8.GetString(statusPayload);
 
-        var retJson = JsonNode.Parse(retCtx) ?? throw new NullReferenceException("服务器返回了错误的信息");
+        var retJson = JsonCompat.ParseNode(retCtx) ?? throw new NullReferenceException("服务器返回了错误的信息");
 #if DEBUG
         var resJsonDebug = retJson.DeepClone();
         if (resJsonDebug is JsonObject jsonObject && jsonObject.ContainsKey("favicon"))
@@ -143,7 +143,7 @@ public class McPingService : IMcPingService
             retJson["description"] = _ConvertJNodeToMcString(descObj);
         }
 
-        var response = JsonSerializer.Deserialize<McPingResult>(retJson);
+        var response = JsonSerializer.Deserialize<McPingResult>(retJson, JsonCompat.SerializerOptions);
         if (response?.Version is null)
             throw new NullReferenceException("服务器返回了错误的字段，缺失: version");
 

--- a/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
+++ b/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
@@ -1,4 +1,4 @@
-using PCL.Core.App;
+﻿using PCL.Core.App;
 using PCL.Core.Logging;
 using PCL.Core.UI;
 using PCL.Core.Utils.OS;
@@ -8,6 +8,8 @@ using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using PCL.Core.IO.Net.Http;
+using System.Text.Json;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Natayark;
 
@@ -65,7 +67,7 @@ public static class NatayarkProfileManager
 
                 var result = await oauthResponse.AsStringAsync().ConfigureAwait(false) 
                     ?? throw new Exception("获取 AccessToken 与 RefreshToken 失败，返回内容为空");
-                var data = JsonNode.Parse(result);
+                var data = JsonCompat.ParseNode(result);
                 var accessToken = data?["access_token"]?.ToString();
                 var refreshToken = data?["refresh_token"]?.ToString();
 
@@ -87,14 +89,14 @@ public static class NatayarkProfileManager
 
                 var receivedUserData = await userDataResponse.AsStringAsync()
                     ?? throw new Exception("获取 Natayark 用户信息失败，返回内容为空");
-                var userData = (JsonNode.Parse(receivedUserData)?["data"])
+                var userData = (JsonCompat.ParseNode(receivedUserData)?["data"])
                     ?? throw new Exception("获取 Natayark 用户信息失败，解析返回内容失败");
 
-                NaidProfile.Id = userData["id"]?.GetValue<int>() ?? 0;
+                NaidProfile.Id = JsonCompat.ToObject<int>(userData["id"]);
                 NaidProfile.Username = userData["username"]?.ToString() ?? string.Empty;
                 NaidProfile.Email = userData["email"]?.ToString() ?? string.Empty;
-                NaidProfile.Status = userData["status"]?.GetValue<int>() ?? 0;
-                NaidProfile.IsRealNamed = userData["realname"]?.GetValue<bool>() ?? false;
+                NaidProfile.Status = JsonCompat.ToObject<int>(userData["status"]);
+                NaidProfile.IsRealNamed = JsonCompat.ToObject<bool>(userData["realname"]);
                 NaidProfile.LastIp = userData["last_ip"]?.ToString() ?? string.Empty;
 
                 // 保存数据

--- a/PCL.Core/Link/Scaffolding/Client/Requests/GetPlayerProfileListRequest.cs
+++ b/PCL.Core/Link/Scaffolding/Client/Requests/GetPlayerProfileListRequest.cs
@@ -5,12 +5,13 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using PCL.Core.Link.Scaffolding.Client.Abstractions;
 using PCL.Core.Link.Scaffolding.Client.Models;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Scaffolding.Client.Requests;
 
 public sealed class GetPlayerProfileListRequest : IRequest<IReadOnlyList<PlayerProfile>>
 {
-    private static readonly JsonSerializerOptions _JsonOptions = new()
+    private static readonly JsonSerializerOptions _JsonOptions = new(JsonCompat.SerializerOptions)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull

--- a/PCL.Core/Link/Scaffolding/Client/Requests/PlayerPingRequest.cs
+++ b/PCL.Core/Link/Scaffolding/Client/Requests/PlayerPingRequest.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using PCL.Core.Link.Scaffolding.Client.Abstractions;
 using PCL.Core.Link.Scaffolding.Client.Models;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Scaffolding.Client.Requests;
 
@@ -16,7 +17,7 @@ public sealed class PlayerPingRequest(string name, string machineId, string vend
         Vendor = vendor
     };
 
-    private static readonly JsonSerializerOptions _JsonOptions = new()
+    private static readonly JsonSerializerOptions _JsonOptions = new(JsonCompat.SerializerOptions)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull

--- a/PCL.Core/Link/Scaffolding/EasyTier/CliNetTest.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/CliNetTest.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using PCL.Core.Logging;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Scaffolding.EasyTier;
 
@@ -56,7 +57,7 @@ public class CliNetTest
         StunInfo? stunInfo = null;
         try
         {
-            stunInfo = await JsonSerializer.DeserializeAsync<StunInfo>(reader);
+            stunInfo = await JsonSerializer.DeserializeAsync<StunInfo>(reader, JsonCompat.SerializerOptions);
         }
         catch (Exception ex)
         {

--- a/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
@@ -1,4 +1,4 @@
-using PCL.Core.App;
+﻿using PCL.Core.App;
 using PCL.Core.Link.EasyTier;
 using PCL.Core.Link.Scaffolding.Client.Models;
 using PCL.Core.Logging;
@@ -502,7 +502,7 @@ public class EasyTierEntity
             var output = stdOut + stdErr;
             //LogWrapper.Debug("ET Cli", output);
 
-            if (JsonNode.Parse(output) is not JsonArray jArray)
+            if (JsonCompat.ParseNode(output) is not JsonArray jArray)
             {
                 return new EtPlayerList(null, null);
             }
@@ -514,7 +514,7 @@ public class EasyTierEntity
             {
                 LogWrapper.Debug("Et Cli", "Getting player info.");
 
-                var info = arr.Deserialize<ETPeerInfo>();
+                var info = arr.Deserialize<ETPeerInfo>(JsonCompat.SerializerOptions);
                 if (info is null)
                 {
                     LogWrapper.Debug("Et Cli", "Player info is null.");

--- a/PCL.Core/Link/Scaffolding/Server/Handlers/GetPlayerProfileListHandler.cs
+++ b/PCL.Core/Link/Scaffolding/Server/Handlers/GetPlayerProfileListHandler.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Scaffolding.Server.Handlers;
 
@@ -15,7 +16,7 @@ public class GetPlayerProfileListHandler : IRequestHandler
     /// <inheritdoc />
     public string RequestType { get; } = "c:player_profiles_list";
 
-    private static readonly JsonSerializerOptions _JsonOptions = new()
+    private static readonly JsonSerializerOptions _JsonOptions = new(JsonCompat.SerializerOptions)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull

--- a/PCL.Core/Link/Scaffolding/Server/Handlers/PlayerPingHandler.cs
+++ b/PCL.Core/Link/Scaffolding/Server/Handlers/PlayerPingHandler.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Link.Scaffolding.Server.Handlers;
 
@@ -14,7 +15,7 @@ public class PlayerPingHandler : IRequestHandler
     /// <inheritdoc />
     public string RequestType { get; } = "c:player_ping";
 
-    private static readonly JsonSerializerOptions _JsonOptions = new()
+    private static readonly JsonSerializerOptions _JsonOptions = new(JsonCompat.SerializerOptions)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/JsonWebToken/JsonWebKeys.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/JsonWebToken/JsonWebKeys.cs
@@ -1,9 +1,9 @@
-using Microsoft.IdentityModel.Tokens;
+﻿using Microsoft.IdentityModel.Tokens;
 using System.Text.Json.Serialization;
 
 namespace PCL.Core.Minecraft.IdentityModel.Extensions.JsonWebToken;
 
 public record JsonWebKeys
 {
-    [JsonPropertyName("keys")] public required JsonWebKey[] Keys;
+    [JsonPropertyName("keys")] public required JsonWebKey[] Keys { get; init; }
 }

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/JsonWebToken/JsonWebToken.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/JsonWebToken/JsonWebToken.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security;
 using System.Text.Json;
 using Microsoft.IdentityModel.Tokens;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Minecraft.IdentityModel.Extensions.JsonWebToken;
 
@@ -101,8 +102,8 @@ public class JsonWebToken(string token, OpenIdMetadata meta)
             if (typeof(T) == typeof(JwtPayload))
                 return (T)(object)jwtToken.Payload;
 
-            var payloadJson = JsonSerializer.Serialize(jwtToken.Payload);
-            var result = JsonSerializer.Deserialize<T>(payloadJson);
+            var payloadJson = JsonSerializer.Serialize(jwtToken.Payload, JsonCompat.SerializerOptions);
+            var result = JsonSerializer.Deserialize<T>(payloadJson, JsonCompat.SerializerOptions);
 
             return result;
         }
@@ -137,8 +138,8 @@ public class JsonWebToken(string token, OpenIdMetadata meta)
             if (typeof(T) == typeof(JwtHeader))
                 return (T)(object)jwtToken.Header;
 
-            var headerJson = JsonSerializer.Serialize(jwtToken.Header);
-            var result = JsonSerializer.Deserialize<T>(headerJson);
+            var headerJson = JsonSerializer.Serialize(jwtToken.Header, JsonCompat.SerializerOptions);
+            var result = JsonSerializer.Deserialize<T>(headerJson, JsonCompat.SerializerOptions);
 
             return result;
         }

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using PCL.Core.IO.Net.Http;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 
@@ -139,7 +140,11 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
             .SendAsync(options.GetClient.Invoke(), cancellationToken: token)
             .ConfigureAwait(false);
 
-        var data = JsonNode.Parse(await response.AsStringAsync(token));
-        return (response.StatusCode == HttpStatusCode.NoContent, data?["errorMessage"]?.ToString()!);
+        if (response.StatusCode == HttpStatusCode.NoContent)
+            return (true, null!);
+
+        var content = await response.AsStringAsync(token).ConfigureAwait(false);
+        var data = string.IsNullOrWhiteSpace(content) ? null : JsonCompat.ParseNode(content);
+        return (false, data?["errorMessage"]?.ToString()!);
     }
 }

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/Client.cs
@@ -9,26 +9,26 @@ using PCL.Core.Utils;
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 
 /// <summary>
-/// 提供 Yggdrasil 传统认证支持
+///     提供 Yggdrasil 传统认证支持
 /// </summary>
-/// <param name="options"><see cref="YggdrasilLegacyAuthenticateOptions"/> 认证参数</param>
+/// <param name="options"><see cref="YggdrasilLegacyAuthenticateOptions" /> 认证参数</param>
 public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions options)
 {
     /// <summary>
-    /// 异步向服务器发送一次登录请求
+    ///     异步向服务器发送一次登录请求
     /// </summary>
     /// <param name="token"></param>
-    /// <returns><see cref="YggdrasilAuthenticateResult"/>  认证结果</returns>
+    /// <returns><see cref="YggdrasilAuthenticateResult" />  认证结果</returns>
     /// <exception cref="ArgumentException">用户名或密码无效</exception>
     public async Task<YggdrasilAuthenticateResult?> AuthenticateAsync(CancellationToken token)
     {
         ArgumentException.ThrowIfNullOrEmpty(options.Username);
         ArgumentException.ThrowIfNullOrEmpty(options.Password);
-        
+
         var credential = new YggdrasilCredential
         {
             User = options.Username,
-            Password = options.Password,
+            Password = options.Password
         };
         var address = $"{options.YggdrasilApiLocation}/authserver/authenticate";
 
@@ -43,21 +43,22 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
             .AsJsonAsync<YggdrasilAuthenticateResult>(cancellationToken: token)
             .ConfigureAwait(false);
     }
+
     /// <summary>
-    /// 异步向服务器发送一次刷新请求
+    ///     异步向服务器发送一次刷新请求
     /// </summary>
     /// <param name="token"></param>
     /// <param name="seleectedProfile">如果需要选择角色，请填写此参数</param>
-    public async Task<YggdrasilAuthenticateResult?> RefreshAsync(CancellationToken token,Profile? seleectedProfile)
+    public async Task<YggdrasilAuthenticateResult?> RefreshAsync(CancellationToken token, Profile? seleectedProfile)
     {
         ArgumentException.ThrowIfNullOrEmpty(options.AccessToken);
-        
-        var refreshData = new YggdrasilRefresh()
+
+        var refreshData = new YggdrasilRefresh
         {
             AccessToken = options.AccessToken
         };
         if (seleectedProfile is not null) refreshData.SelectedProfile = seleectedProfile;
-        
+
         var address = $"{options.YggdrasilApiLocation}/authserver/refresh";
 
         using var response = await HttpRequest
@@ -71,8 +72,9 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
             .AsJsonAsync<YggdrasilAuthenticateResult>(cancellationToken: token)
             .ConfigureAwait(false);
     }
+
     /// <summary>
-    /// 异步向服务器发送一次验证请求
+    ///     异步向服务器发送一次验证请求
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
@@ -80,7 +82,7 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
     {
         ArgumentException.ThrowIfNullOrEmpty(options.AccessToken);
 
-        var validateData = new YggdrasilRefresh()
+        var validateData = new YggdrasilRefresh
         {
             AccessToken = options.AccessToken
         };
@@ -95,16 +97,16 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
 
         return response.StatusCode == HttpStatusCode.NoContent;
     }
-    
+
     /// <summary>
-    /// 异步向服务器发送一次注销请求
+    ///     异步向服务器发送一次注销请求
     /// </summary>
     /// <param name="token"></param>
     public async Task InvalidateAsync(CancellationToken token)
     {
         ArgumentException.ThrowIfNullOrEmpty(options.AccessToken);
 
-        var validateData = new YggdrasilRefresh()
+        var validateData = new YggdrasilRefresh
         {
             AccessToken = options.AccessToken
         };
@@ -117,13 +119,14 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
             .SendAsync(options.GetClient.Invoke(), cancellationToken: token)
             .ConfigureAwait(false);
     }
+
     /// <summary>
-    /// 异步向服务器发送登出请求 <br/>
-    /// 这会立刻注销所有会话，无论当前会话是否属于调用方
+    ///     异步向服务器发送登出请求 <br />
+    ///     这会立刻注销所有会话，无论当前会话是否属于调用方
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
-    public async Task<(bool IsSuccess,string ErrorDescription)> SignOutAsync(CancellationToken token)
+    public async Task<(bool IsSuccess, string ErrorDescription)> SignOutAsync(CancellationToken token)
     {
         // 不想写 Model 了，就这样吧（趴
         var signoutData = new JsonObject
@@ -141,10 +144,24 @@ public sealed class YggdrasilLegacyClient(YggdrasilLegacyAuthenticateOptions opt
             .ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.NoContent)
-            return (true, null!);
+            return (true, string.Empty);
 
         var content = await response.AsStringAsync(token).ConfigureAwait(false);
-        var data = string.IsNullOrWhiteSpace(content) ? null : JsonCompat.ParseNode(content);
-        return (false, data?["errorMessage"]?.ToString()!);
+        if (string.IsNullOrWhiteSpace(content))
+            return (false, string.Empty);
+
+        JsonNode? data;
+        try
+        {
+            data = JsonCompat.ParseNode(content);
+        }
+        catch
+        {
+            // 认证服务器偶尔会返回纯文本或 HTML 错误页，保留原始响应便于上层展示和诊断。
+            return (false, content);
+        }
+
+        var error = data?["errorMessage"]?.ToString() ?? string.Empty;
+        return (false, error);
     }
 }

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
@@ -6,7 +6,7 @@ public record YggdrasilCredential
 {
     [JsonPropertyName("username")] public required string User { get; init; }
     [JsonPropertyName("password")] public required string Password { get; init; }
-    [JsonPropertyName("agent")] public Agent Agent = new();
+    [JsonPropertyName("agent")] public Agent Agent { get; init; } = new();
     [JsonPropertyName("requestUser")] public bool RequestUser { get; set; }
 }
 
@@ -39,7 +39,7 @@ public record YggdrasilAuthenticateResult
     /// <summary>
     /// 用户信息
     /// </summary>
-    [JsonPropertyName("user")] public Profile? User;
+    [JsonPropertyName("user")] public Profile? User { get; init; }
 }
 
 public record YggdrasilRefresh

--- a/PCL.Core/Minecraft/Java/JavaManager.cs
+++ b/PCL.Core/Minecraft/Java/JavaManager.cs
@@ -1,4 +1,4 @@
-using PCL.Core.Logging;
+﻿using PCL.Core.Logging;
 using PCL.Core.Minecraft.Java;
 using PCL.Core.Minecraft.Java.Parser;
 using PCL.Core.Minecraft.Java.Scanner;
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
+using PCL.Core.Utils;
 
 namespace PCL.Core.Minecraft;
 
@@ -47,7 +48,7 @@ public class JavaManager
                     Source = x.Value.Source
                 })
                 .ToArray();
-            States.Game.JavaList = JsonSerializer.Serialize(items);
+            States.Game.JavaList = JsonSerializer.Serialize(items, JsonCompat.SerializerOptions);
         }
         catch(Exception ex)
         {
@@ -59,7 +60,7 @@ public class JavaManager
     {
         try
         {
-            var items = JsonSerializer.Deserialize<JavaStorageItem[]>(States.Game.JavaList);
+            var items = JsonSerializer.Deserialize<JavaStorageItem[]>(States.Game.JavaList, JsonCompat.SerializerOptions);
             if (items is null) return;
 
             var itemsAdded = new List<JavaEntry>();

--- a/PCL.Core/Minecraft/McVersionClassifier.cs
+++ b/PCL.Core/Minecraft/McVersionClassifier.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Globalization;
+using System;
 using System.Text.Json.Nodes;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -162,32 +162,9 @@ public static class McVersionClassifier
 
     private static DateTime _GetDateTime(JsonObject obj, string key)
     {
-        var node = obj[key];
-        switch (node)
-        {
-            case null:
-                break;
-            case JsonValue value:
-            {
-                if (value.TryGetValue<DateTime>(out var dateTime))
-                    return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
-
-                if (value.TryGetValue<string>(out var text))
-                {
-                    if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
-                            out var dateTimeOffset))
-                        return dateTimeOffset.LocalDateTime;
-
-                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal,
-                            out dateTime))
-                        return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
-                }
-
-                break;
-            }
-        }
-
-        return DateTime.MinValue;
+        return JsonCompat.TryGetDateTime(obj[key], out var dateTime)
+            ? dateTime
+            : DateTime.MinValue;
     }
 
     private static string _GetString(JsonObject obj, string key)

--- a/PCL.Core/Minecraft/McVersionClassifier.cs
+++ b/PCL.Core/Minecraft/McVersionClassifier.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Globalization;
 using System.Text.Json.Nodes;
 using PCL.Core.App.Localization;
 
@@ -42,7 +43,7 @@ public static class McVersionClassifier
 
     public static DateTime GetReleaseTime(JsonObject version)
     {
-        return version["releaseTime"]?.GetValue<DateTime>() ?? DateTime.MinValue;
+        return _GetDateTime(version, "releaseTime");
     }
 
     private static McVersionCategory _ClassifySnapshotOrPending(JsonObject version, string idLower)
@@ -159,8 +160,43 @@ public static class McVersionClassifier
         };
     }
 
+    private static DateTime _GetDateTime(JsonObject obj, string key)
+    {
+        var node = obj[key];
+        switch (node)
+        {
+            case null:
+                break;
+            case JsonValue value:
+            {
+                if (value.TryGetValue<DateTime>(out var dateTime))
+                    return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
+
+                if (value.TryGetValue<string>(out var text))
+                {
+                    if (DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
+                            out var dateTimeOffset))
+                        return dateTimeOffset.LocalDateTime;
+
+                    if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal,
+                            out dateTime))
+                        return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
+                }
+
+                break;
+            }
+        }
+
+        return DateTime.MinValue;
+    }
+
     private static string _GetString(JsonObject obj, string key)
     {
-        return obj[key]?.GetValue<string>() ?? "";
+        var node = obj[key];
+        if (node is null) return "";
+
+        return node is JsonValue value && value.TryGetValue<string>(out var result)
+            ? result
+            : node.ToString();
     }
 }

--- a/PCL.Core/Utils/ExpandoObjectConverter.cs
+++ b/PCL.Core/Utils/ExpandoObjectConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -12,9 +13,11 @@ namespace PCL.Core.Utils;
 
 public sealed class ExpandoObjectConverter : JsonConverter<ExpandoObject>
 {
-    public ExpandoObjectConverter() { }
-    
     public static readonly ExpandoObjectConverter Default = new ExpandoObjectConverter();
+
+    public ExpandoObjectConverter()
+    {
+    }
 
     public override ExpandoObject Read(
         ref Utf8JsonReader reader,
@@ -41,11 +44,29 @@ public sealed class ExpandoObjectConverter : JsonConverter<ExpandoObject>
         IDictionary<string, object> dict = expandoObject;
         foreach (JsonProperty property in element.EnumerateObject())
         {
-            object value = JsonSerializer.Deserialize<object>(
-                property.Value.GetRawText(), options);
-            dict.Add(property.Name, value);
+            dict.Add(property.Name, _ConvertElement(property.Value, options));
         }
+
         return expandoObject;
+    }
+
+    private static object _ConvertElement(JsonElement element, JsonSerializerOptions options)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => Read(element, options),
+            JsonValueKind.Array => element.EnumerateArray()
+                .Select(item => _ConvertElement(item, options))
+                .ToList(),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number when element.TryGetInt64(out var integer) => integer,
+            JsonValueKind.Number when element.TryGetDouble(out var number) => number,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            JsonValueKind.Undefined => null,
+            _ => element.GetRawText()
+        };
     }
 
     public override void Write(

--- a/PCL.Core/Utils/JsonCompat.cs
+++ b/PCL.Core/Utils/JsonCompat.cs
@@ -1,39 +1,61 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
-namespace PCL;
+namespace PCL.Core.Utils;
 
-public static class JsonNodeExtensions
+/// <summary>
+///     System.Text.Json 兼容 Newtonsoft.Json 宽松行为的统一入口。
+/// </summary>
+public static class JsonCompat
 {
-    public static readonly JsonNodeOptions CompatNodeOptions = new()
+    public static readonly JsonNodeOptions NodeOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };
 
-    public static readonly JsonDocumentOptions CompatDocumentOptions = new()
+    public static readonly JsonDocumentOptions DocumentOptions = new()
     {
         AllowTrailingCommas = true,
         CommentHandling = JsonCommentHandling.Skip
     };
 
-    public static readonly JsonSerializerOptions CompatOptions = new()
+    public static readonly JsonSerializerOptions SerializerOptions = new()
     {
         PropertyNameCaseInsensitive = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         ReadCommentHandling = JsonCommentHandling.Skip,
         AllowTrailingCommas = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         Converters =
         {
-            new LocalDateTimeConverter(),
+            new FlexibleDateTimeConverter(),
             new FlexibleBoolConverter(),
             new FlexibleStringConverter(),
             new JsonStringEnumConverter()
         }
     };
 
-    public static JsonNode ParseJson(string data)
+    public static JsonNode ParseNode(string text)
     {
-        return JsonNode.Parse(data, CompatNodeOptions, CompatDocumentOptions)!;
+        return JsonNode.Parse(text, NodeOptions, DocumentOptions)!;
+    }
+
+    public static T? ToObject<T>(this JsonNode? node)
+    {
+        return node is null ? default : node.Deserialize<T>(SerializerOptions);
+    }
+
+    public static JsonArray FromObject<T>(IEnumerable<T> items)
+    {
+        var arr = new JsonArray();
+        foreach (var item in items)
+            arr.Add(JsonSerializer.SerializeToNode(item, SerializerOptions));
+        return arr;
     }
 
     public static void Merge(this JsonObject target, JsonNode? source)
@@ -64,20 +86,7 @@ public static class JsonNodeExtensions
             target.Add(item?.DeepClone());
     }
 
-    public static T? ToObject<T>(this JsonNode node)
-    {
-        return node.Deserialize<T>(CompatOptions);
-    }
-
-    public static JsonArray FromObject<T>(IEnumerable<T> items)
-    {
-        var arr = new JsonArray();
-        foreach (var item in items)
-            arr.Add(JsonSerializer.SerializeToNode(item, CompatOptions));
-        return arr;
-    }
-
-    private sealed class LocalDateTimeConverter : JsonConverter<DateTime>
+    private sealed class FlexibleDateTimeConverter : JsonConverter<DateTime>
     {
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
@@ -102,7 +111,6 @@ public static class JsonNodeExtensions
         }
     }
 
-
     private sealed class FlexibleBoolConverter : JsonConverter<bool>
     {
         public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -115,7 +123,7 @@ public static class JsonNodeExtensions
                 JsonTokenType.String when int.TryParse(reader.GetString(), NumberStyles.Integer,
                     CultureInfo.InvariantCulture, out var number) => number != 0,
                 JsonTokenType.Number when reader.TryGetInt64(out var number) => number != 0,
-                _ => throw new JsonException($"无法将 JSON Token {reader.TokenType} 转换为 Boolean。")
+                _ => throw new JsonException($"Can not convert JSON token {reader.TokenType} to Boolean.")
             };
         }
 

--- a/PCL.Core/Utils/JsonCompat.cs
+++ b/PCL.Core/Utils/JsonCompat.cs
@@ -24,21 +24,33 @@ public static class JsonCompat
         CommentHandling = JsonCommentHandling.Skip
     };
 
-    public static readonly JsonSerializerOptions SerializerOptions = new()
+    /// <summary>
+    ///     统一的宽松 JSON 序列化配置。该实例在静态初始化时已被冻结，调用方不能修改全局行为。
+    ///     如需追加调用点专用设置，请使用 <c>new JsonSerializerOptions(JsonCompat.SerializerOptions)</c> 克隆后修改。
+    /// </summary>
+    public static JsonSerializerOptions SerializerOptions { get; } = _CreateSerializerOptions();
+
+    private static JsonSerializerOptions _CreateSerializerOptions()
     {
-        PropertyNameCaseInsensitive = true,
-        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters =
+        var options = new JsonSerializerOptions
         {
-            new FlexibleDateTimeConverter(),
-            new FlexibleBoolConverter(),
-            new FlexibleStringConverter(),
-            new JsonStringEnumConverter()
-        }
-    };
+            PropertyNameCaseInsensitive = true,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters =
+            {
+                new FlexibleDateTimeConverter(),
+                new FlexibleBoolConverter(),
+                new FlexibleStringConverter(),
+                new JsonStringEnumConverter()
+            }
+        };
+
+        options.MakeReadOnly(true);
+        return options;
+    }
 
     public static JsonNode ParseNode(string text)
     {
@@ -56,6 +68,64 @@ public static class JsonCompat
         foreach (var item in items)
             arr.Add(JsonSerializer.SerializeToNode(item, SerializerOptions));
         return arr;
+    }
+
+    public static bool TryGetDateTime(JsonNode? node, out DateTime dateTime)
+    {
+        dateTime = default;
+        switch (node)
+        {
+            case null:
+                return false;
+            case JsonValue value when value.TryGetValue<DateTime>(out var rawDateTime):
+                dateTime = NormalizeDateTime(rawDateTime);
+                return true;
+            case JsonValue value
+                when value.TryGetValue<string>(out var rawText) && TryParseDateTime(rawText, out dateTime):
+                return true;
+            default:
+                try
+                {
+                    dateTime = NormalizeDateTime(node.Deserialize<DateTime>(SerializerOptions));
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    return false;
+                }
+                catch (InvalidOperationException)
+                {
+                    return false;
+                }
+                catch (NotSupportedException)
+                {
+                    return false;
+                }
+        }
+    }
+
+    public static bool TryParseDateTime(string? value, out DateTime dateTime)
+    {
+        dateTime = default;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
+                out var dateTimeOffset))
+        {
+            dateTime = dateTimeOffset.LocalDateTime;
+            return true;
+        }
+
+        if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var parsed))
+            return false;
+
+        dateTime = NormalizeDateTime(parsed);
+        return true;
+    }
+
+    public static DateTime NormalizeDateTime(DateTime dateTime)
+    {
+        return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
     }
 
     public static void Merge(this JsonObject target, JsonNode? source)
@@ -90,19 +160,13 @@ public static class JsonCompat
     {
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                var value = reader.GetString();
-                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
-                        out var dateTimeOffset))
-                    return dateTimeOffset.LocalDateTime;
-                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal,
-                        out var dateTime))
-                    return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
-            }
+            if (reader.TokenType != JsonTokenType.String)
+                return NormalizeDateTime(reader.GetDateTime());
 
-            var result = reader.GetDateTime();
-            return result.Kind == DateTimeKind.Utc ? result.ToLocalTime() : result;
+            var value = reader.GetString();
+            return TryParseDateTime(value, out var dateTime)
+                ? dateTime
+                : NormalizeDateTime(reader.GetDateTime());
         }
 
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)

--- a/Plain Craft Launcher 2/Modules/Base/JsonNodeExtensions.cs
+++ b/Plain Craft Launcher 2/Modules/Base/JsonNodeExtensions.cs
@@ -1,40 +1,39 @@
 using System.Globalization;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace PCL;
 
 public static class JsonNodeExtensions
 {
-    private static readonly JsonSerializerOptions CompatOptions = new()
+    public static readonly JsonNodeOptions CompatNodeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static readonly JsonDocumentOptions CompatDocumentOptions = new()
+    {
+        AllowTrailingCommas = true,
+        CommentHandling = JsonCommentHandling.Skip
+    };
+
+    public static readonly JsonSerializerOptions CompatOptions = new()
     {
         PropertyNameCaseInsensitive = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
-        Converters = { new LocalDateTimeConverter() }
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        Converters =
+        {
+            new LocalDateTimeConverter(),
+            new FlexibleBoolConverter(),
+            new FlexibleStringConverter(),
+            new JsonStringEnumConverter()
+        }
     };
 
-    private sealed class LocalDateTimeConverter : JsonConverter<DateTime>
+    public static JsonNode ParseJson(string data)
     {
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                var value = reader.GetString();
-                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dateTimeOffset))
-                    return dateTimeOffset.LocalDateTime;
-                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dateTime))
-                    return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
-            }
-
-            var result = reader.GetDateTime();
-            return result.Kind == DateTimeKind.Utc ? result.ToLocalTime() : result;
-        }
-
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value);
-        }
+        return JsonNode.Parse(data, CompatNodeOptions, CompatDocumentOptions)!;
     }
 
     public static void Merge(this JsonObject target, JsonNode? source)
@@ -76,5 +75,80 @@ public static class JsonNodeExtensions
         foreach (var item in items)
             arr.Add(JsonSerializer.SerializeToNode(item, CompatOptions));
         return arr;
+    }
+
+    private sealed class LocalDateTimeConverter : JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var value = reader.GetString();
+                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
+                        out var dateTimeOffset))
+                    return dateTimeOffset.LocalDateTime;
+                if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal,
+                        out var dateTime))
+                    return dateTime.Kind == DateTimeKind.Utc ? dateTime.ToLocalTime() : dateTime;
+            }
+
+            var result = reader.GetDateTime();
+            return result.Kind == DateTimeKind.Utc ? result.ToLocalTime() : result;
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+
+
+    private sealed class FlexibleBoolConverter : JsonConverter<bool>
+    {
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.True => true,
+                JsonTokenType.False => false,
+                JsonTokenType.String when bool.TryParse(reader.GetString(), out var value) => value,
+                JsonTokenType.String when int.TryParse(reader.GetString(), NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var number) => number != 0,
+                JsonTokenType.Number when reader.TryGetInt64(out var number) => number != 0,
+                _ => throw new JsonException($"无法将 JSON Token {reader.TokenType} 转换为 Boolean。")
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            writer.WriteBooleanValue(value);
+        }
+    }
+
+    private sealed class FlexibleStringConverter : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.Null => null,
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => _ReadRawJsonValue(ref reader),
+                JsonTokenType.True => bool.TrueString,
+                JsonTokenType.False => bool.FalseString,
+                _ => _ReadRawJsonValue(ref reader)
+            };
+        }
+
+        private static string _ReadRawJsonValue(ref Utf8JsonReader reader)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            return document.RootElement.GetRawText();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
     }
 }

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -1611,7 +1611,7 @@ public static class ModBase
     {
         try
         {
-            return JsonNodeExtensions.ParseJson(Data);
+            return JsonCompat.ParseNode(Data);
         }
         catch (Exception ex)
         {

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -1611,13 +1611,7 @@ public static class ModBase
     {
         try
         {
-            return JsonNode.Parse(Data,
-                new JsonNodeOptions { PropertyNameCaseInsensitive = true },
-                new JsonDocumentOptions
-                {
-                    AllowTrailingCommas = true,
-                    CommentHandling = JsonCommentHandling.Skip
-                })!;
+            return JsonNodeExtensions.ParseJson(Data);
         }
         catch (Exception ex)
         {

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -242,14 +242,14 @@ public static class ModComp
                     // 尝试作为新格式解析
                     try
                     {
-                        RawList = JsonSerializer.Deserialize<List<FavData>>(RawData, JsonNodeExtensions.CompatOptions);
+                        RawList = JsonSerializer.Deserialize<List<FavData>>(RawData, JsonCompat.SerializerOptions);
                     }
                     catch (Exception ex1)
                     {
                         // 尝试作为旧格式（HashSet）迁移
                         try
                         {
-                            var Migrate = JsonSerializer.Deserialize<HashSet<string>>(RawData, JsonNodeExtensions.CompatOptions);
+                            var Migrate = JsonSerializer.Deserialize<HashSet<string>>(RawData, JsonCompat.SerializerOptions);
                             if (Migrate is not null) RawList = new List<FavData> { GetNewFav(Lang.Text("Download.Comp.Detail.Favorites.DefaultName"), Migrate) };
                         }
                         catch (Exception ex2)
@@ -271,8 +271,8 @@ public static class ModComp
                 _FavoritesList = value;
                 foreach (var item in _FavoritesList)
                     item.Notes = item.Notes.Where(n => !string.IsNullOrWhiteSpace(n.Value)).ToDictionary();
-                var RawList = JsonSerializer.Serialize(_FavoritesList, JsonNodeExtensions.CompatOptions);
-                States.Game.CompFavorites = JsonSerializer.Serialize(_FavoritesList, JsonNodeExtensions.CompatOptions);
+                var RawList = JsonSerializer.Serialize(_FavoritesList, JsonCompat.SerializerOptions);
+                States.Game.CompFavorites = JsonSerializer.Serialize(_FavoritesList, JsonCompat.SerializerOptions);
             }
         }
 
@@ -280,7 +280,7 @@ public static class ModComp
         {
             try
             {
-                return JsonSerializer.Serialize(Data, JsonNodeExtensions.CompatOptions);
+                return JsonSerializer.Serialize(Data, JsonCompat.SerializerOptions);
             }
             catch (Exception ex)
             {
@@ -294,7 +294,7 @@ public static class ModComp
         {
             try
             {
-                return JsonSerializer.Deserialize<HashSet<string>>(Code, JsonNodeExtensions.CompatOptions);
+                return JsonSerializer.Deserialize<HashSet<string>>(Code, JsonCompat.SerializerOptions);
             }
             catch (Exception ex)
             {

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -242,14 +242,14 @@ public static class ModComp
                     // 尝试作为新格式解析
                     try
                     {
-                        RawList = JsonSerializer.Deserialize<List<FavData>>(RawData);
+                        RawList = JsonSerializer.Deserialize<List<FavData>>(RawData, JsonNodeExtensions.CompatOptions);
                     }
                     catch (Exception ex1)
                     {
                         // 尝试作为旧格式（HashSet）迁移
                         try
                         {
-                            var Migrate = JsonSerializer.Deserialize<HashSet<string>>(RawData);
+                            var Migrate = JsonSerializer.Deserialize<HashSet<string>>(RawData, JsonNodeExtensions.CompatOptions);
                             if (Migrate is not null) RawList = new List<FavData> { GetNewFav(Lang.Text("Download.Comp.Detail.Favorites.DefaultName"), Migrate) };
                         }
                         catch (Exception ex2)
@@ -271,8 +271,8 @@ public static class ModComp
                 _FavoritesList = value;
                 foreach (var item in _FavoritesList)
                     item.Notes = item.Notes.Where(n => !string.IsNullOrWhiteSpace(n.Value)).ToDictionary();
-                var RawList = JsonSerializer.Serialize(_FavoritesList);
-                States.Game.CompFavorites = JsonSerializer.Serialize(_FavoritesList);
+                var RawList = JsonSerializer.Serialize(_FavoritesList, JsonNodeExtensions.CompatOptions);
+                States.Game.CompFavorites = JsonSerializer.Serialize(_FavoritesList, JsonNodeExtensions.CompatOptions);
             }
         }
 
@@ -280,7 +280,7 @@ public static class ModComp
         {
             try
             {
-                return JsonSerializer.Serialize(Data);
+                return JsonSerializer.Serialize(Data, JsonNodeExtensions.CompatOptions);
             }
             catch (Exception ex)
             {
@@ -294,7 +294,7 @@ public static class ModComp
         {
             try
             {
-                return JsonSerializer.Deserialize<HashSet<string>>(Code);
+                return JsonSerializer.Deserialize<HashSet<string>>(Code, JsonNodeExtensions.CompatOptions);
             }
             catch (Exception ex)
             {
@@ -1136,7 +1136,7 @@ public static class ModComp
 
             // Tags
             var categories = ((data["categories"] as JsonArray) ?? [])
-                .Select(t => t["id"]?.GetValue<int?>())
+                .Select(t => t["id"]?.ToObject<int?>())
                 .Where(t => t.HasValue)
                 .Select(t => t.Value)
                 .Distinct()

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -808,12 +808,12 @@ public static class ModDownload
 
     private static void DlForgeListOfficialMain(ModLoader.LoaderTask<int, DlForgeListResult> Loader)
     {
-        var Result = Requester.FetchJson(
+        var Result = Requester.FetchString(
             "https://files.minecraftforge.net/maven/net/minecraftforge/forge/index_1.2.4.html", new RequestParam
             {
                 Encoding = Encoding.Default,
                 UseBrowserUserAgent = true
-            })?.ToString() ?? "";
+            });
         if (Result.Length < 200)
             throw new Exception(Lang.Text("Minecraft.Download.Error.VersionListOperationFailed", "Forge", Result));
         // 获取所有版本信息

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -8,6 +8,7 @@ using PCL.Network;
 using PCL.Network.Loaders;
 using PCL.Core.App.Localization;
 using PCL.Core.Utils.OS;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -183,7 +184,7 @@ public static class ModJava
         {
             try
             {
-                preference = JsonSerializer.Deserialize<JavaPreference>(rawPreference, JsonNodeExtensions.CompatOptions);
+                preference = JsonSerializer.Deserialize<JavaPreference>(rawPreference, JsonCompat.SerializerOptions);
             }
             catch (JsonException)
             {

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -183,7 +183,7 @@ public static class ModJava
         {
             try
             {
-                preference = JsonSerializer.Deserialize<JavaPreference>(rawPreference);
+                preference = JsonSerializer.Deserialize<JavaPreference>(rawPreference, JsonNodeExtensions.CompatOptions);
             }
             catch (JsonException)
             {
@@ -241,7 +241,7 @@ public static class ModJava
             var UserSetup = Config.Launch.SelectedJava;
             if (UserSetup.StartsWith("{")) // 旧版本 Json 格式
             {
-                var js = JsonNode.Parse(UserSetup);
+                var js = ModBase.GetJson(UserSetup);
                 UserSetup = $"{js["Path"]}java.exe";
                 Config.Launch.SelectedJava = UserSetup;
             }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1676,7 +1676,7 @@ public static class ModLaunch
             // 获取服务器信息
             var Response =
                 Requester.FetchString(Data.Input.BaseUrl.Replace("/authserver", ""));
-            var ServerName = JsonNode.Parse(Response)["meta"]["serverName"].ToString();
+            var ServerName = ModBase.GetJson(Response)["meta"]?["serverName"]?.ToString() ?? Data.Input.BaseUrl.Replace("/authserver", "");
             // 保存缓存
             if (Data.Input.IsExist)
             {
@@ -1736,7 +1736,7 @@ public static class ModLaunch
         {
             using var responseStream = ex.Response?.Content.ReadAsStream();
             if (responseStream is null) return false;
-            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream);
+            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream, JsonNodeExtensions.CompatOptions);
             if (result?.ErrorMessage is null) return false;
             message = result.ErrorMessage;
             return true;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1736,7 +1736,7 @@ public static class ModLaunch
         {
             using var responseStream = ex.Response?.Content.ReadAsStream();
             if (responseStream is null) return false;
-            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream, JsonNodeExtensions.CompatOptions);
+            var result = JsonSerializer.Deserialize<YggdrasilAuthenticateResult>(responseStream, JsonCompat.SerializerOptions);
             if (result?.ErrorMessage is null) return false;
             message = result.ErrorMessage;
             return true;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -2301,7 +2301,7 @@ public static class ModLocalComp
         }
 
         ModBase.WriteFile(Path.Combine(ModBase.PathTemp, "Cache", "LocalComp.json"),
-            Cache.ToJsonString(ModBase.ModeDebug ? new JsonSerializerOptions { WriteIndented = true } : null));
+            Cache.ToJsonString(ModBase.ModeDebug ? new JsonSerializerOptions(JsonCompat.SerializerOptions) { WriteIndented = true } : null));
 
         // 刷新 UI
         ModBase.RunInUi(() =>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -3371,7 +3371,7 @@ public static class ModMinecraft
                 throw new FileNotFoundException(Lang.Text("Minecraft.Error.AssetIndexNotFound"),
                     Path.Combine(McFolderSelected, "assets", "indexes", indexName + ".json"));
             var result = new List<McAssetsToken>();
-            var json = (JsonObject)JsonNode.Parse(
+            var json = (JsonObject)ModBase.GetJson(
                 ModBase.ReadFile($@"{McFolderSelected}assets\indexes\{indexName}.json"));
 
             // 读取列表
@@ -3379,10 +3379,10 @@ public static class ModMinecraft
             {
                 string localPath;
                 var hash = file.Value["hash"].ToString();
-                if (json["map_to_resources"] is not null && json["map_to_resources"].GetValue<bool>())
+                if (json["map_to_resources"] is not null && json["map_to_resources"].ToObject<bool>())
                     // Remap
                     localPath = Path.Combine(instance.PathIndie, "resources", file.Key.Replace("/", @"\"));
-                else if (json["virtual"] is not null && json["virtual"].GetValue<bool>())
+                else if (json["virtual"] is not null && json["virtual"].ToObject<bool>())
                     // Virtual
                     localPath = Path.Combine(McFolderSelected, "assets", "virtual", "legacy", file.Key.Replace("/", @"\"));
                 else

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -689,31 +689,31 @@ public static class ModModpack
             {
                 case "minecraft":
                 {
-                    MinecraftVersion = Entry.Value?.GetValue<string>();
+                    MinecraftVersion = Entry.Value?.ToObject<string>();
                     break;
                 }
                 case "forge": // eg. 14.23.5.2859 / 1.19-41.1.0
                 {
-                    ForgeVersion = Entry.Value?.GetValue<string>();
+                    ForgeVersion = Entry.Value?.ToObject<string>();
                     ModBase.Log("[ModPack] 整合包 Forge 版本：" + ForgeVersion);
                     break;
                 }
                 case "neoforge":
                 case "neo-forge": // eg. 20.6.98-beta
                 {
-                    NeoForgeVersion = Entry.Value?.GetValue<string>();
+                    NeoForgeVersion = Entry.Value?.ToObject<string>();
                     ModBase.Log("[ModPack] 整合包 NeoForge 版本：" + NeoForgeVersion);
                     break;
                 }
                 case "fabric-loader": // eg. 0.14.14
                 {
-                    FabricVersion = Entry.Value?.GetValue<string>();
+                    FabricVersion = Entry.Value?.ToObject<string>();
                     ModBase.Log("[ModPack] 整合包 Fabric 版本：" + FabricVersion);
                     break;
                 }
                 case "quilt-loader": // eg. 0.26.0
                 {
-                    QuiltVersion = Entry.Value?.GetValue<string>();
+                    QuiltVersion = Entry.Value?.ToObject<string>();
                     ModBase.Log("[ModPack] 整合包 Quilt 版本：" + QuiltVersion);
                     break;
                 }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -451,7 +451,7 @@ public static class ModModpack
             }
 
             ModList.Add((int)ModEntry["fileID"]);
-            if (ModEntry["required"] is JsonValue { } jv && !jv.GetValue<bool>())
+            if (ModEntry["required"] is JsonNode requiredNode && !requiredNode.ToObject<bool>())
                 ModOptionalList.Add((int)ModEntry["fileID"]);
         }
 
@@ -799,7 +799,7 @@ public static class ModModpack
             }
 
             FileList.Add(new DownloadFile(Urls, TargetPath,
-                new ModBase.FileChecker(ActualSize: ((JsonNode)File["fileSize"]).GetValue<long>(),
+                new ModBase.FileChecker(ActualSize: ((JsonNode)File["fileSize"]).ToObject<long>(),
                     Hash: File["hashes"]["sha1"].ToString()), true));
         }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -10,6 +10,7 @@ using PCL.Core.Utils.Validate;
 using PCL.Network;
 using PCL.Network.Loaders;
 using static PCL.ModLoader;
+using PCL.Core.Utils;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
@@ -729,7 +729,7 @@ public static class ModProfile
                 }
 
                 var jsonBytes = File.ReadAllBytes(path);
-                using (var doc = JsonDocument.Parse(jsonBytes, JsonNodeExtensions.CompatDocumentOptions))
+                using (var doc = JsonDocument.Parse(jsonBytes, JsonCompat.DocumentOptions))
                 {
                     var importCount = 0;
                     var importProfiles = new List<McProfile>();
@@ -790,7 +790,7 @@ public static class ModProfile
                 var oldJson = File.ReadAllText(path);
                 if (!string.IsNullOrWhiteSpace(oldJson))
                     // 这里简单处理：将旧的转回原始结构，避免丢失 HMCL 自己的其他账户
-                    using (var doc = JsonDocument.Parse(oldJson, JsonNodeExtensions.CompatDocumentOptions))
+                    using (var doc = JsonDocument.Parse(oldJson, JsonCompat.DocumentOptions))
                     {
                         foreach (var el in doc.RootElement.EnumerateArray())
                         {
@@ -804,7 +804,7 @@ public static class ModProfile
                 finalDictList.Add(ConvertToHmclDict(profile));
 
             // 3. 序列化并写入
-            var options = new JsonSerializerOptions(JsonNodeExtensions.CompatOptions) { WriteIndented = true };
+            var options = new JsonSerializerOptions(JsonCompat.SerializerOptions) { WriteIndented = true };
             var jsonString = JsonSerializer.Serialize(finalDictList, options);
 
             Directory.CreateDirectory(Path.GetDirectoryName(path));

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModProfile.cs
@@ -291,7 +291,7 @@ public static class ModProfile
                 ModBase.WriteFile(profilePath, "{\"lastUsed\":0,\"profiles\":[]}"); // 创建档案列表文件
             }
 
-            var profileJobj = JsonNode.Parse(ModBase.ReadFile(profilePath));
+            var profileJobj = ModBase.GetJson(ModBase.ReadFile(profilePath));
             LastUsedProfile = (int)profileJobj["lastUsed"];
             var profileListJobj = (JsonArray)profileJobj["profiles"];
             foreach (var Profile in profileListJobj)
@@ -729,7 +729,7 @@ public static class ModProfile
                 }
 
                 var jsonBytes = File.ReadAllBytes(path);
-                using (var doc = JsonDocument.Parse(jsonBytes))
+                using (var doc = JsonDocument.Parse(jsonBytes, JsonNodeExtensions.CompatDocumentOptions))
                 {
                     var importCount = 0;
                     var importProfiles = new List<McProfile>();
@@ -790,7 +790,7 @@ public static class ModProfile
                 var oldJson = File.ReadAllText(path);
                 if (!string.IsNullOrWhiteSpace(oldJson))
                     // 这里简单处理：将旧的转回原始结构，避免丢失 HMCL 自己的其他账户
-                    using (var doc = JsonDocument.Parse(oldJson))
+                    using (var doc = JsonDocument.Parse(oldJson, JsonNodeExtensions.CompatDocumentOptions))
                     {
                         foreach (var el in doc.RootElement.EnumerateArray())
                         {
@@ -804,7 +804,7 @@ public static class ModProfile
                 finalDictList.Add(ConvertToHmclDict(profile));
 
             // 3. 序列化并写入
-            var options = new JsonSerializerOptions { WriteIndented = true };
+            var options = new JsonSerializerOptions(JsonNodeExtensions.CompatOptions) { WriteIndented = true };
             var jsonString = JsonSerializer.Serialize(finalDictList, options);
 
             Directory.CreateDirectory(Path.GetDirectoryName(path));

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModStyle.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModStyle.cs
@@ -5,6 +5,7 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Threading;
 using PCL.Core.UI.Controls;
+using PCL.Core.Utils;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -39,7 +39,7 @@ public static class Requester
 
     public static async Task<JsonNode> FetchJsonAsync(string url, RequestParam param = default)
     {
-        return JsonNode.Parse(await FetchStringAsync(url, param).ConfigureAwait(false))!;
+        return ModBase.GetJson(await FetchStringAsync(url, param).ConfigureAwait(false));
     }
 
     public static async Task<T> FetchJsonAsync<T>(string url, RequestParam param = default) where T : JsonNode

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
@@ -33,7 +33,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
     {
         // 先检查缓存
         var remoteCache =
-            JsonNode.Parse(Requester.FetchString($"{_baseUrl}apiv2/cache.json", RequestParam.WithRetry));
+            ModBase.GetJson(Requester.FetchString($"{_baseUrl}apiv2/cache.json", RequestParam.WithRetry));
         _remoteCache = remoteCache.ToObject<Dictionary<string, string>>();
         return true;
     }
@@ -160,7 +160,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
         JsonNode jsonData;
         if (IsCacheValid($"{name}.json", _remoteCache[name]))
         {
-            jsonData = JsonNode.Parse(ModBase.ReadFile(localInfoFile));
+            jsonData = ModBase.GetJson(ModBase.ReadFile(localInfoFile));
         }
         else
         {
@@ -170,7 +170,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
                 .GetResult();
 
             var content = response.AsString();
-            jsonData = JsonNode.Parse(content);
+            jsonData = ModBase.GetJson(content);
             ModBase.WriteFile(localInfoFile, content);
         }
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -312,10 +312,10 @@ public static class ModDownloadLib
         if (Entry["lore"] is null)
         {
             if (FormattedVersion != (string)Entry["id"])
-                NewItem.Info = Lang.Date(Entry["releaseTime"].GetValue<DateTime>(), "g") + " | " +
+                NewItem.Info = Lang.Date(Entry["releaseTime"].ToObject<DateTime>(), "g") + " | " +
                                Entry["id"];
             else
-                NewItem.Info = Lang.Date(Entry["releaseTime"].GetValue<DateTime>(), "g");
+                NewItem.Info = Lang.Date(Entry["releaseTime"].ToObject<DateTime>(), "g");
         }
         else if (FormattedVersion != (string)Entry["id"])
         {
@@ -2023,7 +2023,7 @@ public static class ModDownloadLib
                     Json.Merge(Json2);
                     // 如果是 1.16.5 就升级一下 Authlib
                     if (Inherit == "1.16.5" && (bool)Config.Download.FixAuthLib)
-                        Json = (JsonObject)JsonNode.Parse(Json.ToString()
+                        Json = (JsonObject)ModBase.GetJson(Json.ToString()
                             .Replace("2.1.28/authlib-2.1.28.jar", "2.3.31/authlib-2.3.31.jar")
                             .Replace("com.mojang:authlib:2.1.28", "com.mojang:authlib:2.3.31")
                             .Replace("ad54da276bf59983d02d5ed16fc14541354c71fd",
@@ -4621,36 +4621,47 @@ public static class ModDownloadLib
             }
 
             foreach (var Library in LabyModLib["libraries"].AsArray())
-                OutputLibraries.Add(JsonNode.Parse($@"{{
-                    ""name"": ""{Library["name"]}"",
-                    ""downloads"": {{
-                        ""artifact"": {{
-                            ""path"": ""{Library["url"].ToString().Substring(Library["url"].ToString().LastIndexOfF("https://releases.r2.labymod.net/libraries/") + 42)}"",
-                            ""sha1"": ""{Library["sha1"]}"",
-                            ""size"": {Library["size"]},
-                            ""url"": ""{Library["url"]}""
-                        }}
-                    }}
-                }}"));
+            {
+                var libraryUrl = Library?["url"]?.ToString() ?? "";
+                OutputLibraries.Add(new JsonObject
+                {
+                    ["name"] = Library?["name"]?.ToString(),
+                    ["downloads"] = new JsonObject
+                    {
+                        ["artifact"] = new JsonObject
+                        {
+                            ["path"] = libraryUrl.Substring(libraryUrl.LastIndexOfF("https://releases.r2.labymod.net/libraries/") + 42),
+                            ["sha1"] = Library?["sha1"]?.ToString(),
+                            ["size"] = Library?["size"]?.DeepClone(),
+                            ["url"] = libraryUrl
+                        }
+                    }
+                });
+            }
 
-            OutputLibraries.Add(JsonNode.Parse($@"{{
-                    ""name"": ""net.labymod:LabyMod:4"",
-                    ""downloads"": {{
-                        ""artifact"": {{
-                            ""path"": ""net/labymod/LabyMod/4/LabyMod-4.jar"",
-                            ""sha1"": ""{LabyModCore["sha1"]}"",
-                            ""size"": {LabyModCore["size"]},
-                            ""url"": ""https://releases.r2.labymod.net/api/v1/download/labymod4/{LabyModChannel}/{LabyModCore["commitReference"]}.jar""
-                        }}
-                    }}
-                }}"));
+            var labyModCommitReference = LabyModCore["commitReference"]?.ToString() ?? "";
+            OutputLibraries.Add(new JsonObject
+            {
+                ["name"] = "net.labymod:LabyMod:4",
+                ["downloads"] = new JsonObject
+                {
+                    ["artifact"] = new JsonObject
+                    {
+                        ["path"] = "net/labymod/LabyMod/4/LabyMod-4.jar",
+                        ["sha1"] = LabyModCore["sha1"]?.ToString(),
+                        ["size"] = LabyModCore["size"]?.DeepClone(),
+                        ["url"] = $"https://releases.r2.labymod.net/api/v1/download/labymod4/{LabyModChannel}/{labyModCommitReference}.jar"
+                    }
+                }
+            });
             OutputJson["libraries"] = OutputLibraries;
-            OutputJson.Add("labymod_data", JsonNode.Parse($@"{{
-                ""channelType"": ""{LabyModChannel}"",
-                ""commitReference"": ""{LabyModCore["commitReference"]}"",
-                ""version"": ""{LabyModCore["labyModVersion"]}"",
-                ""versionType"": ""release""
-            }}"));
+            OutputJson.Add("labymod_data", new JsonObject
+            {
+                ["channelType"] = LabyModChannel,
+                ["commitReference"] = labyModCommitReference,
+                ["version"] = LabyModCore["labyModVersion"]?.ToString(),
+                ["versionType"] = "release"
+            });
         }
 
         // 修改

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -8,6 +8,7 @@ using DotNet.Globbing;
 using PCL.Core.App;
 using PCL.Core.UI;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -1065,7 +1066,7 @@ public partial class PageInstanceExport : IRefreshable
                     { "summary", McInstance.Desc }, { "files", Files }, { "dependencies", Dependencies }
                 };
                 File.WriteAllText(Path.Combine(CacheFolder, "modpack", "modrinth.index.json"),
-                    ResultJson.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+                    ResultJson.ToJsonString(new JsonSerializerOptions(JsonCompat.SerializerOptions) { WriteIndented = true }));
                 // 打包
                 Directory.CreateDirectory(ModBase.GetPathFromFullPath(PackPath));
                 if (File.Exists(PackPath))

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Shapes;
 using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
+using PCL.Core.Utils;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1295,7 +1295,7 @@ public partial class PageInstanceInstall
 
                                 default:
                                 {
-                                    var ReleaseDate = Version["releaseTime"].GetValue<DateTime>().ToUniversalTime()
+                                    var ReleaseDate = Version["releaseTime"].ToObject<DateTime>().ToUniversalTime()
                                         .AddHours(2d);
                                     if (ReleaseDate.Month == 4 && ReleaseDate.Day == 1)
                                     {
@@ -1329,19 +1329,19 @@ public partial class PageInstanceInstall
 
                 // 排序
                 foreach (var Pair in Dict.ToList())
-                    Dict[Pair.Key] = Pair.Value.OrderByDescending(j => j["releaseTime"].GetValue<DateTime>()).ToList();
+                    Dict[Pair.Key] = Pair.Value.OrderByDescending(j => j["releaseTime"].ToObject<DateTime>()).ToList();
                 // 清空当前
                 PanMinecraft.Children.Clear();
                 // 添加最新版本
                 var CardInfo = new MyCard { Title = Lang.Text("Download.Version.Latest.Title"), Margin = new Thickness(0d, 15d, 0d, 15d) };
                 var TopestVersions = new List<JsonObject>();
                 var Release = (JsonObject)Dict["正式版"][0].DeepClone();
-                Release["lore"] = Lang.Text("Download.Version.Latest.Release", Lang.Date(Release["releaseTime"].GetValue<DateTime>(), "g"));
+                Release["lore"] = Lang.Text("Download.Version.Latest.Release", Lang.Date(Release["releaseTime"].ToObject<DateTime>(), "g"));
                 TopestVersions.Add(Release);
-                if (Dict["正式版"][0]["releaseTime"].GetValue<DateTime>() < Dict["预览版"][0]["releaseTime"].GetValue<DateTime>())
+                if (Dict["正式版"][0]["releaseTime"].ToObject<DateTime>() < Dict["预览版"][0]["releaseTime"].ToObject<DateTime>())
                 {
                     var Snapshot = (JsonObject)Dict["预览版"][0].DeepClone();
-                    Snapshot["lore"] = Lang.Text("Download.Version.Latest.Development", Lang.Date(Snapshot["releaseTime"].GetValue<DateTime>(), "g"));
+                    Snapshot["lore"] = Lang.Text("Download.Version.Latest.Development", Lang.Date(Snapshot["releaseTime"].ToObject<DateTime>(), "g"));
                     TopestVersions.Add(Snapshot);
                 }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -12,6 +12,7 @@ using PCL.Core.Minecraft.Java.UserPreference;
 using PCL.Core.UI;
 using PCL.Core.Utils.OS;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -953,7 +954,7 @@ public partial class PageInstanceSetup
         }
 
         // 保存配置
-        var json = JsonSerializer.Serialize(preference, JsonNodeExtensions.CompatOptions);
+        var json = JsonSerializer.Serialize(preference, JsonCompat.SerializerOptions);
         Config.Instance.SelectedJava[PageInstanceLeft.Instance.PathInstance] = json;
 
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -953,7 +953,7 @@ public partial class PageInstanceSetup
         }
 
         // 保存配置
-        var json = JsonSerializer.Serialize(preference);
+        var json = JsonSerializer.Serialize(preference, JsonNodeExtensions.CompatOptions);
         Config.Instance.SelectedJava[PageInstanceLeft.Instance.PathInstance] = json;
 
 

--- a/Plain Craft Launcher 2/Pages/PageLaunch/MyMsgLogin.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/MyMsgLogin.xaml.cs
@@ -5,6 +5,7 @@ using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.UI.Controls;
 using PCL.Network;
+using PCL.Core.Utils;
 
 namespace PCL;
 

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginAuth.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginAuth.xaml.cs
@@ -151,7 +151,7 @@ public partial class PageLoginAuth
                 serverUri = await ApiLocation.TryRequestAsync(serverUriInput);
                 using var resp = await HttpRequest.Create(serverUri).SendAsync();
                 var responseText = await resp.AsStringAsync();
-                serverName = await Task.Run(() => JsonNode.Parse(responseText)["meta"]["serverName"].ToString());
+                serverName = await Task.Run(() => ModBase.GetJson(responseText)["meta"]?["serverName"]?.ToString());
             }
             catch (Exception ex)
             {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -46,7 +46,7 @@ public partial class PageSetupAbout
                        .Create("https://api.github.com/repos/PCL-Community/PCL2-CE/contributors").SendAsync())
             {
                 response.EnsureSuccessStatusCode();
-                var cos = await response.AsJsonAsync<List<GitHubContributor>>();
+                var cos = await response.AsJsonAsync<List<GitHubContributor>>(JsonNodeExtensions.CompatOptions);
                 Contributors.Clear();
                 foreach (var item in cos)
                     Contributors.Add((GitHubContributor)item);

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Input;
 using PCL.Core.App.Localization;
 using PCL.Core.IO.Net.Http;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -46,7 +47,7 @@ public partial class PageSetupAbout
                        .Create("https://api.github.com/repos/PCL-Community/PCL2-CE/contributors").SendAsync())
             {
                 response.EnsureSuccessStatusCode();
-                var cos = await response.AsJsonAsync<List<GitHubContributor>>(JsonNodeExtensions.CompatOptions);
+                var cos = await response.AsJsonAsync<List<GitHubContributor>>(JsonCompat.SerializerOptions);
                 Contributors.Clear();
                 foreach (var item in cos)
                     Contributors.Add((GitHubContributor)item);

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -422,7 +422,7 @@ public partial class PageToolsGameLink
                 LobbyInfoProvider.RequiresLogin = (bool)jObj["requireLogin"];
                 LobbyInfoProvider.RequiresRealName = (bool)jObj["requireRealname"];
 
-                if (jObj["version"].GetValue<double>() > LobbyInfoProvider.ProtocolVersion)
+                if (jObj["version"].ToObject<double>() > LobbyInfoProvider.ProtocolVersion)
                 {
                     ModBase.RunInUi(() =>
                     {
@@ -444,8 +444,8 @@ public partial class PageToolsGameLink
                     if (string.IsNullOrWhiteSpace(content)) continue;
 
                     // 版本过滤
-                    var minVer = notice["minVer"].GetValue<double>();
-                    var maxVer = notice["maxVer"].GetValue<double>();
+                    var minVer = notice["minVer"].ToObject<double>();
+                    var maxVer = notice["maxVer"].ToObject<double>();
                     if (ModBase.VersionCode < minVer || ModBase.VersionCode > maxVer) continue;
 
                     // 类型映射

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -14,6 +14,7 @@ using PCL.Core.Logging;
 using PCL.Core.Utils.Validate;
 using PCL.Network;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 


### PR DESCRIPTION
> GPT-5.5 Thinking 修复并校对

新增 `PCL.Core/Utils/JsonCompat` 作为统一的 JSON 兼容解析入口，替代原先散落在 `Plain Craft Launcher 2` 项目中的 `JsonNodeExtensions`，并全部替换调用方式。

- **`JsonCompat`** — 集中管理 `SerializerOptions` / `NodeOptions` / `DocumentOptions`，内置 `FlexibleDateTimeConverter`、`FlexibleBoolConverter`、`FlexibleStringConverter` 三个宽松转换器，提供 `ParseNode()`、`ToObject<T>()`（扩展方法）、`FromObject<T>()`、`Merge()` 等辅助方法
- **全局迁移** — 将整体 `JsonNode.Parse()`、`GetValue<T>()`、`JsonSerializer.*` 裸调用全部替换为 `JsonCompat` 的对应 API，确保所有 JSON 解析使用一致的宽松选项，消除因格式/类型不匹配导致的反序列化崩溃
- **空引用修复** — 服务端名称获取等处加入 `?.` 空条件传播
- **Forge 版本列表** — 从 `FetchJson` 改为 `FetchString`（返回内容实为 HTML）
- **`ExpandoObjectConverter` 优化** — 用直接值类型判断替代二次序列化
- **`SignOutAsync` 优化** — 204 NoContent 时提前返回，避免解析空响应
- **Yggdrasil record 修正** — property 语义从 `set` 改为 `init`

## Summary by Sourcery

引入集中化的 JSON 兼容性工具，并迁移现有的 JSON 解析/序列化逻辑以使用该工具，从而在整个代码库中实现更健壮、更宽松的处理。

Bug 修复：
- 防止由于不一致或过于严格的 JSON 处理（包括可空字段、类型不匹配以及无内容的服务器响应）导致的崩溃和解析错误。
- 修复对实际上是 HTML 而非 JSON 的 Forge 版本列表响应的处理，避免将其误当作 JSON 解析。
- 更正 Yggdrasil 认证模型，使其使用仅在初始化时设置的属性以及正确的默认初始化，以避免非预期的修改和空引用问题。
- 在解析错误消息时，安全地处理返回 204 No Content 且响应体为空的登出（sign-out）响应。

增强功能：
- 通过新的 `JsonCompat` 工具统一 JSON 序列化器、文档和节点选项（包括自定义转换器），以模拟类似 Newtonsoft.Json 的宽松行为。
- 通过避免冗余序列化并添加直接的元素到 CLR 映射，优化动态类型和 `ExpandoObject` 的 JSON 转换。
- 借助共享的 JSON 选项和解析器，提高各类服务（如依赖检查、Natayark、EasyTier、McPing、配置、CLI 和元数据加载）的健壮性。
- 通过增加灵活的 `DateTime` 解析并容忍不同格式和时区，使版本和日期处理更加可靠。
- 用集中化的辅助工具取代临时的 `JsonNode` 解析/合并及分散的辅助函数，这些新工具支持深度合并和宽容的类型转换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized JSON compatibility utility and migrate existing JSON parsing/serialization to use it for more robust, lenient handling across the codebase.

Bug Fixes:
- Prevent crashes and misparsing caused by inconsistent or strict JSON handling, including nullable fields, type mismatches, and server responses without content.
- Fix handling of Forge version list responses that are actually HTML instead of JSON, avoiding invalid JSON parsing.
- Correct Yggdrasil authentication models to use init-only properties and proper default initialization to avoid unintended mutation and null issues.
- Handle sign-out responses with 204 No Content and empty bodies safely when parsing error messages.

Enhancements:
- Standardize JSON serializer, document, and node options (including custom converters) via a new JsonCompat utility to emulate Newtonsoft.Json-like leniency.
- Optimize dynamic and ExpandoObject JSON conversion by avoiding redundant serialization and adding direct element-to-CLR mapping.
- Improve resilience of various services (e.g., dependency checks, Natayark, EasyTier, McPing, config, CLI, and metadata loading) by using shared JSON options and parsers.
- Make version and date handling more robust by adding flexible DateTime parsing and tolerance for different formats and time zones.
- Replace ad-hoc JsonNode parsing/merging and scattered helpers with centralized helpers that support deep merges and tolerant conversions.

</details>