### PR TITLE
fix(login): 修复正版账号皮肤获取与登录刷新异常 (#2947)

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -831,7 +831,11 @@ public static class ModLaunch
             {
                 tokens = MsLoginStep1Refresh(input.OAuthRefreshToken);
                 if (tokens.Length > 0 && tokens[0] == "Relogin")
-                    continue; // 重新登录
+                {
+                    // 刷新令牌已失效，清除后回退到设备代码流重新登录，避免无限循环
+                    input.OAuthRefreshToken = "";
+                    continue;
+                }
             }
 
             if (tokens.Length > 0 && tokens[0] == "Ignore")
@@ -936,8 +940,10 @@ public static class ModLaunch
                        .GetAwaiter()
                        .GetResult())
             {
-                response.EnsureSuccessStatusCode();
                 result = response.AsString();
+                if (!response.IsSuccess)
+                    throw new HttpRequestException(
+                        $"刷新登录请求失败，状态码 {(int)response.StatusCode}：{result}");
             }
         }
         catch (ThreadInterruptedException ex)
@@ -946,7 +952,8 @@ public static class ModLaunch
         }
         catch (Exception ex)
         {
-            if (ex.Message.ContainsF("must sign in again", true) || ex.Message.ContainsF("password expired", true) ||
+            if (ex.Message.ContainsF("invalid_grant", true) || ex.Message.ContainsF("must sign in again", true) ||
+                ex.Message.ContainsF("must first sign in", true) || ex.Message.ContainsF("password expired", true) ||
                 (ex.Message.Contains("refresh_token") && ex.Message.Contains("is not valid"))) // #269
                 return new[] { "Relogin", "" };
 
@@ -962,6 +969,8 @@ public static class ModLaunch
                     isIgnore = true;
             });
             if (isIgnore) return new[] { "Ignore", "" };
+            // 用户取消或登录线程已结束，静默中止启动，避免落入下方的 JSON 解析空引用
+            throw new Exception("$$");
         }
 
         var resultJson = (JsonObject)ModBase.GetJson(result);

--- a/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
@@ -26,7 +26,7 @@ public static class ModNet
             Retries = 3
         };
         var result = Requester.FetchString(url, param);
-        return isJson ? ModBase.GetJson(result) : result;
+        return isJson ? (object)ModBase.GetJson(result) : result;
     }
 
     public static object NetGetCodeByRequestOnce(string url, Encoding? encode = null, int timeout = 30000,
@@ -41,7 +41,7 @@ public static class ModNet
             Retries = 1
         };
         var result = Requester.FetchString(url, param);
-        return isJson ? ModBase.GetJson(result) : result;
+        return isJson ? (object)ModBase.GetJson(result) : result;
     }
 
     public static string NetGetCodeByLoader(string url, int timeout = 45000, bool isJson = false,


### PR DESCRIPTION
## 关联 Issue

fix #2947：正版账号皮肤无法获取、正版游戏无法登录。

## 问题原因

两处问题均为 `Newtonsoft.Json` → `System.Text.Json` 迁移（#2931）后引入的回归。

### 1. 皮肤无法获取（`InvalidCastException`）

`ModNet.NetGetCodeByRequestRetry` / `NetGetCodeByRequestOnce` 中：

```csharp
return IsJson ? ModBase.GetJson(result) : result;
```

`GetJson` 返回 `JsonNode`，而 `result` 为 `string`。`System.Text.Json` 定义了 `string` → `JsonNode` 的**隐式转换**，因此编译器将三元表达式的两个分支统一为 `JsonNode`——即便 `IsJson = false`，原始字符串也会被包装成 `JsonValuePrimitive<string>`。调用方 `McSkinGetAddress` 随后执行 `(string)skinString` 时便抛出 `InvalidCastException`。`Newtonsoft.Json` 没有这一隐式转换，故迁移前正常。

对应日志：

```
[WARN] 获取微软正版皮肤失败（SaltWood_233）
System.InvalidCastException: Unable to cast object of type
'System.Text.Json.Nodes.JsonValuePrimitive`1[System.String]' to type 'System.String'.
   at PCL.ModMinecraft.McSkinGetAddress(String uuid, String type)
```

### 2. 正版无法登录（`ArgumentNullException`）

`MsLoginStep1Refresh` 中刷新令牌请求返回 `400` 时，`response.EnsureSuccessStatusCode()` 绑定到了**内置方法**（实例方法优先于扩展方法），其抛出的异常**不包含响应体**，导致 `invalid_grant` / `must sign in again` 等"令牌失效"判定全部落空。用户点击取消后，代码继续向下执行至 `GetJson(Result)`，而此时 `Result` 为 `null`，最终抛出令人费解的"格式化 JSON 失败 / Value cannot be null"。

对应日志：

```
[INFO] 正版验证 Step 1/6 获取 OAuth Token 失败：
       System.Net.Http.HttpRequestException: Response status code does not indicate success: 400 (Bad Request).
...
System.Exception: 登录失败
 ---> System.Exception: 格式化 JSON 失败：
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'json')
   at PCL.Core.Utils.JsonCompat.ParseNode(String text)
```

### 3. `Relogin` 无限循环（潜在缺陷）

`GetOAuthTokens` 在 `MsLoginStep1Refresh` 返回 `"Relogin"` 时直接 `continue`，但未清空 `input.OAuthRefreshToken`，导致再次进入刷新分支，形成无限循环。

## 修改内容

- **`ModNet.cs`**：将三元表达式的 JSON 分支显式转换为 `object`（`IsJson ? (object)ModBase.GetJson(result) : result`），使非 JSON 分支保留原始 `string` 类型。同时修复 `NetGetCodeByRequestRetry` 与 `NetGetCodeByRequestOnce`。
- **`ModLaunch.cs` · `MsLoginStep1Refresh`**：先读取响应体，再抛出携带正文的 `HttpRequestException`；补充 `invalid_grant` / `must first sign in` 检测；用户取消时以 `"$$"` 静默中止启动，避免落入 `GetJson(null)` 空引用。
- **`ModLaunch.cs` · `GetOAuthTokens`**：`Relogin` 时清空 `OAuthRefreshToken`，回退至设备代码流，避免无限循环。

## 测试情况

- `dotnet build`：**0 个 C# 编译错误**（仅因启动器正在运行导致输出 `.exe` 被占用的文件锁错误，与本次改动无关）。
- 受限于需要真实微软账号会话，未能对登录 / 皮肤的实际运行时流程进行端到端测试；上述修复依据 issue 日志中的精确堆栈跟踪定位并验证。

## Summary by Sourcery

修复由于 JSON 处理和令牌刷新回归导致的 Microsoft 账号登录和皮肤获取问题。

Bug 修复：
- 恢复对非 JSON HTTP 响应的正确处理，防止在获取皮肤时因 `InvalidCastException` 而出错。
- 在 OAuth 刷新令牌时保留 HTTP 错误响应体，以便正确检测无效或过期的刷新令牌，避免对空结果进行 JSON 解析时出现错误。
- 通过在重试设备代码流程前清除无效的 OAuth 刷新令牌，防止出现无限重新登录循环。
- 当用户取消登录时，干净地中止登录流程，避免对空结果进行后续 JSON 解析。

增强：
- 调整网络辅助工具的返回类型，在禁用 JSON 解析时保留原始字符串响应。

> 本pr由claude opus 4.8辅助

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues with Microsoft account login and skin retrieval caused by JSON handling and token refresh regressions.

Bug Fixes:
- Restore correct handling of non-JSON HTTP responses to prevent InvalidCastException when retrieving skins.
- Preserve HTTP error response bodies during OAuth token refresh to correctly detect invalid or expired refresh tokens and avoid null JSON parsing errors.
- Prevent infinite relogin loops by clearing invalid OAuth refresh tokens before retrying the device code flow.
- Stop the login flow cleanly when the user cancels, avoiding downstream JSON parsing on null results.

Enhancements:
- Adjust network helper return types to keep plain string responses intact when JSON parsing is disabled.

</details>