### PR TITLE
style: 击毙 HardwareInfo.cs 和 SystemInfo.cs 里的警告

### DIFF
--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -1,34 +1,33 @@
 using System;
 using System.Collections.Generic;
 using System.Management;
-using System.Runtime.InteropServices;
 using PCL.Core.Logging;
 
 namespace PCL.Core.Utils.OS;
 
 public static class HardwareInfo
 {
-    private static readonly object _lock = new();
+    private static readonly object _Lock = new();
     
     /// <summary>
     /// 系统 CPU 信息
     /// </summary>
-    public static string CPUName = "Unknown";
+    public static string CpuName = "Unknown";
 
     /// <summary>
     /// 系统 GPU 信息
     /// </summary>
-    public static IReadOnlyList<GPUInfo> GPUs { get; private set; } = [];
+    public static IReadOnlyList<GpuInfo> GpUs { get; private set; } = [];
 
     /// <summary>
     /// 已安装物理内存大小，单位 MB
     /// </summary>
-    public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
+    public static readonly long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
 
-    public readonly record struct GPUInfo(string Name, string DriverVersion, long Memory);
+    public readonly record struct GpuInfo(string Name, string DriverVersion, long Memory);
 
     /// <summary>
-    /// 获取系统信息，例如 CPU 与 GPU，并存储到 CPUName 和 GPUs
+    /// 获取系统信息，例如 CPU 与 GPU，并存储到 CpuName 和 GPUs
     /// </summary>
     public static void GetHardwareInfo()
     {
@@ -37,8 +36,9 @@ public static class HardwareInfo
         try
         {
             using var searcher = new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_Processor");
-            foreach (ManagementObject queryObj in searcher.Get())
+            foreach (var o in searcher.Get())
             {
+                var queryObj = (ManagementObject)o;
                 cpuName = queryObj["Name"]?.ToString()?.Trim();
                 break;
             }
@@ -49,14 +49,15 @@ public static class HardwareInfo
         }
 
         // GPU
-        var gpuList = new List<GPUInfo>();
+        var gpuList = new List<GpuInfo>();
         try
         {
             using var searcher =
                 new ManagementObjectSearcher(@"root\CIMV2", "SELECT * FROM Win32_VideoController");
-            foreach (ManagementObject queryObj in searcher.Get())
+            foreach (var o in searcher.Get())
             {
-                var gpuInfo = new GPUInfo
+                var queryObj = (ManagementObject)o;
+                var gpuInfo = new GpuInfo
                 {
                     Name = queryObj["Name"]?.ToString() ?? "",
                     DriverVersion = queryObj["DriverVersion"]?.ToString() ?? "",
@@ -72,12 +73,12 @@ public static class HardwareInfo
             LogWrapper.Warn(ex, "获取 GPU 信息时出错");
         }
 
-        lock (_lock)
+        lock (_Lock)
         {
             if (cpuName is not null)
-                CPUName = cpuName;
+                CpuName = cpuName;
             if (gpuList.Count > 0)
-                GPUs = gpuList;
+                GpUs = gpuList;
         }
         LogWrapper.Info("已获取系统硬件信息");
     }

--- a/PCL.Core/Utils/OS/SystemInfo.cs
+++ b/PCL.Core/Utils/OS/SystemInfo.cs
@@ -19,10 +19,10 @@ public static class SystemInfo
     /// <summary>
     /// 是否使用 GBK 编码。
     /// </summary>
-    public static readonly bool IsGBKEncoding = Encoding.Default.CodePage == 936;
+    public static readonly bool IsGbkEncoding = Encoding.Default.CodePage == 936;
 
     /// <summary>
     /// 系统信息描述，例如 Microsoft Windows 11 专业工作站版 10.0.22635.0
     /// </summary>
-    public static readonly string OSInfo = $"{RuntimeInformation.OSDescription} {Environment.OSVersion.Version}";
+    public static readonly string OsInfo = $"{RuntimeInformation.OSDescription} {Environment.OSVersion.Version}";
 }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCrash.cs
@@ -1302,13 +1302,13 @@ public class CrashAnalyzer
                     envInfo.Append($"MC 文件夹：{mcLauncherLog.Between("MC 文件夹：", "[").TrimEnd('[').Trim()}\r\n");
                     envInfo.Append($"\r\n- 环境信息 -\r\n");
                     envInfo.Append(
-                        $"操作系统：{SystemInfo.OSInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）\r\n");
-                    envInfo.Append($"CPU：{HardwareInfo.CPUName}\r\n");
+                        $"操作系统：{SystemInfo.OsInfo}（64 位：{!SystemInfo.Is32BitSystem}, ARM64: {SystemInfo.IsArm64System}）\r\n");
+                    envInfo.Append($"CPU：{HardwareInfo.CpuName}\r\n");
                     envInfo.Append(
                         $"内存分配 (分配的内存 / 已安装物理内存)：{mcLauncherLog.Between("分配的内存：", "[").TrimEnd('[').Trim()} / {Lang.Number(HardwareInfo.SystemMemorySize / 1024d, "N2")} GB ({Lang.Number(HardwareInfo.SystemMemorySize, "N0")} MB)\r\n");
-                    for (int i = 0; i < HardwareInfo.GPUs.Count; i++)
+                    for (int i = 0; i < HardwareInfo.GpUs.Count; i++)
                     {
-                        var gPU = HardwareInfo.GPUs[i];
+                        var gPU = HardwareInfo.GpUs[i];
                         envInfo.Append(
                             $"显卡 {i}：{gPU.Name} ({(gPU.Memory >= 4095L ? ">= " + gPU.Memory : gPU.Memory)} MB, {gPU.DriverVersion})");
                         envInfo.Append("\r\n");

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -3033,7 +3033,7 @@ public static class ModLaunch
     private static string GetNativesFolder()
     {
         var result = Path.Combine(ModMinecraft.McInstanceSelected.PathInstance, ModMinecraft.McInstanceSelected.Name + "-natives");
-        if (SystemInfo.IsGBKEncoding || result.IsASCII())
+        if (SystemInfo.IsGbkEncoding || result.IsASCII())
             return result;
         result = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft", "bin", "natives");
         if (result.IsASCII())


### PR DESCRIPTION
## Summary by Sourcery

标准化硬件和系统信息的命名，并将只读字段统一处理，以满足代码分析规则并消除警告。

增强内容：
- 重命名 CPU、GPU 和 OS 信息字段/属性及相关类型/用法，使其遵循一致的 .NET 风格命名和大小写规范。
- 在合适的地方将硬件和系统信息字段标记为只读，以更好地体现其不可变性，并消除分析器警告。
- 调整硬件信息中对 WMI 结果的枚举方式，以在遍历 `ManagementObject` 集合时避免类型警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize hardware and system information naming and readonly fields to satisfy code analysis rules and remove warnings.

Enhancements:
- Rename CPU, GPU, and OS info fields/properties and related types/usages to follow consistent .NET-style naming and casing.
- Mark hardware and system info fields as readonly where appropriate to better reflect immutability and silence analyzer warnings.
- Adjust WMI result enumeration in hardware info to avoid type warnings when iterating ManagementObject collections.

</details>