### PR TITLE
feat: 添加建造者披风译名

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -394,6 +394,7 @@
     <sys:String x:Key="Launch.Skin.Cape.Name.Founders">Founders</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.Copper">Copper</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.ZombieHorse">Zombie Horse</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.Builder">Builder</sys:String>
 
     <!-- Launch.Skin.Cape -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -394,6 +394,7 @@
     <sys:String x:Key="Launch.Skin.Cape.Name.Founders">创始人披风</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.Copper">铜披风</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.ZombieHorse">僵尸马披风</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.Builder">建造者披风</sys:String>
 
     <!-- Launch.Skin.Cape -->
 


### PR DESCRIPTION
https://zh.minecraft.wiki/w/%E5%BB%BA%E9%80%A0%E8%80%85%E6%8A%AB%E9%A3%8E

## Summary by Sourcery

为资源文件中的 Builder’s Cloak 物品新增英文和简体中文的本地化名称。

新功能：
- 在 en-US 本地化文件中为 Builder’s Cloak 提供英文翻译条目。
- 在 zh-CN 本地化文件中为 Builder’s Cloak 提供简体中文翻译条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add localized names for the Builder’s Cloak item in English and Simplified Chinese language resources.

New Features:
- Provide an English translation entry for the Builder’s Cloak in the en-US localization file.
- Provide a Simplified Chinese translation entry for the Builder’s Cloak in the zh-CN localization file.

</details>