### PR TITLE
fix: #2955

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/MyBitmap.cs
+++ b/Plain Craft Launcher 2/Modules/Base/MyBitmap.cs
@@ -93,6 +93,7 @@ public class MyBitmap
             var encoder = new PngBitmapEncoder();
             encoder.Frames.Add(BitmapFrame.Create((BitmapSource)image));
             encoder.Save(ms);
+            pic = new Bitmap(ms);
         }
     }
 
@@ -113,6 +114,7 @@ public class MyBitmap
             var encoder = new BmpBitmapEncoder();
             encoder.Frames.Add(BitmapFrame.Create((BitmapSource)image.ImageSource));
             encoder.Save(ms);
+            pic = new Bitmap(ms);
         }
     }
 


### PR DESCRIPTION
#2955 奇妙的 another 2 deletions

## Summary by Sourcery

错误修复：
- 修复在 `MyBitmap` 构造函数中对图像进行编码后，未进行位图初始化的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix missing bitmap initialization after encoding images in MyBitmap constructors.

</details>