### PR TITLE
fix(instance-install): 修复实例修改页面加载器列表不刷新及空列表问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -1027,12 +1027,12 @@ public static class ModDownload
         string result;
         try
         {
-            result = Requester.FetchJson(
+            result = Requester.FetchString(
                 "https://files.minecraftforge.net/maven/net/minecraftforge/forge/index_" +
                 loader.input.Replace("-", "_") + ".html", new RequestParam
                 {
                     UseBrowserUserAgent = true
-                })?.ToString() ?? ""; // 兼容 Forge 1.7.10-pre4，#4057
+                }); // 兼容 Forge 1.7.10-pre4，#4057
         }
         catch (WebException)
         {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -38,6 +38,20 @@ public partial class PageInstanceInstall
         disabledPageAnimControls.Add(BtnSelectStart);
         // PageLoaderInit(LoadMinecraft, PanLoad, PanBack, Nothing, DlClientListLoader, AddressOf LoadMinecraft_OnFinish)
         PageLoaderInit(LoadMinecraft, PanLoad, PanAllBack, null, ModDownload.dlClientListLoader, _ => GetCurrentInfo());
+        LoadOptiFine.StateChanged += (_, _, _) => { OptiFine_Loaded(); ReloadSelected(); };
+        LoadLiteLoader.StateChanged += (_, _, _) => { LiteLoader_Loaded(); ReloadSelected(); };
+        LoadForge.StateChanged += (_, _, _) => { Forge_Loaded(); ReloadSelected(); };
+        LoadNeoForge.StateChanged += (_, _, _) => { NeoForge_Loaded(); ReloadSelected(); };
+        LoadCleanroom.StateChanged += (_, _, _) => { Cleanroom_Loaded(); ReloadSelected(); };
+        LoadFabric.StateChanged += (_, _, _) => { Fabric_Loaded(); ReloadSelected(); };
+        LoadFabricApi.StateChanged += (_, _, _) => { FabricApi_Loaded(); ReloadSelected(); };
+        LoadLegacyFabric.StateChanged += (_, _, _) => { LegacyFabric_Loaded(); ReloadSelected(); };
+        LoadLegacyFabricApi.StateChanged += (_, _, _) => { LegacyFabricApi_Loaded(); ReloadSelected(); };
+        LoadQuilt.StateChanged += (_, _, _) => { Quilt_Loaded(); ReloadSelected(); };
+        LoadQSL.StateChanged += (_, _, _) => { QSL_Loaded(); ReloadSelected(); };
+        LoadOptiFabric.StateChanged += (_, _, _) => { OptiFabric_Loaded(); ReloadSelected(); };
+        LoadLabyMod.StateChanged += (_, _, _) => { LabyMod_Loaded(); ReloadSelected(); };
+        PageExit += () => isInSelectPage = false;
     }
 
     private void Init()
@@ -62,12 +76,12 @@ public partial class PageInstanceInstall
         ModDownload.dlLegacyFabricApiLoader.Start(isForceRestart: needRefresh);
         ModDownload.dlOptiFabricLoader.Start(isForceRestart: needRefresh);
 
-        // 重载预览
-        ReloadSelected();
-
         // 非重复加载部分
         if (isLoad)
+        {
+            ReloadSelected();
             return;
+        }
         isLoad = true;
 
         ModDownloadLib.McDownloadForgeRecommendedRefresh();


### PR DESCRIPTION
## Summary by Sourcery

修复实例安装加载器列表刷新问题，并更新 Forge 版本元数据获取逻辑。

Bug 修复：
- 确保在加载器完成加载后，实例修改页面会刷新加载器选择列表，并避免在首次加载时出现空的加载器列表。
- 调整 Forge 官方版本获取逻辑，改为正确获取并解析 HTML 索引页面，而不是将其当作 JSON 处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues with instance install loader list refresh and update Forge version metadata fetching.

Bug Fixes:
- Ensure the instance modification page refreshes the loader selection list when loaders finish loading and avoids empty loader lists on first load.
- Adjust Forge official version fetching to correctly retrieve and parse the HTML index page instead of treating it as JSON.

</details>