### PR TITLE
feat(metadata): add DotNet.Glob information to metadata.json

### DIFF
--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -129,7 +129,7 @@
     },
     {
       "name": "DotNet.Glob",
-      "info": "Copyright (c) 2015-present Darrell Tunnell\nLicensed under the MIT license.",
+      "info": "Copyright © 2015-present Darrell Tunnell\nLicensed under the MIT license.",
       "website": "https://github.com/dazinator/DotNet.Glob",
       "license": "https://github.com/dazinator/DotNet.Glob/blob/master/LICENSE"
     }

--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -129,7 +129,7 @@
     },
     {
       "name": "DotNet.Glob",
-      "info": "Copyright (c) 2015 present Darrell Tunnell\nLicensed under the MIT license.",
+      "info": "Copyright (c) 2015-present Darrell Tunnell\nLicensed under the MIT license.",
       "website": "https://github.com/dazinator/DotNet.Glob",
       "license": "https://github.com/dazinator/DotNet.Glob/blob/master/LICENSE"
     }

--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -126,6 +126,12 @@
       "info": "Copyright © HMCL-dev\nLicensed under the Apache-2.0 license.",
       "website": "https://github.com/HMCL-dev/lwjgl-unsafe-agent",
       "license": "https://github.com/HMCL-dev/lwjgl-unsafe-agent/blob/main/LICENSE"
+    },
+    {
+      "name": "DotNet.Glob",
+      "info": "Copyright (c) 2015 - present Darrell Tunnell",
+      "website": "https://github.com/dazinator/DotNet.Glob",
+      "license": "https://github.com/dazinator/DotNet.Glob/blob/master/LICENSE"
     }
   ]
 }

--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -129,7 +129,7 @@
     },
     {
       "name": "DotNet.Glob",
-      "info": "Copyright (c) 2015 - present Darrell Tunnell",
+      "info": "Copyright (c) 2015 present Darrell Tunnell\nLicensed under the MIT license.",
       "website": "https://github.com/dazinator/DotNet.Glob",
       "license": "https://github.com/dazinator/DotNet.Glob/blob/master/LICENSE"
     }


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

新功能：
- 在用于启动器的 `metadata.json` 中暴露与 `DotNet.Glob` 相关的元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Expose DotNet.Glob-related metadata in metadata.json for the launcher.

</details>