### PR TITLE
fix: 修复正版验证失败的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -640,7 +640,7 @@ public static class ModLaunch
 
         // 尝试加载
         loader.WaitForExit(data.input, mcLoginLoader, data.isForceRestarting);
-        data.output = (McLoginResult)((dynamic)loader).Output;
+        data.output = (McLoginResult)((dynamic)loader).output;
         ModBase.RunInUi(() => ModMain.frmLaunchLeft.RefreshPage(false)); // 刷新自动填充列表
         ModBase.Log("[Profile] 选定档案加载完成");
     }


### PR DESCRIPTION
如题，`ModLaunch` 访问动态 loader 时使用了 `Output`，而 `ModLoader` 定义中：
```cs
/// <summary>
///     用于异步执行并监控单一函数的加载器。
/// </summary>
public class LoaderTask<InputType, OutputType> : LoaderTask
{
    // 输入输出
    public InputType input;
    protected internal Func<InputType?>? inputDelegate;

    // 执行事件
    protected internal Action<LoaderTask<InputType, OutputType>> loadDelegate;
    public OutputType output = default;

    private CancellationTokenSource? cancelToken;

    // 线程设定
    protected internal ThreadPriority threadPriority;

    // ...
}
```
导致正版验证失败（无法获取到输出内容）

## Summary by Sourcery

错误修复：
- 通过从加载器的 `output` 字段而不是错误的 `Output` 属性中读取 McLogin 加载器结果，修复了许可证验证失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct McLogin loader result retrieval by reading from the loader's output field instead of an incorrect Output property, preventing license verification failures.

</details>