### PR TITLE
feat: 重新实现 Toast 通知（第一部分：基础通知）

### DIFF
--- a/PCL.Core.Test/ToastTest.cs
+++ b/PCL.Core.Test/ToastTest.cs
@@ -10,6 +10,7 @@ public class ToastTest
     [TestMethod]
     public void TestToast()
     {
+        // 别跑会炸，因为 Basics.cs 的 Metadata 需要在运行时加载，单元测试项目无法访问
         SendToast("A toast notice from PCL.Core!", "Test Toast");
     }
 }

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -37,6 +37,8 @@ public static class ToastNotification
             </toast>
             """);
 
+        
+        // TODO: 将 AUMID 判断放在其他位置
         if (!AumidHelper.HasAumid())
         {
             AumidHelper.RegisterAumid("PCLCommunity.PCLCE");

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -1,3 +1,11 @@
+using System;
+using System.Runtime.InteropServices;
+using PCL.Core.Utils.OS;
+using PCL.Core.Utils.WinRT;
+using PCL.Core.Utils.WinRT.Interface;
+using PCL.Core.Utils.WinRT.Interface.Windows.Data.Xml.Dom;
+using PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
+
 namespace PCL.Core.UI;
 
 public static class ToastNotification
@@ -7,7 +15,7 @@ public static class ToastNotification
     /// </summary>
     /// <param name="message">Notification detail text</param>
     /// <param name="title">Notification title</param>
-    public static void SendToast(string message, string title = "Notice")
+    public static unsafe void SendToast(string message, string title = "Notice")
     {
         // var toast = new ToastContentBuilder();
         // toast
@@ -17,6 +25,54 @@ public static class ToastNotification
         //
         // toast.Show();
         // TODO
+        
+        var xml = HStringHelper.ToHString($"""
+            <toast>
+                <visual>
+                    <binding template="ToastGeneric">
+                        <text>{title}</text>
+                        <text>{message}</text>
+                    </binding>
+                </visual>
+            </toast>
+            """);
+
+        if (!AumidHelper.HasAumid())
+        {
+            AumidHelper.RegisterAumid("PCLCommunity.PCLCE");
+        }
+        var aumid = HStringHelper.ToHString("PCLCommunity.PCLCE");
+        
+        fixed (Guid* xmlDocumentIOIid = &IXmlDocumentIOInfo.Iid)
+        {
+            void* xmlDocumentIO;
+            void* toastNotification;
+            void* toastNotifier;
+
+            var inspectable = (IInspectable*)WinRTInterop.ActivateInstance(IXmlDocumentIOInfo.ActivatableClassId);
+            Marshal.ThrowExceptionForHR(
+                inspectable->lpVtbl->QueryInterface(inspectable, xmlDocumentIOIid, &xmlDocumentIO));
+            Marshal.ThrowExceptionForHR(
+                ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->LoadXml(xmlDocumentIO, xml));
+
+            var toastNotificationFactory =
+                (IToastNotificationFactory*)WinRTInterop.GetActivationFactory(
+                    IToastNotificationFactoryInfo.ActivatableClassId, IToastNotificationFactoryInfo.Iid);
+            Marshal.ThrowExceptionForHR(
+                toastNotificationFactory->lpVtbl->CreateToastNotification(toastNotificationFactory, xmlDocumentIO,
+                    &toastNotification));
+
+            var toastNotificationManagerStatics = (IToastNotificationManagerStatics*)WinRTInterop.GetActivationFactory(
+                IToastNotificationManagerStaticsInfo.ActivatableClassId, IToastNotificationManagerStaticsInfo.Iid);
+            Marshal.ThrowExceptionForHR(
+                toastNotificationManagerStatics->lpVtbl->CreateToastNotifierWithId(toastNotificationManagerStatics,
+                    aumid, &toastNotifier));
+            Marshal.ThrowExceptionForHR(
+                ((IToastNotifier*)toastNotifier)->lpVtbl->Show(toastNotifier, toastNotification));
+        }
+        
+        HStringHelper.DeleteHString(xml);
+        HStringHelper.DeleteHString(aumid);
     }
 
     /// <summary>
@@ -27,6 +83,4 @@ public static class ToastNotification
         // ToastNotificationManagerCompat.Uninstall();
         // TODO
     }
-    
-    
 }

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -47,7 +47,7 @@ public static class ToastNotification
             AumidHelper.RegisterAumid();
         }
 
-        var aumid = HStringHelper.ToHString("PCLCommunity.PCLCE");
+        var aumid = HStringHelper.ToHString(AumidHelper.Aumid);
 
         // TODO: 支持触发事件
 

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -27,7 +27,6 @@ public static class ToastNotification
                 </visual>
             </toast>
             """);
-
         
         // TODO: 将 AUMID 判断放在其他位置
         if (!AumidHelper.HasAumid())
@@ -35,6 +34,8 @@ public static class ToastNotification
             AumidHelper.RegisterAumid("PCLCommunity.PCLCE");
         }
         var aumid = HStringHelper.ToHString("PCLCommunity.PCLCE");
+        
+        // TODO: 支持触发事件
         
         fixed (Guid* xmlDocumentIOIid = &IXmlDocumentIOInfo.Iid)
         {

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -28,7 +28,7 @@ public static class ToastNotification
                        </visual>
                    </toast>
                    """;
-        
+
         SendToastFromTemplate(xml);
     }
 
@@ -40,62 +40,103 @@ public static class ToastNotification
     {
         // 定义 Toast 模板
         var toastXml = HStringHelper.ToHString(xml);
-        
+
         // TODO: 将 AUMID 判断放在其他位置
         if (!AumidHelper.HasAumid())
         {
             AumidHelper.RegisterAumid();
         }
+
         var aumid = HStringHelper.ToHString("PCLCommunity.PCLCE");
-        
+
         // TODO: 支持触发事件
-        
-        fixed (Guid* xmlDocumentIOIid = &IXmlDocumentIOInfo.Iid)
+
+        IInspectable* inspectable = null;
+        IXmlDocumentIO* xmlDocumentIO = null;
+        IToastNotificationFactory* toastNotificationFactory = null;
+        IToastNotificationManagerStatics* toastNotificationManagerStatics = null;
+        IInspectable* toastNotification = null;
+        IToastNotifier* toastNotifier = null;
+
+        try
         {
-            void* xmlDocumentIO;
-            void* toastNotification;
-            void* toastNotifier;
+            fixed (Guid* xmlDocumentIOIid = &IXmlDocumentIOInfo.Iid)
+            {
+                // 创建 XmlDocument 对象
+                inspectable =
+                    (IInspectable*)WinRTInterop.ActivateInstance(
+                        IXmlDocumentIOInfo.ActivatableClassId);
 
-            // 创建 XmlDocument 对象
-            var inspectable = (IInspectable*)WinRTInterop.ActivateInstance(IXmlDocumentIOInfo.ActivatableClassId);
-            Marshal.ThrowExceptionForHR(
-                inspectable->lpVtbl->QueryInterface(inspectable, xmlDocumentIOIid, &xmlDocumentIO));
-            // 加载 XML
-            Marshal.ThrowExceptionForHR(
-                ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->LoadXml(xmlDocumentIO, toastXml));
+                Marshal.ThrowExceptionForHR(
+                    inspectable->lpVtbl->QueryInterface(
+                        inspectable,
+                        xmlDocumentIOIid,
+                        (void**)&xmlDocumentIO));
 
-            // 获取 ToastNotification 的激活工厂
-            var toastNotificationFactory =
-                (IToastNotificationFactory*)WinRTInterop.GetActivationFactory(
-                    IToastNotificationFactoryInfo.ActivatableClassId, IToastNotificationFactoryInfo.Iid);
-            // 从 XML 创建 ToastNotification 对象
-            Marshal.ThrowExceptionForHR(
-                toastNotificationFactory->lpVtbl->CreateToastNotification(toastNotificationFactory, xmlDocumentIO,
-                    &toastNotification));
+                // 加载 XML
+                Marshal.ThrowExceptionForHR(
+                    xmlDocumentIO->lpVtbl->LoadXml(
+                        xmlDocumentIO,
+                        toastXml));
 
-            // 创建 ToastNotifierManager 对象
-            var toastNotificationManagerStatics = (IToastNotificationManagerStatics*)WinRTInterop.GetActivationFactory(
-                IToastNotificationManagerStaticsInfo.ActivatableClassId, IToastNotificationManagerStaticsInfo.Iid);
-            // 获取 ToastNotifier 对象
-            Marshal.ThrowExceptionForHR(
-                toastNotificationManagerStatics->lpVtbl->CreateToastNotifierWithId(toastNotificationManagerStatics,
-                    aumid, &toastNotifier));
-            // 发送 Toast 通知
-            Marshal.ThrowExceptionForHR(
-                ((IToastNotifier*)toastNotifier)->lpVtbl->Show(toastNotifier, toastNotification));
-            
-            // 释放资源
-            inspectable->lpVtbl->Release(inspectable);
-            ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->Release(xmlDocumentIO);
-            toastNotificationFactory->lpVtbl->Release(toastNotificationFactory);
-            ((IInspectable*)toastNotification)->lpVtbl->Release(toastNotification);
-            toastNotificationManagerStatics->lpVtbl->Release(toastNotificationManagerStatics);
-            ((IToastNotifier*)toastNotifier)->lpVtbl->Release(toastNotifier);
+                // 获取 ToastNotificationFactory
+                toastNotificationFactory =
+                    (IToastNotificationFactory*)WinRTInterop.GetActivationFactory(
+                        IToastNotificationFactoryInfo.ActivatableClassId,
+                        IToastNotificationFactoryInfo.Iid);
+
+                // 创建 ToastNotification
+                Marshal.ThrowExceptionForHR(
+                    toastNotificationFactory->lpVtbl->CreateToastNotification(
+                        toastNotificationFactory,
+                        xmlDocumentIO,
+                        (void**)&toastNotification));
+
+                // 获取 ToastNotificationManager
+                toastNotificationManagerStatics =
+                    (IToastNotificationManagerStatics*)WinRTInterop.GetActivationFactory(
+                        IToastNotificationManagerStaticsInfo.ActivatableClassId,
+                        IToastNotificationManagerStaticsInfo.Iid);
+
+                // 创建 ToastNotifier
+                Marshal.ThrowExceptionForHR(
+                    toastNotificationManagerStatics->lpVtbl->CreateToastNotifierWithId(
+                        toastNotificationManagerStatics,
+                        aumid,
+                        (void**)&toastNotifier));
+
+                // 发送
+                Marshal.ThrowExceptionForHR(
+                    toastNotifier->lpVtbl->Show(
+                        toastNotifier,
+                        toastNotification));
+            }
         }
-        
-        // 释放 HSTRING
-        HStringHelper.DeleteHString(toastXml);
-        HStringHelper.DeleteHString(aumid);
+        finally
+        {
+            if (toastNotifier is not null)
+                toastNotifier->lpVtbl->Release(toastNotifier);
+
+            if (toastNotification is not null)
+                toastNotification->lpVtbl->Release(toastNotification);
+
+            if (toastNotificationManagerStatics is not null)
+                toastNotificationManagerStatics->lpVtbl->Release(
+                    toastNotificationManagerStatics);
+
+            if (toastNotificationFactory is not null)
+                toastNotificationFactory->lpVtbl->Release(
+                    toastNotificationFactory);
+
+            if (xmlDocumentIO is not null)
+                xmlDocumentIO->lpVtbl->Release(xmlDocumentIO);
+
+            if (inspectable is not null)
+                inspectable->lpVtbl->Release(inspectable);
+
+            HStringHelper.DeleteHString(toastXml);
+            HStringHelper.DeleteHString(aumid);
+        }
     }
 
     /// <summary>

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -12,22 +12,34 @@ namespace PCL.Core.UI;
 public static class ToastNotification
 {
     /// <summary>
-    /// Send a Toast notification with simple texts to the system.
+    /// 发送简单的 Toast 通知。
     /// </summary>
-    /// <param name="message">Notification detail text</param>
-    /// <param name="title">Notification title</param>
-    public static unsafe void SendToast(string message, string title = "Notice")
+    /// <param name="message">通知内容</param>
+    /// <param name="title">通知标题</param>
+    public static void SendToast(string message, string title = "Notice")
     {
-        var xml = HStringHelper.ToHString($"""
-            <toast>
-                <visual>
-                    <binding template="ToastGeneric">
-                        <text>{SecurityElement.Escape(title)}</text>
-                        <text>{SecurityElement.Escape(message)}</text>
-                    </binding>
-                </visual>
-            </toast>
-            """);
+        var xml = $"""
+                   <toast>
+                       <visual>
+                           <binding template="ToastGeneric">
+                               <text>{SecurityElement.Escape(title)}</text>
+                               <text>{SecurityElement.Escape(message)}</text>
+                           </binding>
+                       </visual>
+                   </toast>
+                   """;
+        
+        SendToastFromTemplate(xml);
+    }
+
+    /// <summary>
+    /// 根据模板发送 Toast 通知。
+    /// </summary>
+    /// <param name="xml">Toast 模板</param>
+    public static unsafe void SendToastFromTemplate(string xml)
+    {
+        // 定义 Toast 模板
+        var toastXml = HStringHelper.ToHString(xml);
         
         // TODO: 将 AUMID 判断放在其他位置
         if (!AumidHelper.HasAumid())
@@ -44,24 +56,31 @@ public static class ToastNotification
             void* toastNotification;
             void* toastNotifier;
 
+            // 创建 XmlDocument 对象
             var inspectable = (IInspectable*)WinRTInterop.ActivateInstance(IXmlDocumentIOInfo.ActivatableClassId);
             Marshal.ThrowExceptionForHR(
                 inspectable->lpVtbl->QueryInterface(inspectable, xmlDocumentIOIid, &xmlDocumentIO));
+            // 加载 XML
             Marshal.ThrowExceptionForHR(
-                ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->LoadXml(xmlDocumentIO, xml));
+                ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->LoadXml(xmlDocumentIO, toastXml));
 
+            // 获取 ToastNotification 的激活工厂
             var toastNotificationFactory =
                 (IToastNotificationFactory*)WinRTInterop.GetActivationFactory(
                     IToastNotificationFactoryInfo.ActivatableClassId, IToastNotificationFactoryInfo.Iid);
+            // 从 XML 创建 ToastNotification 对象
             Marshal.ThrowExceptionForHR(
                 toastNotificationFactory->lpVtbl->CreateToastNotification(toastNotificationFactory, xmlDocumentIO,
                     &toastNotification));
 
+            // 创建 ToastNotifierManager 对象
             var toastNotificationManagerStatics = (IToastNotificationManagerStatics*)WinRTInterop.GetActivationFactory(
                 IToastNotificationManagerStaticsInfo.ActivatableClassId, IToastNotificationManagerStaticsInfo.Iid);
+            // 获取 ToastNotifier 对象
             Marshal.ThrowExceptionForHR(
                 toastNotificationManagerStatics->lpVtbl->CreateToastNotifierWithId(toastNotificationManagerStatics,
                     aumid, &toastNotifier));
+            // 发送 Toast 通知
             Marshal.ThrowExceptionForHR(
                 ((IToastNotifier*)toastNotifier)->lpVtbl->Show(toastNotifier, toastNotification));
             
@@ -74,7 +93,8 @@ public static class ToastNotification
             ((IToastNotifier*)toastNotifier)->lpVtbl->Release(toastNotifier);
         }
         
-        HStringHelper.DeleteHString(xml);
+        // 释放 HSTRING
+        HStringHelper.DeleteHString(toastXml);
         HStringHelper.DeleteHString(aumid);
     }
 

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Security;
 using PCL.Core.Utils.OS;
 using PCL.Core.Utils.WinRT;
 using PCL.Core.Utils.WinRT.Interface;
@@ -21,8 +22,8 @@ public static class ToastNotification
             <toast>
                 <visual>
                     <binding template="ToastGeneric">
-                        <text>{title}</text>
-                        <text>{message}</text>
+                        <text>{SecurityElement.Escape(title)}</text>
+                        <text>{SecurityElement.Escape(message)}</text>
                     </binding>
                 </visual>
             </toast>
@@ -31,7 +32,7 @@ public static class ToastNotification
         // TODO: 将 AUMID 判断放在其他位置
         if (!AumidHelper.HasAumid())
         {
-            AumidHelper.RegisterAumid("PCLCommunity.PCLCE");
+            AumidHelper.RegisterAumid();
         }
         var aumid = HStringHelper.ToHString("PCLCommunity.PCLCE");
         
@@ -63,6 +64,14 @@ public static class ToastNotification
                     aumid, &toastNotifier));
             Marshal.ThrowExceptionForHR(
                 ((IToastNotifier*)toastNotifier)->lpVtbl->Show(toastNotifier, toastNotification));
+            
+            // 释放资源
+            inspectable->lpVtbl->Release(inspectable);
+            ((IXmlDocumentIO*)xmlDocumentIO)->lpVtbl->Release(xmlDocumentIO);
+            toastNotificationFactory->lpVtbl->Release(toastNotificationFactory);
+            ((IInspectable*)toastNotification)->lpVtbl->Release(toastNotification);
+            toastNotificationManagerStatics->lpVtbl->Release(toastNotificationManagerStatics);
+            ((IToastNotifier*)toastNotifier)->lpVtbl->Release(toastNotifier);
         }
         
         HStringHelper.DeleteHString(xml);
@@ -75,6 +84,6 @@ public static class ToastNotification
     public static void UninstallToasts()
     {
         // TODO: 更改这里的逻辑
-        AumidHelper.UnregisterAumid("PCLCommunity.PCLCE");
+        AumidHelper.UnregisterAumid();
     }
 }

--- a/PCL.Core/UI/ToastNotification.cs
+++ b/PCL.Core/UI/ToastNotification.cs
@@ -17,15 +17,6 @@ public static class ToastNotification
     /// <param name="title">Notification title</param>
     public static unsafe void SendToast(string message, string title = "Notice")
     {
-        // var toast = new ToastContentBuilder();
-        // toast
-        //     .AddArgument("action", "viewConversation")
-        //     .AddText(title)
-        //     .AddText(message);
-        //
-        // toast.Show();
-        // TODO
-        
         var xml = HStringHelper.ToHString($"""
             <toast>
                 <visual>
@@ -82,7 +73,7 @@ public static class ToastNotification
     /// </summary>
     public static void UninstallToasts()
     {
-        // ToastNotificationManagerCompat.Uninstall();
-        // TODO
+        // TODO: 更改这里的逻辑
+        AumidHelper.UnregisterAumid("PCLCommunity.PCLCE");
     }
 }

--- a/PCL.Core/Utils/IconHelper.cs
+++ b/PCL.Core/Utils/IconHelper.cs
@@ -20,8 +20,9 @@ public static class IconHelper
 
     private static void CreateIcon()
     {
-        var icon = Icon.ExtractAssociatedIcon(Basics.ExecutablePath)!;
-        var bitmap = icon.ToBitmap();
+        using var icon = Icon.ExtractAssociatedIcon(Basics.ExecutablePath) ??
+                         throw new InvalidOperationException("无法提取程序图标。");
+        using var bitmap = icon.ToBitmap();
         bitmap.Save(Path.Combine(Paths.Temp, "icon.png"));
     }
 }

--- a/PCL.Core/Utils/IconHelper.cs
+++ b/PCL.Core/Utils/IconHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Drawing;
+using System.IO;
+using PCL.Core.App;
+
+namespace PCL.Core.Utils;
+
+public static class IconHelper
+{
+    public static string GetIconPath()
+    {
+        var paths = Path.Combine(Paths.Temp, "icon.png");
+        if (!File.Exists(paths))
+        {
+            CreateIcon();
+        }
+
+        return paths;
+    }
+
+    private static void CreateIcon()
+    {
+        var icon = Icon.ExtractAssociatedIcon(Basics.ExecutablePath)!;
+        var bitmap = icon.ToBitmap();
+        bitmap.Save(Path.Combine(Paths.Temp, "icon.png"));
+    }
+}

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -1,0 +1,24 @@
+using Microsoft.Win32;
+
+namespace PCL.Core.Utils.OS;
+
+public static class AumidHelper
+{
+    public static bool HasAumid()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(@"Software\Classes\AppUserModelId\XXX");
+        return key != null;
+    }
+    
+    public static void RegisterAumid(string aumid)
+    {
+        using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\{aumid}");
+        key.SetValue("DisplayName", "Plain Craft Launcher Community Edition");
+        key.SetValue("IconUri", IconHelper.GetIconPath());
+    }
+
+    public static void UnregisterAumid(string aumid)
+    {
+        Registry.CurrentUser.DeleteSubKey($@"Software\Classes\AppUserModelId\{aumid}", false);
+    }
+}

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -15,6 +15,7 @@ public static class AumidHelper
         using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\{aumid}");
         key.SetValue("DisplayName", "Plain Craft Launcher Community Edition");
         key.SetValue("IconUri", IconHelper.GetIconPath());
+        key.SetValue("IconBackgroundColor", "FFDDDD");
     }
 
     public static void UnregisterAumid(string aumid)

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -9,11 +9,12 @@ public static class AumidHelper
     public static bool HasAumid()
     {
         using var key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
-        return key != null;
+        return key is not null;
     }
     
     public static void RegisterAumid()
     {
+        //
         using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
         key.SetValue("DisplayName", "Plain Craft Launcher Community Edition");
         key.SetValue("IconUri", IconHelper.GetIconPath());

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -8,20 +8,20 @@ public static class AumidHelper
     
     public static bool HasAumid()
     {
-        using var key = Registry.CurrentUser.OpenSubKey(@"Software\Classes\AppUserModelId\XXX");
+        using var key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
         return key != null;
     }
     
-    public static void RegisterAumid(string aumid)
+    public static void RegisterAumid()
     {
-        using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\{aumid}");
+        using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
         key.SetValue("DisplayName", "Plain Craft Launcher Community Edition");
         key.SetValue("IconUri", IconHelper.GetIconPath());
         key.SetValue("IconBackgroundColor", "FFDDDD");
     }
 
-    public static void UnregisterAumid(string aumid)
+    public static void UnregisterAumid()
     {
-        Registry.CurrentUser.DeleteSubKey($@"Software\Classes\AppUserModelId\{aumid}", false);
+        Registry.CurrentUser.DeleteSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE", false);
     }
 }

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -4,6 +4,8 @@ namespace PCL.Core.Utils.OS;
 
 public static class AumidHelper
 {
+    // TODO: 针对每个路径建立单独的 AUMID
+    
     public static bool HasAumid()
     {
         using var key = Registry.CurrentUser.OpenSubKey(@"Software\Classes\AppUserModelId\XXX");

--- a/PCL.Core/Utils/OS/AumidHelper.cs
+++ b/PCL.Core/Utils/OS/AumidHelper.cs
@@ -4,18 +4,18 @@ namespace PCL.Core.Utils.OS;
 
 public static class AumidHelper
 {
-    // TODO: 针对每个路径建立单独的 AUMID
+    public const string Aumid = "PCLCommunity.PCLCE";
     
     public static bool HasAumid()
     {
-        using var key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
+        using var key = Registry.CurrentUser.OpenSubKey(string.Concat(@"Software\Classes\AppUserModelId\", Aumid));
         return key is not null;
     }
     
     public static void RegisterAumid()
     {
-        //
-        using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE");
+        // .NET 8 在正常情况下不可能返回 null，如果炸了不应该包住而是让他炸下去
+        using var key = Registry.CurrentUser.CreateSubKey(string.Concat(@"Software\Classes\AppUserModelId\", Aumid));
         key.SetValue("DisplayName", "Plain Craft Launcher Community Edition");
         key.SetValue("IconUri", IconHelper.GetIconPath());
         key.SetValue("IconBackgroundColor", "FFDDDD");
@@ -23,6 +23,6 @@ public static class AumidHelper
 
     public static void UnregisterAumid()
     {
-        Registry.CurrentUser.DeleteSubKey($@"Software\Classes\AppUserModelId\PCLCommunity.PCLCE", false);
+        Registry.CurrentUser.DeleteSubKey(string.Concat(@"Software\Classes\AppUserModelId\", Aumid), false);
     }
 }

--- a/PCL.Core/Utils/WinRT/HString.cs
+++ b/PCL.Core/Utils/WinRT/HString.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT;
+
+/// <summary>
+/// 表示一个 WinRT HSTRING 句柄的只读包装。
+/// </summary>
+/// <param name="Value">HSTRING 的底层指针句柄（<see cref="nint"/>）。</param>
+public readonly record struct HString(IntPtr Value)
+{
+    public readonly IntPtr Value = Value;
+    public bool IsNull => Value == IntPtr.Zero;
+    public static implicit operator IntPtr(HString h) => h.Value;
+    public static explicit operator HString(IntPtr ptr) => new(ptr);
+}

--- a/PCL.Core/Utils/WinRT/HStringHelper.cs
+++ b/PCL.Core/Utils/WinRT/HStringHelper.cs
@@ -31,7 +31,7 @@ public class HStringHelper
         return new string(buffer, 0, (int)length);
     }
 
-    public static void Delete(HString value)
+    public static void DeleteHString(HString value)
     {
         if (!value.IsNull)
             WinRTInterop.WindowsDeleteString(value);

--- a/PCL.Core/Utils/WinRT/HStringHelper.cs
+++ b/PCL.Core/Utils/WinRT/HStringHelper.cs
@@ -28,7 +28,7 @@ public class HStringHelper
             return "";
         uint length;
         var buffer = WinRTInterop.WindowsGetStringRawBuffer(value, &length);
-        return new string(buffer, 0, (int)length);
+        return length != 0 ? new string(buffer, 0, (int)length) : string.Empty;
     }
 
     public static void DeleteHString(HString value)

--- a/PCL.Core/Utils/WinRT/HStringHelper.cs
+++ b/PCL.Core/Utils/WinRT/HStringHelper.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PCL.Core.Utils.WinRT;
+
+public class HStringHelper
+{
+    public static unsafe HString ToHString(string? value)
+    {
+        if (value is null)
+        {
+            return new HString(IntPtr.Zero);
+        }
+
+        IntPtr handle;
+        fixed (char* lpValue = value)
+        {
+            Marshal.ThrowExceptionForHR(
+                WinRTInterop.WindowsCreateString((ushort*)lpValue, value.Length, &handle));
+        }
+
+        return new HString(handle);
+    }
+
+    public static unsafe string ToManagedString(HString value)
+    {
+        if (value == IntPtr.Zero)
+            return "";
+        uint length;
+        var buffer = WinRTInterop.WindowsGetStringRawBuffer(value, &length);
+        return new string(buffer, 0, (int)length);
+    }
+
+    public static void Delete(HString value)
+    {
+        if (!value.IsNull)
+            WinRTInterop.WindowsDeleteString(value);
+    }
+
+    public static unsafe void WithReference(
+        ReadOnlySpan<char> value,
+        Action<HString> action)
+    {
+        fixed (char* p = value)
+        {
+            WinRTInterop.HStringHeader header;
+            IntPtr hstring;
+
+            Marshal.ThrowExceptionForHR(
+                WinRTInterop.WindowsCreateStringReference(
+                    (ushort*)p,
+                    value.Length,
+                    (IntPtr*)&header,
+                    &hstring));
+
+            action((HString)hstring);
+        }
+    }
+}

--- a/PCL.Core/Utils/WinRT/Interface/IInspectable.cs
+++ b/PCL.Core/Utils/WinRT/Interface/IInspectable.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT.Interface;
+
+public unsafe struct IInspectable
+{
+    public IInspectableVtbl* lpVtbl;
+}
+
+public unsafe struct IInspectableVtbl
+{
+    // IUnknown
+    public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged<void*, uint> AddRef;
+    public delegate* unmanaged<void*, uint> Release;
+
+    // IInspectable
+    public delegate* unmanaged<void*, uint*, Guid**, int> GetIids;
+    public delegate* unmanaged<void*, IntPtr*, int> GetRuntimeClassName;
+    public delegate* unmanaged<void*, int*, int> GetTrustLevel;
+}

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -5,7 +5,7 @@ namespace PCL.Core.Utils.WinRT.Interface.Windows.Data.Xml.Dom;
 public static class IXmlDocumentIOInfo
 {
     public static readonly string ActivatableClassId = "Windows.Data.Xml.Dom.XmlDocument";
-    public static readonly Guid Iid = new("50ac103f-d235-4598-bbef-98fe4d1a3ad4");
+    public static readonly Guid Iid = new("6cd0e74e-ee65-4489-9ebf-ca43e87ba637");
 }
 
 internal unsafe struct IXmlDocumentIO

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT.Interface.Windows.Data.Xml.Dom;
+
+internal unsafe struct IXmlDocumentIO
+{
+    public IXmlDocumentIOVtbl* lpVtbl;
+}
+
+internal unsafe struct IXmlDocumentIOVtbl
+{
+    // IUnknown
+    public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged<void*, uint> AddRef;
+    public delegate* unmanaged<void*, uint> Release;
+
+    // IInspectable
+    public delegate* unmanaged<void*, uint*, Guid**, int> GetIids;
+    public delegate* unmanaged<void*, IntPtr*, int> GetRuntimeClassName;
+    public delegate* unmanaged<void*, int*, int> GetTrustLevel;
+
+    // IXmlDocumentIO
+
+    // LoadXml(string xml)
+    public delegate* unmanaged<void*, IntPtr, int> LoadXml;
+
+    // LoadXml(string xml, XmlLoadSettings settings)
+    public delegate* unmanaged<void*, IntPtr, void*, int> LoadXmlWithSettings;
+
+    // SaveToFileAsync(IStorageFile file)
+    public delegate* unmanaged<void*, void*, void**, int> SaveToFileAsync;
+}

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -28,17 +28,17 @@ internal unsafe struct IXmlDocumentIOVtbl
     // IXmlDocumentIO
 
     /// <summary>
-    /// LoadXml(string xml)
+    /// void LoadXml(string xml)
     /// </summary>
     public delegate* unmanaged<void*, IntPtr, int> LoadXml;
 
     /// <summary>
-    /// LoadXml(string xml, XmlLoadSettings settings)
+    /// void LoadXml(string xml, XmlLoadSettings settings)
     /// </summary>
     public delegate* unmanaged<void*, IntPtr, void*, int> LoadXmlWithSettings;
 
     /// <summary>
-    /// SaveToFileAsync(IStorageFile file)
+    /// IAsyncAction SaveToFileAsync(IStorageFile file)
     /// </summary>
     public delegate* unmanaged<void*, void*, void**, int> SaveToFileAsync;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -27,12 +27,18 @@ internal unsafe struct IXmlDocumentIOVtbl
 
     // IXmlDocumentIO
 
-    // LoadXml(string xml)
+    /// <summary>
+    /// LoadXml(string xml)
+    /// </summary>
     public delegate* unmanaged<void*, IntPtr, int> LoadXml;
 
-    // LoadXml(string xml, XmlLoadSettings settings)
+    /// <summary>
+    /// LoadXml(string xml, XmlLoadSettings settings)
+    /// </summary>
     public delegate* unmanaged<void*, IntPtr, void*, int> LoadXmlWithSettings;
 
-    // SaveToFileAsync(IStorageFile file)
+    /// <summary>
+    /// SaveToFileAsync(IStorageFile file)
+    /// </summary>
     public delegate* unmanaged<void*, void*, void**, int> SaveToFileAsync;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -8,12 +8,12 @@ public static class IXmlDocumentIOInfo
     public static readonly Guid Iid = new("6cd0e74e-ee65-4489-9ebf-ca43e87ba637");
 }
 
-internal unsafe struct IXmlDocumentIO
+public unsafe struct IXmlDocumentIO
 {
     public IXmlDocumentIOVtbl* lpVtbl;
 }
 
-internal unsafe struct IXmlDocumentIOVtbl
+public unsafe struct IXmlDocumentIOVtbl
 {
     // IUnknown
     public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;

--- a/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/Data/Xml/Dom/IXmlDocumentIO.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace PCL.Core.Utils.WinRT.Interface.Windows.Data.Xml.Dom;
 
+public static class IXmlDocumentIOInfo
+{
+    public static readonly string ActivatableClassId = "Windows.Data.Xml.Dom.XmlDocument";
+    public static readonly Guid Iid = new("50ac103f-d235-4598-bbef-98fe4d1a3ad4");
+}
+
 internal unsafe struct IXmlDocumentIO
 {
     public IXmlDocumentIOVtbl* lpVtbl;

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -28,7 +28,7 @@ public unsafe struct IToastNotificationFactoryVtbl
     // IToastNotificationFactory
 
     /// <summary>
-    /// CreateToastNotification(IXmlDocument content, IToastNotification value)
+    /// CreateToastNotification(XmlDocument content, ToastNotification value)
     /// </summary>
     public delegate* unmanaged<void*, int*, int**> LoadXml;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
 
+public static class IToastNotificationFactoryInfo
+{
+    public static readonly string ActivatableClassId = "Windows.UI.Notifications.ToastNotification";
+    public static readonly Guid Iid = new("04124b20-82c6-4229-b109-fd9ed4662b53");
+}
+
 internal unsafe struct IToastNotificationFactory
 {
     public IToastNotificationFactoryVtbl* lpVtbl;

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -28,7 +28,7 @@ public unsafe struct IToastNotificationFactoryVtbl
     // IToastNotificationFactory
 
     /// <summary>
-    /// CreateToastNotification(XmlDocument content, ToastNotification value)
+    /// ToastNotification CreateToastNotification(XmlDocument content)
     /// </summary>
     public delegate* unmanaged<void*, int*, int**> LoadXml;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -8,12 +8,12 @@ public static class IToastNotificationFactoryInfo
     public static readonly Guid Iid = new("04124b20-82c6-4229-b109-fd9ed4662b53");
 }
 
-internal unsafe struct IToastNotificationFactory
+public unsafe struct IToastNotificationFactory
 {
     public IToastNotificationFactoryVtbl* lpVtbl;
 }
 
-internal unsafe struct IToastNotificationFactoryVtbl
+public unsafe struct IToastNotificationFactoryVtbl
 {
     // IUnknown
     public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
@@ -27,6 +27,8 @@ internal unsafe struct IToastNotificationFactoryVtbl
 
     // IToastNotificationFactory
 
-    // CreateToastNotification(IXmlDocument content, IToastNotification value)
+    /// <summary>
+    /// CreateToastNotification(IXmlDocument content, IToastNotification value)
+    /// </summary>
     public delegate* unmanaged<void*, int*, int**> LoadXml;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -30,5 +30,5 @@ public unsafe struct IToastNotificationFactoryVtbl
     /// <summary>
     /// ToastNotification CreateToastNotification(XmlDocument content)
     /// </summary>
-    public delegate* unmanaged<void*, int*, int**> LoadXml;
+    public delegate* unmanaged<void*, void*, void**, int> CreateToastNotification;
 }

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationFactory.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
+
+internal unsafe struct IToastNotificationFactory
+{
+    public IToastNotificationFactoryVtbl* lpVtbl;
+}
+
+internal unsafe struct IToastNotificationFactoryVtbl
+{
+    // IUnknown
+    public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged<void*, uint> AddRef;
+    public delegate* unmanaged<void*, uint> Release;
+
+    // IInspectable
+    public delegate* unmanaged<void*, uint*, Guid**, int> GetIids;
+    public delegate* unmanaged<void*, IntPtr*, int> GetRuntimeClassName;
+    public delegate* unmanaged<void*, int*, int> GetTrustLevel;
+
+    // IToastNotificationFactory
+
+    // CreateToastNotification(IXmlDocument content, IToastNotification value)
+    public delegate* unmanaged<void*, int*, int**> LoadXml;
+}

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationManagerStatics.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationManagerStatics.cs
@@ -35,7 +35,7 @@ public unsafe struct IToastNotificationManagerStaticsVtbl
     /// <summary>
     /// ToastNotifier CreateToastNotifier(string applicationId)
     /// </summary>
-    public delegate* unmanaged<void*, void**, IntPtr, int> CreateToastNotifierWithId;
+    public delegate* unmanaged<void*, IntPtr, void**, int> CreateToastNotifierWithId;
 
     /// <summary>
     /// XmlDocument GetTemplateContent(ToastTemplateType type)

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationManagerStatics.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotificationManagerStatics.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
+
+public static class IToastNotificationManagerStaticsInfo
+{
+    public static readonly string ActivatableClassId = "Windows.UI.Notifications.ToastNotificationManager";
+    public static readonly Guid Iid = new("50ac103f-d235-4598-bbef-98fe4d1a3ad4");
+}
+
+public unsafe struct IToastNotificationManagerStatics
+{
+    public IToastNotificationManagerStaticsVtbl* lpVtbl;
+}
+
+public unsafe struct IToastNotificationManagerStaticsVtbl
+{
+    // IUnknown
+    public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged<void*, uint> AddRef;
+    public delegate* unmanaged<void*, uint> Release;
+
+    // IInspectable
+    public delegate* unmanaged<void*, uint*, Guid**, int> GetIids;
+    public delegate* unmanaged<void*, IntPtr*, int> GetRuntimeClassName;
+    public delegate* unmanaged<void*, int*, int> GetTrustLevel;
+
+    // IToastNotificationManagerStatics
+    
+    /// <summary>
+    /// ToastNotifier CreateToastNotifier()
+    /// </summary>
+    public delegate* unmanaged<void*, void**, int> CreateToastNotifier;
+    
+    /// <summary>
+    /// ToastNotifier CreateToastNotifier(string applicationId)
+    /// </summary>
+    public delegate* unmanaged<void*, void**, IntPtr, int> CreateToastNotifierWithId;
+
+    /// <summary>
+    /// XmlDocument GetTemplateContent(ToastTemplateType type)
+    /// </summary>
+    public delegate* unmanaged<void*, int, void**, int> GetTemplateContent;
+}

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotifier.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotifier.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
+
+public static class IToastNotifierStaticsInfo
+{
+    public static readonly string ActivatableClassId = "Windows.UI.Notifications.ToastNotifier";
+    public static readonly Guid Iid = new("75927b93-03f3-41ec-91d3-6e5bac1b38e7");
+}
+
+public unsafe struct IToastNotifier
+{
+    public IToastNotifierVtbl* lpVtbl;
+}
+
+public unsafe struct IToastNotifierVtbl
+{
+    // IUnknown
+    public delegate* unmanaged<void*, Guid*, void**, int> QueryInterface;
+    public delegate* unmanaged<void*, uint> AddRef;
+    public delegate* unmanaged<void*, uint> Release;
+
+    // IInspectable
+    public delegate* unmanaged<void*, uint*, Guid**, int> GetIids;
+    public delegate* unmanaged<void*, IntPtr*, int> GetRuntimeClassName;
+    public delegate* unmanaged<void*, int*, int> GetTrustLevel;
+
+    // IToastNotifier
+    
+    /// <summary>
+    /// void Show(ToastNotification notification)
+    /// </summary>
+    public delegate* unmanaged<void*, void*, int> Show;
+
+    /// <summary>
+    /// void Hide(ToastNotification notification)
+    /// </summary>
+    public delegate* unmanaged<void*, void*, int> Hide;
+    
+    /// <summary>
+    /// NotificationSetting Setting { get; }
+    /// </summary>
+    public delegate* unmanaged<void*, int, int> get_Setting;
+    
+    /// <summary>
+    /// void AddToSchedule(ScheduledToastNotification scheduledToast)
+    /// </summary>
+    public delegate* unmanaged<void*, void*, int> AddToSchedule;
+    
+    /// <summary>
+    /// void RemoveFromSchedule(ScheduledToastNotification scheduledToast)
+    /// </summary>
+    public delegate* unmanaged<void*, void*, int> RemoveFromSchedule;
+    
+    /// <summary>
+    /// IVectorView&lt;ScheduledToastNotification&gt; GetScheduledToastNotifications()
+    /// </summary>
+    public delegate* unmanaged<void*, void**, int> GetScheduledToastNotifications;
+}

--- a/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotifier.cs
+++ b/PCL.Core/Utils/WinRT/Interface/Windows/UI/Notifications/IToastNotifier.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace PCL.Core.Utils.WinRT.Interface.Windows.UI.Notifications;
 
-public static class IToastNotifierStaticsInfo
+public static class IToastNotifierInfo
 {
     public static readonly string ActivatableClassId = "Windows.UI.Notifications.ToastNotifier";
     public static readonly Guid Iid = new("75927b93-03f3-41ec-91d3-6e5bac1b38e7");

--- a/PCL.Core/Utils/WinRT/WinRTInterop.cs
+++ b/PCL.Core/Utils/WinRT/WinRTInterop.cs
@@ -10,6 +10,57 @@ public static partial class WinRTInterop
     private static unsafe partial int RoGetActivationFactory(IntPtr activatableClassId, Guid* iid, IntPtr* factory);
     [LibraryImport("combase.dll")]
     private static unsafe partial int RoActiveInstance(IntPtr activatableClassId, IntPtr* instance);
+
+    public static unsafe IntPtr ActiveInstance(ReadOnlySpan<char> activatableClassId)
+    {
+        var instance = IntPtr.Zero;
+
+        fixed (char* pName = activatableClassId)
+        {
+            HStringHeader header;
+            IntPtr hstring;
+
+            Marshal.ThrowExceptionForHR(
+                WindowsCreateStringReference(
+                    (ushort*)pName,
+                    activatableClassId.Length,
+                    (IntPtr*)&header,
+                    &hstring));
+
+            Marshal.ThrowExceptionForHR(
+                RoActiveInstance(
+                    hstring,
+                    &instance));
+        }
+
+        return instance;
+    }
+
+    public static unsafe IntPtr GetActivationFactory(ReadOnlySpan<char> activatableClassId, Guid iid)
+    {
+        var factory = IntPtr.Zero;
+
+        fixed (char* pName = activatableClassId)
+        {
+            HStringHeader header;
+            IntPtr hstring;
+
+            Marshal.ThrowExceptionForHR(
+                WindowsCreateStringReference(
+                    (ushort*)pName,
+                    activatableClassId.Length,
+                    (IntPtr*)&header,
+                    &hstring));
+
+            Marshal.ThrowExceptionForHR(
+                RoGetActivationFactory(
+                    hstring,
+                    &iid,
+                    &factory));
+        }
+
+        return factory;
+    }
     
     // winstring.h
     [LibraryImport("combase.dll")]

--- a/PCL.Core/Utils/WinRT/WinRTInterop.cs
+++ b/PCL.Core/Utils/WinRT/WinRTInterop.cs
@@ -7,24 +7,24 @@ public static partial class WinRTInterop
 {
     // roapi.h
     [LibraryImport("combase.dll")]
-    public static unsafe partial int RoGetActivationFactory(IntPtr activatableClassId, Guid* iid, IntPtr* factory);
+    private static unsafe partial int RoGetActivationFactory(IntPtr activatableClassId, Guid* iid, IntPtr* factory);
     [LibraryImport("combase.dll")]
-    public static unsafe partial int RoActiveInstance(IntPtr activatableClassId, IntPtr* instance);
+    private static unsafe partial int RoActiveInstance(IntPtr activatableClassId, IntPtr* instance);
     
     // winstring.h
     [LibraryImport("combase.dll")]
-    public static unsafe partial int WindowsCreateString(ushort* sourceString, int length, IntPtr* hstring);
+    internal static unsafe partial int WindowsCreateString(ushort* sourceString, int length, IntPtr* hstring);
     [LibraryImport("combase.dll")]
-    public static unsafe partial int WindowsCreateStringReference(ushort* sourceString, int length,
+    internal static unsafe partial int WindowsCreateStringReference(ushort* sourceString, int length,
         IntPtr* hstringHeader, IntPtr* hstring);
     [LibraryImport("combase.dll")]
-    public static unsafe partial int WindowsDeleteString(IntPtr hstring);
+    internal static unsafe partial int WindowsDeleteString(IntPtr hstring);
     [LibraryImport("combase.dll")]
-    public static unsafe partial char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
+    internal static unsafe partial char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
     
     // hstring.h
     [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct HStringHeader
+    internal unsafe struct HStringHeader
     {
         private fixed byte _data[24];
     }

--- a/PCL.Core/Utils/WinRT/WinRTInterop.cs
+++ b/PCL.Core/Utils/WinRT/WinRTInterop.cs
@@ -9,9 +9,9 @@ public static partial class WinRTInterop
     [LibraryImport("combase.dll")]
     private static unsafe partial int RoGetActivationFactory(IntPtr activatableClassId, Guid* iid, IntPtr* factory);
     [LibraryImport("combase.dll")]
-    private static unsafe partial int RoActiveInstance(IntPtr activatableClassId, IntPtr* instance);
+    private static unsafe partial int RoActivateInstance(IntPtr activatableClassId, IntPtr* instance);
 
-    public static unsafe IntPtr ActiveInstance(ReadOnlySpan<char> activatableClassId)
+    public static unsafe IntPtr ActivateInstance(ReadOnlySpan<char> activatableClassId)
     {
         var instance = IntPtr.Zero;
 
@@ -28,7 +28,7 @@ public static partial class WinRTInterop
                     &hstring));
 
             Marshal.ThrowExceptionForHR(
-                RoActiveInstance(
+                RoActivateInstance(
                     hstring,
                     &instance));
         }

--- a/PCL.Core/Utils/WinRT/WinRTInterop.cs
+++ b/PCL.Core/Utils/WinRT/WinRTInterop.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace PCL.Core.Utils.WinRT;
+
+public static partial class WinRTInterop
+{
+    // roapi.h
+    [LibraryImport("combase.dll")]
+    public static unsafe partial int RoGetActivationFactory(IntPtr activatableClassId, Guid* iid, IntPtr* factory);
+    [LibraryImport("combase.dll")]
+    public static unsafe partial int RoActiveInstance(IntPtr activatableClassId, IntPtr* instance);
+    
+    // winstring.h
+    [LibraryImport("combase.dll")]
+    public static unsafe partial int WindowsCreateString(ushort* sourceString, int length, IntPtr* hstring);
+    [LibraryImport("combase.dll")]
+    public static unsafe partial int WindowsCreateStringReference(ushort* sourceString, int length,
+        IntPtr* hstringHeader, IntPtr* hstring);
+    [LibraryImport("combase.dll")]
+    public static unsafe partial int WindowsDeleteString(IntPtr hstring);
+    [LibraryImport("combase.dll")]
+    public static unsafe partial char* WindowsGetStringRawBuffer(IntPtr hstring, uint* length);
+    
+    // hstring.h
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct HStringHeader
+    {
+        private fixed byte _data[24];
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

使用直接的 WinRT 互操作重新实现 toast 通知，在 Windows 上构建并显示基于 XML 的 toast，同时处理应用程序 AUMID 的注册和清理。

New Features:
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助函数。
- 引入 Ro 激活辅助工具，以便从托管代码获取 WinRT 激活工厂和实例。
- 定义用于 XML 文档 I/O 和 toast 通知创建/管理的 WinRT 接口绑定，以支持基于 WinRT 的 toast 通知。
- 实现实际的 toast 显示逻辑，用于构建 toast XML、激活 WinRT 组件，并使用已注册的 AUMID 显示通知。
- 添加用于生成并持久化 toast 元数据所需应用程序图标文件的工具。
- 引入辅助工具，在注册表中注册、检测和注销用于 toast 通知的应用程序 AUMID。

Enhancements:
- 调整 toast 卸载逻辑，从之前未实现状态改为在卸载时注销应用程序 AUMID。

Tests:
- 在 toast 测试上添加警告注释，说明其运行时元数据需求，导致该测试无法在单元测试项目下运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement toast notifications using direct WinRT interop to build and display XML-based toasts on Windows, including registration and cleanup of the application AUMID.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management.
- Introduce Ro activation helpers to obtain WinRT activation factories and instances from managed code.
- Define WinRT interface bindings for XML document I/O and toast notification creation/management to support WinRT-based toast notifications.
- Implement actual toast display logic that constructs toast XML, activates WinRT components, and shows notifications using a registered AUMID.
- Add utilities to generate and persist an application icon file used by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the registry for toast notifications.

Enhancements:
- Adjust toast uninstallation logic to unregister the application AUMID instead of leaving it unimplemented.

Tests:
- Annotate the toast test with a warning comment about runtime metadata requirements that prevent it from running under the unit test project.

</details>

新特性：
- 添加 HString 值类型以及用于在托管字符串与 WinRT HSTRING 句柄之间转换的辅助工具。
- 添加 Ro 激活 API 和 HSTRING 管理的 WinRT 互操作绑定。
- 定义用于 XML 文档 IO 和 toast 通知工厂的 WinRT 接口结构体，以启用基于 WinRT 的 toast 通知。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使用直接的 WinRT 互操作重新实现 toast 通知，在 Windows 上构建并显示基于 XML 的 toast，同时处理应用程序 AUMID 的注册和清理。

New Features:
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助函数。
- 引入 Ro 激活辅助工具，以便从托管代码获取 WinRT 激活工厂和实例。
- 定义用于 XML 文档 I/O 和 toast 通知创建/管理的 WinRT 接口绑定，以支持基于 WinRT 的 toast 通知。
- 实现实际的 toast 显示逻辑，用于构建 toast XML、激活 WinRT 组件，并使用已注册的 AUMID 显示通知。
- 添加用于生成并持久化 toast 元数据所需应用程序图标文件的工具。
- 引入辅助工具，在注册表中注册、检测和注销用于 toast 通知的应用程序 AUMID。

Enhancements:
- 调整 toast 卸载逻辑，从之前未实现状态改为在卸载时注销应用程序 AUMID。

Tests:
- 在 toast 测试上添加警告注释，说明其运行时元数据需求，导致该测试无法在单元测试项目下运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement toast notifications using direct WinRT interop to build and display XML-based toasts on Windows, including registration and cleanup of the application AUMID.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management.
- Introduce Ro activation helpers to obtain WinRT activation factories and instances from managed code.
- Define WinRT interface bindings for XML document I/O and toast notification creation/management to support WinRT-based toast notifications.
- Implement actual toast display logic that constructs toast XML, activates WinRT components, and shows notifications using a registered AUMID.
- Add utilities to generate and persist an application icon file used by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the registry for toast notifications.

Enhancements:
- Adjust toast uninstallation logic to unregister the application AUMID instead of leaving it unimplemented.

Tests:
- Annotate the toast test with a warning comment about runtime metadata requirements that prevent it from running under the unit test project.

</details>

</details>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

</details>

</details>

新功能：
- 添加 WinRT 互操作辅助工具和 HSTRING 实用函数，用于创建、转换和管理 WinRT 字符串以及激活工厂（activation factories）。
- 引入用于 XML 文档和通知（toast）类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 实现从 XML 模板发送 toast，并使用固定的应用 AUMID 将其集成到公共的 toast API 中。
- 添加实用工具，用于提取并持久化应用图标，以在 toast 元数据中使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用 AUMID。

改进：
- 修改 toast 卸载逻辑，从之前未实现的状态改为在卸载时注销应用 AUMID。

测试：
- 为 toast 单元测试添加注释，说明其对运行时元数据的要求，这些要求会阻止该测试在当前测试项目中运行。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

通过使用直接的 WinRT 互操作和基于 AUMID 的注册，重新实现 Windows toast 通知，使核心 UI API 能够发送基于 XML 的 toast。

新功能：
- 添加用于 HSTRING 创建、转换和生命周期管理的 WinRT 互操作辅助工具，包括一个专用的 HString 值类型。
- 引入 Ro 激活辅助工具，以及用于 XML 文档和 toast 通知类型的 WinRT 接口绑定，以支持基于 XML 的 toast 创建和显示。
- 在 `ToastNotification` 中实现基于 XML 模板发送 toast，并集成固定的应用程序 AUMID。
- 添加用于提取和持久化应用程序图标的工具，以供 toast 元数据使用。
- 引入辅助工具，用于在 Windows 注册表中注册、检测和注销应用程序的 AUMID，以支持 toast 通知。

增强：
- 更改 toast 卸载逻辑，从原先未实现的操作改为注销应用程序的 AUMID。

测试：
- 在 toast 单元测试上添加注释，警示其对运行时元数据的要求，这些要求会阻止该测试在当前的单元测试项目中运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reimplement Windows toast notifications using direct WinRT interop and AUMID-backed registration, enabling XML-based toasts to be sent from the core UI API.

New Features:
- Add WinRT interop helpers for HSTRING creation, conversion, and lifetime management, including a dedicated HString value type.
- Introduce Ro activation helpers and WinRT interface bindings for XML documents and toast notification types to support XML-based toast creation and display.
- Implement toast sending from XML templates in ToastNotification, integrating with a fixed application AUMID.
- Add utilities to extract and persist the application icon for use by toast metadata.
- Introduce helpers to register, detect, and unregister the application AUMID in the Windows registry for toast notifications.

Enhancements:
- Change toast uninstallation to unregister the application AUMID instead of leaving the operation unimplemented.

Tests:
- Annotate the toast unit test with a warning about runtime metadata requirements that prevent it from running in the current unit test project.

</details>

</details>

</details>

</details>