### PR TITLE
fix: 从旧配置迁移会错误匹配进程优先级

### DIFF
--- a/PCL.Core/App/ConfigEnums.cs
+++ b/PCL.Core/App/ConfigEnums.cs
@@ -57,11 +57,11 @@ public enum GameWindowSizeMode
 /// </summary>
 public enum GameProcessPriority
 {
-    RealTime = 0,
-    High = 1,
-    AboveNormal = 2,
-    Normal = 3,
-    BelowNormal = 4
+    AboveNormal = 0,
+    Normal = 1,
+    BelowNormal = 2,
+    High = 3,
+    RealTime = 4
 }
 
 /// <summary>


### PR DESCRIPTION
急修一下神秘的迁移问题
不然从旧配置升上来高就直接变实时了，太可怕了（）

## Summary by Sourcery

Bug Fixes:
- 修复从旧配置迁移时，将旧版配置值映射到游戏进程优先级等级的不正确问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect mapping of legacy configuration values to game process priority levels during migration from old configs.

</details>