### PR TITLE
refactor: 击毙 PCL.Core 里的所有 BOM

### DIFF
--- a/PCL.Core/App/Cli/CommandLine.cs
+++ b/PCL.Core/App/Cli/CommandLine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;

--- a/PCL.Core/App/Cli/SubcommandDefinition.cs
+++ b/PCL.Core/App/Cli/SubcommandDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace PCL.Core.App.Cli;
 

--- a/PCL.Core/App/Cli/TextArgument.cs
+++ b/PCL.Core/App/Cli/TextArgument.cs
@@ -1,4 +1,4 @@
-﻿namespace PCL.Core.App.Cli;
+namespace PCL.Core.App.Cli;
 
 public class TextArgument : CommandArgument<string>
 {

--- a/PCL.Core/App/ConfigEnums.cs
+++ b/PCL.Core/App/ConfigEnums.cs
@@ -1,4 +1,4 @@
-﻿namespace PCL.Core.App;
+namespace PCL.Core.App;
 
 /// <summary>
 /// 联机协议偏好

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"

--- a/PCL.Core/App/Paths.cs
+++ b/PCL.Core/App/Paths.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using PCL.Core.Utils.OS;
 using Special = System.Environment.SpecialFolder;

--- a/PCL.Core/IO/Net/Http/HttpResponseException.cs
+++ b/PCL.Core/IO/Net/Http/HttpResponseException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 

--- a/PCL.Core/Logging/ActionLevel.cs
+++ b/PCL.Core/Logging/ActionLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace PCL.Core.Logging;
+namespace PCL.Core.Logging;
 
 /// <summary>
 /// 事件/意外行为等级。

--- a/PCL.Core/Minecraft/GameCore.cs
+++ b/PCL.Core/Minecraft/GameCore.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.IO.Compression;
 
 namespace PCL.Core.Minecraft;

--- a/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Yggdrasil/YggdrasilCredential.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace PCL.Core.Minecraft.IdentityModel.Yggdrasil;
 

--- a/PCL.Core/Minecraft/NbtFileHandler.cs
+++ b/PCL.Core/Minecraft/NbtFileHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/PCL.Core/UI/GrayProfileConfig.cs
+++ b/PCL.Core/UI/GrayProfileConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace PCL.Core.UI;
 

--- a/PCL.Core/UI/HintWrapper.cs
+++ b/PCL.Core/UI/HintWrapper.cs
@@ -1,4 +1,4 @@
-﻿namespace PCL.Core.UI;
+namespace PCL.Core.UI;
 
 public enum HintTheme
 {

--- a/PCL.Core/UI/NColor.cs
+++ b/PCL.Core/UI/NColor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using System.Windows.Media;
 using PCL.Core.App.IoC;

--- a/PCL.Core/Utils/Diff/ItemDiff.cs
+++ b/PCL.Core/Utils/Diff/ItemDiff.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Management;
 using System.Runtime.InteropServices;

--- a/PCL.Core/Utils/OS/SystemPaths.cs
+++ b/PCL.Core/Utils/OS/SystemPaths.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace PCL.Core.Utils.OS;


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- 通过移除 UTF-8 BOM 标记，规范多个 PCL.Core 源文件的编码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Normalize encoding of multiple PCL.Core source files by removing UTF-8 BOM markers.

</details>