### PR TITLE
fix(instance-export): 修复 Modrinth 整合包导出时出现的路径拼接问题

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -821,7 +821,7 @@ public partial class PageInstanceExport : IRefreshable
 
                     if (!shouldKeep)
                         continue;
-                    var targetPath = overridesFolder + relativePath;
+                    var targetPath = Path.Combine(overridesFolder, relativePath);
                     ModBase.CopyFile(Entry.FullName, targetPath);
                     // 若为压缩包，考虑联网获取路径
                     if (checkHostedAssets &&
@@ -858,7 +858,7 @@ public partial class PageInstanceExport : IRefreshable
                 }
                 else if (File.Exists(Line))
                 {
-                    ModBase.CopyFile(Line, baseFolder + ModBase.GetFileNameFromPath(Line));
+                    ModBase.CopyFile(Line, Path.Combine(baseFolder, ModBase.GetFileNameFromPath(Line)));
                 }
                 else
                 {
@@ -1037,7 +1037,7 @@ public partial class PageInstanceExport : IRefreshable
                     var modFile = Pair.Key;
                     files.Add(new JsonObject
                     {
-                        { "path", modFile.path.AfterFirst(overridesFolder).Replace(@"\", "/") },
+                        { "path", Path.GetRelativePath(overridesFolder, modFile.path).Replace(@"\", "/") },
                         {
                             "hashes",
                             new JsonObject


### PR DESCRIPTION
fix: #2970

如题，原代码使用路径拼接，但 overridesFolder 结尾没有 `/`，relativePath 开头也没有 `/`，导致拼接出来的路径出现问题，该 PR 通过使用 `Path.Combine()` 方法修复了此问题，同时也修复了其它的一些潜在的路径拼接问题

## 由 Sourcery 提供的总结

通过统一路径构建方式和相对路径计算方式，修复在导出 Modrinth 实例时路径处理不正确的问题。

Bug 修复：
- 通过使用平台安全的路径组合方式，解决在导出 Modrinth 实例时 overrides 文件夹路径拼接错误的问题。
- 通过使用正确的路径拼接来构建目标路径，修复基础文件夹文件复制路径的问题。
- 通过相对于 overrides 目录计算路径，而不是依赖字符串切片，纠正导出元数据路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect path handling when exporting Modrinth instances by standardizing path construction and relative path calculation.

Bug Fixes:
- Resolve incorrect overrides folder path concatenation during Modrinth instance export by using platform-safe path combination.
- Fix base folder file copy paths by constructing destinations with proper path joining.
- Correct exported metadata paths by computing paths relative to the overrides directory instead of relying on string slicing.

</details>