### PR TITLE
fix(http): null reference warning

### DIFF
--- a/PCL.Core/IO/Net/Http/HttpResponseException.cs
+++ b/PCL.Core/IO/Net/Http/HttpResponseException.cs
@@ -23,7 +23,8 @@ public class HttpResponseException:HttpRequestException,IDisposable
         
     }
 
-    public HttpResponseException(HttpResponseMessage? response):this($"{(int?)response?.StatusCode} {response?.ReasonPhrase ?? Enum.GetName(response.StatusCode)}")
+    public HttpResponseException(HttpResponseMessage? response) : this(
+        $"{(int?)response?.StatusCode} {response?.ReasonPhrase ?? (response is null ? "undefined" : Enum.GetName(response.StatusCode))})")
     {
         Response = response;
     }


### PR DESCRIPTION
修复了可能的 Null Reference

## Summary by Sourcery

Bug Fixes:
- 防止在从可为空的 `HttpResponseMessage` 构造 `HttpResponseException` 消息时，可能出现的空引用问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential null reference when constructing HttpResponseException messages from a nullable HttpResponseMessage.

</details>