### PR TITLE
feat(i18n): 工具、联机与辅助页面迁移

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2628,4 +2628,58 @@
     <sys:String x:Key="Instance.Export.MrpackFilter">Modrinth modpack file (*.mrpack)|*.mrpack</sys:String>
     <sys:String x:Key="Instance.Export.PackPathInvalid.Title">Cannot use the export path specified in config</sys:String>
 
+    <!-- Tools -->
+
+    <sys:String x:Key="Tools.Left.Online">Online</sys:String>
+    <sys:String x:Key="Tools.Left.Lobby">Lobby</sys:String>
+    <sys:String x:Key="Tools.Left.Utilities">Utilities</sys:String>
+    <sys:String x:Key="Tools.Left.Utilities.Title">Toolbox</sys:String>
+    <sys:String x:Key="Tools.Left.Help">Help center</sys:String>
+
+    <!-- Tools.Help -->
+
+    <sys:String x:Key="Tools.Help.Search.Hint">Search help</sys:String>
+    <sys:String x:Key="Tools.Help.Loading">Loading help list</sys:String>
+    <sys:String x:Key="Tools.Help.Category.Guide">Guide</sys:String>
+    <sys:String x:Key="Tools.Help.Search.NoResults">No results</sys:String>
+    <sys:String x:Key="Tools.Help.Search.Results">Search results</sys:String>
+    <sys:String x:Key="Tools.Help.Search.ExactMatch">Exact match  |  Similarity: {0}  |  {1}</sys:String>
+    <sys:String x:Key="Tools.Help.Search.Similarity">Similarity: {0}  |  {1}</sys:String>
+
+    <!-- Tools.Test -->
+    <!-- Tools.Test.CustomDownload -->
+    <!-- Tools.Test.Skin -->
+    <!-- Tools.Test.ServerQuery -->
+    <!-- Tools.Test.Achievement -->
+    <!-- Tools.Test.Avatar -->
+    <!-- Tools.Test.Memory -->
+    <!-- Tools.Test.Clean -->
+    <!-- Tools.Test.Shortcut -->
+    <!-- Tools.Test.Luck -->
+    <!-- Tools.Test.Crash -->
+
+    <!-- Tools.GameLink -->
+    <!-- Tools.GameLink.Agreement -->
+    <!-- Tools.GameLink.Natayark -->
+    <!-- Tools.GameLink.Nat -->
+    <!-- Tools.GameLink.Join -->
+    <!-- Tools.GameLink.Create -->
+    <!-- Tools.GameLink.Finish -->
+    <!-- Tools.GameLink.Player -->
+    <!-- Tools.GameLink.Member -->
+    <!-- Tools.GameLink.Error -->
+
+    <!-- Speed -->
+
+    <!-- ServerQuery -->
+
+    <!-- Update -->
+    <!-- Update.Task -->
+    <!-- Update.Error -->
+    <!-- Update.CommunityNotice -->
+
+    <!-- LogPage -->
+    <!-- LogPage.Action -->
+    <!-- LogPage.Export -->
+
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2698,7 +2698,57 @@
     <!-- Update.CommunityNotice -->
 
     <!-- LogPage -->
-    <!-- LogPage.Action -->
-    <!-- LogPage.Export -->
+
+    <sys:String x:Key="LogPage.Title">Live logs</sys:String>
+    <sys:String x:Key="LogPage.Empty.Title">No live logs</sys:String>
+    <sys:String x:Key="LogPage.Empty.Description">Go to Instance Settings → Overview → Test Game to display live game logs.</sys:String>
+    <sys:String x:Key="LogPage.Left.InstancesTitle">Test instances</sys:String>
+    <sys:String x:Key="LogPage.Action.Scroll">Scroll</sys:String>
+    <sys:String x:Key="LogPage.Action.Export">Export</sys:String>
+    <sys:String x:Key="LogPage.Action.Clear">Clear</sys:String>
+    <sys:String x:Key="LogPage.Action.KillProcess">Kill</sys:String>
+    <sys:String x:Key="LogPage.Action.ExportStack">Dump</sys:String>
+    <sys:String x:Key="LogPage.Action.GameClosed">Game {0} closed!</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Title">Max lines</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.ToolTip">Maximum number of lines displayed; older logs are automatically removed when exceeded.</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Unlimited">Unlimited</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Hint">Logs are limited to {0} lines by default. Adjust this in Max Log Lines settings.</sys:String>
+    <sys:String x:Key="LogPage.Export.SelectLocation">Select export location</sys:String>
+    <sys:String x:Key="LogPage.Export.Success">Log exported!</sys:String>
+    <sys:String x:Key="LogPage.Export.GameLog.FileName">Game log - {0}.log</sys:String>
+    <sys:String x:Key="LogPage.Export.GameLog.Filter">Game log(*.log)|*.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.FileName">Game stack dump - {0}.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Filter">Game stack dump(*.log)|*.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Progress">Exporting stack dump, please wait (may take 15s ~ 1min)</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Success">Stack dump exported!</sys:String>
+
+    <!-- Watcher -->
+
+    <sys:String x:Key="Watcher.Start">Started Minecraft log monitoring</sys:String>
+    <sys:String x:Key="Watcher.Exited">Minecraft log monitoring exited</sys:String>
+    <sys:String x:Key="Watcher.ProcessExited">Minecraft exited with code: {0}</sys:String>
+    <sys:String x:Key="Watcher.LoadComplete">Minecraft loading completed</sys:String>
+    <sys:String x:Key="Watcher.WindowLoaded">Minecraft window loaded: {0} ({1})</sys:String>
+    <sys:String x:Key="Watcher.FmlWindowLoaded">FML window loaded: {0} ({1})</sys:String>
+    <sys:String x:Key="Watcher.WindowMaximized">Minecraft window maximized: {0}</sys:String>
+    <sys:String x:Key="Watcher.SecurityBlocked">PCL cannot access the game window due to anti-cheat or security software</sys:String>
+    <sys:String x:Key="Watcher.Progress.LogAppeared">Log 1/5: Log output appeared</sys:String>
+    <sys:String x:Key="Watcher.Progress.UserSet">Log 2/5: Game user set</sys:String>
+    <sys:String x:Key="Watcher.Progress.LwjglConfirmed">Log 3/5: LWJGL version confirmed</sys:String>
+    <sys:String x:Key="Watcher.Progress.OpenAlLoaded">Log 4/5: OpenAL loaded</sys:String>
+    <sys:String x:Key="Watcher.Progress.TexturesLoaded">Log 5/5: Textures loaded</sys:String>
+    <sys:String x:Key="Watcher.Log.CloseDetected">Identified close log: {0}</sys:String>
+    <sys:String x:Key="Watcher.Log.CrashDetected">Identified crash log: {0}</sys:String>
+    <sys:String x:Key="Watcher.Crash.Suspected">Minecraft hasn't finished loading, may have crashed</sys:String>
+    <sys:String x:Key="Watcher.Crash.AbnormalExit">Minecraft exit code abnormal, may have crashed</sys:String>
+    <sys:String x:Key="Watcher.Crash.Detected">Minecraft has crashed, crash analysis will start in 2 seconds</sys:String>
+    <sys:String x:Key="Watcher.Crash.AnalysisStart">Crash analysis started</sys:String>
+    <sys:String x:Key="Watcher.Crash.Hint">Minecraft error detected, analysis started...</sys:String>
+    <sys:String x:Key="Watcher.Kill.Attempt">Attempting to force kill Minecraft process</sys:String>
+    <sys:String x:Key="Watcher.Kill.TaskkillAttempt">Process still alive, trying taskkill.exe</sys:String>
+    <sys:String x:Key="Watcher.Kill.TaskkillResult">taskkill.exe result: {0}</sys:String>
+    <sys:String x:Key="Watcher.Kill.Timeout">Force kill failed: process exit timeout</sys:String>
+    <sys:String x:Key="Watcher.Kill.Success">Minecraft process forcefully killed</sys:String>
+    <sys:String x:Key="Watcher.Kill.Failed">Failed to force kill Minecraft process</sys:String>
 
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1756,7 +1756,7 @@
 
     <sys:String x:Key="Setup.GameLink.RestartRequired">A lobby restart is required for changes on this page to take effect.</sys:String>
     <sys:String x:Key="Setup.GameLink.Username">Username</sys:String>
-    <sys:String x:Key="Setup.GameLink.Username.ToolTip">PCL CE will try to use this username for lobby display.&#x0a;If left blank, the Natayark ID username will be used.&#x0a;&#x0a;In some cases, the Natayark ID username may still be displayed instead of the name set here.</sys:String>
+    <sys:String x:Key="Setup.GameLink.Username.ToolTip">PCL CE will try to use this username for lobby display.&#x0A;If left blank, the Natayark ID username will be used.&#x0A;&#x0A;In some cases, the Natayark ID username may still be displayed instead of the name set here.</sys:String>
     <sys:String x:Key="Setup.GameLink.Protocol.Preference">Protocol preference</sys:String>
     <sys:String x:Key="Setup.GameLink.Protocol.Tcp">TCP</sys:String>
     <sys:String x:Key="Setup.GameLink.Protocol.Udp">UDP</sys:String>
@@ -1768,20 +1768,20 @@
     <sys:String x:Key="Setup.GameLink.PortGuessNat.ToolTip">Let EasyTier attempt port guessing for symmetric NAT (birthday paradox).&#x0a;This may improve the multiplayer experience, but it may also cause issues in some cases.&#x0a;Generally, keep it enabled.</sys:String>
     <sys:String x:Key="Setup.GameLink.EnableIPv6">Allow IPv6 communication</sys:String>
     <sys:String x:Key="Setup.GameLink.EnableIPv6.ToolTip">Compared with IPv4, IPv6 makes P2P communication easier and can greatly improve the multiplayer experience. Do not disable it unless you have a specific reason.</sys:String>
-    <sys:String x:Key="Setup.GameLink.CliDebugOutput">Output CLI info to logs for debugging</sys:String>
-    <sys:String x:Key="Setup.GameLink.CliDebugOutput.ToolTip">Output EasyTier CLI info to the launcher log every 30 seconds for developer and community support investigation.&#x0a;This option is for debugging only and is not recommended to keep enabled.</sys:String>
+    <sys:String x:Key="Setup.GameLink.CliDebugOutput">Output CLI information to logs for debugging</sys:String>
+    <sys:String x:Key="Setup.GameLink.CliDebugOutput.ToolTip">Output EasyTier CLI information to the launcher log every 30 seconds for developer and community support investigation.&#x0a;This option is for debugging only and is not recommended to keep enabled.</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.Title">Network test</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.Start">Start test</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.Testing">Testing...</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.NotTested">Not tested</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.Supported">Supported</sys:String>
     <sys:String x:Key="Setup.GameLink.NetworkTest.Unsupported">Unsupported</sys:String>
-    <sys:String x:Key="Setup.GameLink.NetworkTest.UdpNatType">UDP NAT Type: {0}</sys:String>
-    <sys:String x:Key="Setup.GameLink.NetworkTest.TcpNatType">TCP NAT Type: {0}</sys:String>
-    <sys:String x:Key="Setup.GameLink.NetworkTest.Ipv6Status">IPv6: {0}</sys:String>
+    <sys:String x:Key="Setup.GameLink.NetworkTest.UdpNatType">UDP NAT type: {0}</sys:String>
+    <sys:String x:Key="Setup.GameLink.NetworkTest.TcpNatType">TCP NAT type: {0}</sys:String>
+    <sys:String x:Key="Setup.GameLink.NetworkTest.Ipv6Status">IPv6 status: {0}</sys:String>
     <sys:String x:Key="Setup.GameLink.Initialized">Multiplayer settings have been initialized!</sys:String>
     <sys:String x:Key="Setup.GameLink.Error.InitFailed">Failed to initialize multiplayer settings</sys:String>
-    <sys:String x:Key="Setup.GameLink.Error.ConfigChangeFailed">Failed to change configuration item</sys:String>
+    <sys:String x:Key="Setup.GameLink.Error.ConfigChangeFailed">Failed to change configuration item.</sys:String>
 
     <!-- Setup.Update -->
 
@@ -2084,7 +2084,7 @@
     <sys:String x:Key="Instance.Overall.Manage.Delete">Delete instance</sys:String>
     <sys:String x:Key="Instance.Overall.Manage.PatchCore">Patch core</sys:String>
     <sys:String x:Key="Instance.Overall.Script.SelectSaveTitle">Select where to save the script</sys:String>
-    <sys:String x:Key="Instance.Overall.Script.FileFilter">Batch file(*.bat)|*.bat</sys:String>
+    <sys:String x:Key="Instance.Overall.Script.FileFilter">Batch file (*.bat)|*.bat</sys:String>
     <sys:String x:Key="Instance.Overall.Script.WaitForLaunchTask">Please wait for the current launch task to finish first!</sys:String>
     <sys:String x:Key="Instance.Overall.Script.Exporting">Exporting launch script...</sys:String>
     <sys:String x:Key="Instance.Overall.Script.ExportingWarning">Exporting launch script... (Note: using the script to launch may cause your login session to expire!)</sys:String>
@@ -2248,7 +2248,7 @@
     <sys:String x:Key="Instance.Resource.Export.Mode.Txt">TXT format</sys:String>
     <sys:String x:Key="Instance.Resource.Export.Mode.Csv">CSV format</sys:String>
     <sys:String x:Key="Instance.Resource.Export.SelectSaveLocation">Select save location</sys:String>
-    <sys:String x:Key="Instance.Resource.Export.FilesFilter">Text file(*.txt)|*.txt|CSV file(*.csv)|*.csv</sys:String>
+    <sys:String x:Key="Instance.Resource.Export.FilesFilter">Text file (*.txt)|*.txt|CSV file (*.csv)|*.csv</sys:String>
 
     <!-- Instance.Resource.Datapack -->
 
@@ -2283,7 +2283,7 @@
 
     <sys:String x:Key="Instance.Resource.Item.UpdateCompare">Current version: {0} ({1})&#x0a;Latest version: {2} ({3})</sys:String>
     <sys:String x:Key="Instance.Resource.Item.UpdateToolTip">Click to update, right-click to view changelog.</sys:String>
-    <sys:String x:Key="Instance.Resource.Item.InfoUnavailable">Error, unable to get information</sys:String>
+    <sys:String x:Key="Instance.Resource.Item.InfoUnavailable">Unable to get information</sys:String>
     <sys:String x:Key="Instance.Resource.Item.FolderTag">Folder</sys:String>
     <sys:String x:Key="Instance.Resource.Item.ErrorSuffix"> [Error]</sys:String>
     <sys:String x:Key="Instance.Resource.Item.UpdateConfirm.Title">Confirm update</sys:String>
@@ -2292,7 +2292,7 @@
     <sys:String x:Key="Instance.Resource.Item.ViewChangelog">View changelog</sys:String>
     <sys:String x:Key="Instance.Resource.Item.OpenChangelogFailed">Failed to open changelog</sys:String>
     <sys:String x:Key="Instance.Resource.Item.Info.FailedTitle">Failed to Read Resource</sys:String>
-    <sys:String x:Key="Instance.Resource.Item.Info.FailedMessage">Unable to read info for this resource.</sys:String>
+    <sys:String x:Key="Instance.Resource.Item.Info.FailedMessage">Unable to read information for this resource.</sys:String>
     <sys:String x:Key="Instance.Resource.Item.Info.EmptyFolder">Empty folder</sys:String>
     <sys:String x:Key="Instance.Resource.Item.Info.ContainsOne">Contains 1 file</sys:String>
     <sys:String x:Key="Instance.Resource.Item.Info.ContainsMany">Contains {0} files</sys:String>
@@ -2368,7 +2368,7 @@
     <sys:String x:Key="Instance.Saves.Datapack.Update.Warning.Confirm">I understand the risks, continue updating</sys:String>
     <sys:String x:Key="Instance.Saves.Datapack.ToggleWarning">Data pack status toggle failed. Please try closing any running games and try again!</sys:String>
     <sys:String x:Key="Instance.Saves.Datapack.Export.Mode.Message">TXT format: Only export the current data pack file name information&#x0a;CSV format: Export detailed data pack information, including file name, project ID, version information, and other details</sys:String>
-    <sys:String x:Key="Instance.Saves.Datapack.Info.ReadFailed">Unable to read data pack info.</sys:String>
+    <sys:String x:Key="Instance.Saves.Datapack.Info.ReadFailed">Unable to read data pack information.</sys:String>
     <sys:String x:Key="Instance.Saves.Datapack.Info.ReadFailedTitle">Data pack read failed</sys:String>
     <sys:String x:Key="Instance.Saves.Datapack.Info.Author">Author: </sys:String>
     <sys:String x:Key="Instance.Saves.Datapack.Info.File">File: </sys:String>
@@ -2630,7 +2630,7 @@
 
     <!-- Tools -->
 
-    <sys:String x:Key="Tools.Left.Online">Online</sys:String>
+    <sys:String x:Key="Tools.Left.Multiplayer">Multiplayer</sys:String>
     <sys:String x:Key="Tools.Left.Lobby">Lobby</sys:String>
     <sys:String x:Key="Tools.Left.Utilities">Utilities</sys:String>
     <sys:String x:Key="Tools.Left.Utilities.Title">Toolbox</sys:String>
@@ -2654,7 +2654,7 @@
     <!-- Tools.Test.CustomDownload -->
 
     <sys:String x:Key="Tools.Test.CustomDownload.Title">Custom download</sys:String>
-    <sys:String x:Key="Tools.Test.CustomDownload.Description">Use PCL's high-speed multi-threaded download engine to download any file. Note: some websites (e.g. Baidu Netdisk) may return error (403) Forbidden and cannot be downloaded.</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Description">Use PCL's high-speed multi-threaded download engine to download any file. Note: some websites may return 403 Forbidden errors and cannot be downloaded.</sys:String>
     <sys:String x:Key="Tools.Test.CustomDownload.Url">Download URL</sys:String>
     <sys:String x:Key="Tools.Test.CustomDownload.UserAgent">User-Agent</sys:String>
     <sys:String x:Key="Tools.Test.CustomDownload.SaveTo">Save to</sys:String>
@@ -2674,9 +2674,9 @@
     <sys:String x:Key="Tools.Test.Skin.Save">Save skin</sys:String>
     <sys:String x:Key="Tools.Test.Skin.Fetching">Fetching skin...</sys:String>
     <sys:String x:Key="Tools.Test.Skin.InvalidId">This is not a valid ID...</sys:String>
-    <sys:String x:Key="Tools.Test.Skin.TooFrequent">Skin fetch rate limited, please try again in 5 minutes!</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.TooFrequent">Skin fetch has been rate-limited. Please try again in 5 minutes!</sys:String>
     <sys:String x:Key="Tools.Test.Skin.Saved">Player {0}'s skin saved!</sys:String>
-    <sys:String x:Key="Tools.Test.Skin.FileFilter">Skin image file(*.png)|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.FileFilter">Skin image file (*.png)|*.png</sys:String>
 
     <!-- Tools.Test.ServerQuery -->
 
@@ -2693,8 +2693,8 @@
     <sys:String x:Key="Tools.Test.Achievement.Save">Save image</sys:String>
     <sys:String x:Key="Tools.Test.Achievement.InvalidId">Please enter a valid item ID!</sys:String>
     <sys:String x:Key="Tools.Test.Achievement.Saved">Custom achievement image saved!</sys:String>
-    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG image|*.png</sys:String>
-    <sys:String x:Key="Tools.Test.Achievement.FetchFailed">Failed to get achievement image, check for special characters</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG image (*.png)|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FetchFailed">Failed to get achievement image. Please check for special characters.</sys:String>
 
     <!-- Tools.Test.Avatar -->
 
@@ -2702,7 +2702,7 @@
     <sys:String x:Key="Tools.Test.Avatar.Size">Avatar size:</sys:String>
     <sys:String x:Key="Tools.Test.Avatar.SelectSkin">Select skin</sys:String>
     <sys:String x:Key="Tools.Test.Avatar.SelectSkinFile">Select skin file</sys:String>
-    <sys:String x:Key="Tools.Test.Avatar.FileFilter">Image file(*.png)|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.FileFilter">Image file (*.png)|*.png</sys:String>
     <sys:String x:Key="Tools.Test.Avatar.Save">Save avatar</sys:String>
     <sys:String x:Key="Tools.Test.Avatar.SelectFirst">Please select a skin first!</sys:String>
     <sys:String x:Key="Tools.Test.Avatar.InvalidSize">Image size is incorrect! Please confirm you selected the correct file!</sys:String>
@@ -2713,23 +2713,23 @@
     <!-- Tools.Test.Memory -->
 
     <sys:String x:Key="Tools.Test.Memory.Title">Optimize memory</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.ToolTip">Memory optimization is a PCL CE exclusive, supercharged!&#xa;&#xa;Reduces physical memory usage by about 1/3, not just for MC!&#xa;If using an HDD, this may cause a brief period of severe lag.&#xa;Use the --memory flag to run memory optimization silently on launch.</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.Deprecated">Memory optimization will be deprecated.&#xa;&#xa;This feature relies on undocumented Windows NT kernel function calls, may become unavailable in future versions, and could cause undefined behavior.&#xa;&#xa;It is recommended to use Mem Reduct instead, a professional third-party memory management tool.&#xa;&#xa;Continue using memory optimization anyway?</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.DeprecatedTitle">Feature deprecating</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.ToolTip">Memory optimization is a PCL CE-exclusive boosted feature!&#x0A;&#x0A;It reduces physical memory usage by about 1/3, and not only for Minecraft.&#x0A;If you are using an HDD, this may cause severe lag for a short time.&#x0A;Use the --memory flag to run memory optimization silently on launch.</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Deprecated">Memory optimization will be deprecated.&#x0A;&#x0A;This feature relies on undocumented Windows NT kernel function calls, which may become unavailable in future versions or cause undefined behavior.&#x0A;&#x0A;We recommend using Mem Reduct instead, a professional third-party memory management tool.&#x0A;&#x0A;Continue using memory optimization anyway?</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.DeprecatedTitle">Memory optimization is deprecating</sys:String>
     <sys:String x:Key="Tools.Test.Memory.LearnMemReduct">Learn about Mem Reduct</sys:String>
     <sys:String x:Key="Tools.Test.Memory.Optimizing">Optimizing memory...</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.StillRunning">Memory optimization is still running, please wait!</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.Result">Memory optimization complete, freed {0}, available memory {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.StillRunning">Memory optimization is still running. Please wait!</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Result">Memory optimization complete. Freed {0}; available memory: {1}</sys:String>
     <sys:String x:Key="Tools.Test.Memory.Failed">Memory optimization failed</sys:String>
     <sys:String x:Key="Tools.Test.Memory.FailedMessage">Memory optimization failed&#xa;&#xa;Details: {0}</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.PromoteFailed">Elevation failed, please grant administrator access to use memory optimization</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.PromoteFailed">Elevation failed. Please grant administrator permission to use memory optimization.</sys:String>
 
     <!-- Tools.Test.Clean -->
 
     <sys:String x:Key="Tools.Test.Clean.Title">Clean game junk</sys:String>
-    <sys:String x:Key="Tools.Test.Clean.ToolTip">Clean PCL cache and MC logs, crash reports, and other junk files</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ToolTip">Clean PCL cache, Minecraft logs, crash reports, and other junk files</sys:String>
     <sys:String x:Key="Tools.Test.Clean.ConfirmTitle">Confirm cleanup</sys:String>
-    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">About to clean game logs, error reports, caches, and other files.&#xa;While nobody should put important files there, are you sure you want to continue?&#xa;&#xa;PCL will restart automatically after cleanup.</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">About to clean game logs, error reports, caches, and other files.&#x0A;These folders should not contain important files, but are you sure you want to continue?&#x0A;&#x0A;PCL will restart automatically after cleanup.</sys:String>
     <sys:String x:Key="Tools.Test.Clean.Cleared">Cache cleared</sys:String>
     <sys:String x:Key="Tools.Test.Clean.ClearedMessage">Cleaned {0} files!&#xa;PCL will restart...</sys:String>
     <sys:String x:Key="Tools.Test.Clean.NoFiles">No files to clean!</sys:String>
@@ -2767,7 +2767,7 @@
     <sys:String x:Key="Tools.Test.Crash.Title">Crash test</sys:String>
     <sys:String x:Key="Tools.Test.Crash.ToolTip">Clicking this will crash the launcher directly. Don't click unless you know what you're doing. No issues or problems caused by this will be accepted, and related issues will be closed immediately.</sys:String>
     <sys:String x:Key="Tools.Test.Crash.ConfirmTitle">Crash confirmation</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">You must have clicked wrong, confirm below if not</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">You probably clicked the wrong button. Confirm below if you really meant to do this.</sys:String>
     <sys:String x:Key="Tools.Test.Crash.ManualCrash">Manual crash</sys:String>
 
     <!-- Tools.Test.LaunchCount -->
@@ -2779,7 +2779,7 @@
 
     <sys:String x:Key="Tools.Test.Dependency.Title">Dependency check</sys:String>
     <sys:String x:Key="Tools.Test.Dependency.Checking">Checking environment...</sys:String>
-    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">Missing required dependency "{0}"&#xa;&#xa;Click OK to open Microsoft Store</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">Required dependency "{0}" is missing.&#x0A;&#x0A;Click OK to open Microsoft Store.</sys:String>
     <sys:String x:Key="Tools.Test.Dependency.Later">Later</sys:String>
 
     <!-- Tools.GameLink -->
@@ -2788,103 +2788,103 @@
     <sys:String x:Key="Tools.GameLink.Loading.DownloadingModule">Downloading lobby module</sys:String>
     <sys:String x:Key="Tools.GameLink.Loading.ConnectingServer">Connecting to lobby server...</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Title">PCL CE Lobby Terms &amp; Conditions</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.Description">Listed below are the service documents and introductions used by PCL CE Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Description">Service documents and introductions used by PCL CE Lobby are listed below.</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE Lobby Privacy Policy</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">Learn how PCL CE handles your personal information</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network User Agreement &amp; Privacy Policy</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">View Natayark OpenID Terms of Service</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I promise to strictly comply with relevant laws and regulations of Mainland China and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I promise to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE Lobby Privacy Policy and the Natayark OpenID Terms of Service.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">Learn how PCL CE handles your personal information.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark OpenID ToS</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">View Natayark OpenID terms of service.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I agree to strictly comply with relevant laws and regulations of Chinese Mainland and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I agree to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE lobby privacy policy and the Natayark OpenID terms of service.</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Accept">I have read and agree</sys:String>
-    <sys:String x:Key="Tools.GameLink.Nat.Title">NAT Type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Title">NAT type</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Test">Click to test</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Testing">Testing</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Failed">Test failed</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Result">UDP: {0}, TCP: {1}</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.Account">Natayark Account</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.Login">Click to login Natayark account</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Account">Natayark account</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Login">Log in to Natayark</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.LoginPrompt">PCL will open a login page. Please complete the login in your browser, then return to the launcher to continue.</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.LoginTitle">Login to Natayark Network</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginTitle">Log in to Natayark Network</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.Continue">Continue</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.BrowserContinue">Please continue in browser...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.BrowserContinue">Please continue in your browser...</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.LoginComplete">Login completed</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.LogoutConfirm">Are you sure you want to log out?</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.LogoutTitle">Logout</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutTitle">Log out</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.LogoutComplete">Logged out!</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.Loading">Loading...</sys:String>
     <sys:String x:Key="Tools.GameLink.Natayark.Abnormal">(Abnormal)</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.TokenExpired">Natayark ID token expired, please login again</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.ProfileLoadFailed">Failed to load Natayark user data, please try to re-login in settings</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.TokenInvalid">Naid Access Token invalid, try refreshing login</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.InvalidAuthCode">Naid authorization code invalid</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.AccountExpired">Natayark account info expired, please re-login in settings!</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.LoginFailed">Naid login failed, please try to login again in settings</sys:String>
-    <sys:String x:Key="Tools.GameLink.Natayark.FetchFailed">Failed to fetch info</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenExpired">Natayark ID token has expired. Please log in again.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.ProfileLoadFailed">Failed to load Natayark user data. Please log in again in Settings.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenInvalid">NAID access token is invalid. Try refreshing your login.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.InvalidAuthCode">NAID authorization code is invalid.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.AccountExpired">Natayark account information has expired. Please log in again in Settings!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginFailed">NAID login failed. Please log in again in Settings.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.FetchFailed">Failed to fetch information</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Important">Important</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Warning">Warning</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Notice">Notice</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Format">[{0}] {1}</sys:String>
-    <sys:String x:Key="Tools.GameLink.EasyTierVersion">Both parties are using different launcher versions, which may cause connectivity issues.&#x0A;It is strongly recommended that both parties upgrade to the latest version before continuing.</sys:String>
-    <sys:String x:Key="Tools.GameLink.Join.Title">Join Lobby</sys:String>
-    <sys:String x:Key="Tools.GameLink.Join.Description">1. Enter the lobby ID sent by your friend below and click [Join]&#x0A;2. Launch the game, select [Multiplayer], and join the lobby in LAN games</sys:String>
+    <sys:String x:Key="Tools.GameLink.EasyTierVersion">Both sides are using different launcher versions, which may cause connection issues.&#x0A;We strongly recommend that both sides upgrade to the latest version before continuing.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Title">Join lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Description">1. Enter the lobby ID sent by your friend below and click "Join"&#x0A;2. Launch the game, select "Multiplayer", and join the lobby in LAN games</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Action">Join</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Paste">Paste</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Clear">Clear</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.IdHint">ID should look like: U/NNNN-AAAA-SSSS-EEEE</sys:String>
-    <sys:String x:Key="Tools.GameLink.Join.InvalidText">Invalid lobby ID, please check and re-enter</sys:String>
-    <sys:String x:Key="Tools.GameLink.Create.Title">Create Lobby</sys:String>
-    <sys:String x:Key="Tools.GameLink.Create.Description">1. After entering a world, select [Open to LAN] in the game menu&#x0A;2. Select this game instance below and click [Create]&#x0A;3. After the lobby is created, copy the lobby ID and send it to your friend</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.InvalidText">Invalid lobby ID. Please check and enter it again.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Title">Create lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Description">1. After entering a world, select "Open to LAN" in the game menu&#x0A;2. Select this game instance below and click "Create"&#x0A;3. After the lobby is created, copy the lobby ID and send it to your friend</sys:String>
     <sys:String x:Key="Tools.GameLink.Create.Action">Create</sys:String>
-    <sys:String x:Key="Tools.GameLink.Create.ManualInput">Manual Input</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.ManualInput">Manual input</sys:String>
     <sys:String x:Key="Tools.GameLink.Create.EnterPort">Enter port</sys:String>
     <sys:String x:Key="Tools.GameLink.Create.NoWorld">Please select a world to play together!</sys:String>
-    <sys:String x:Key="Tools.GameLink.Create.NotMcPort">This doesn't seem to be an MC service port...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.NotMcPort">This doesn't seem to be a Minecraft service port...</sys:String>
     <sys:String x:Key="Tools.GameLink.Link.Report">Report violation</sys:String>
-    <sys:String x:Key="Tools.GameLink.Link.Terms">Natayark Network User Agreement &amp; Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Terms">Natayark OpenID ToS</sys:String>
     <sys:String x:Key="Tools.GameLink.Link.Privacy">Lobby Privacy Policy</sys:String>
-    <sys:String x:Key="Tools.GameLink.Link.Disable">Disable Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Disable">Disable lobby</sys:String>
     <sys:String x:Key="Tools.GameLink.Link.Faq">FAQ</sys:String>
     <sys:String x:Key="Tools.GameLink.Link.Friends">Links: </sys:String>
-    <sys:String x:Key="Tools.GameLink.Link.EasyTier">EasyTier Official Website</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.InfoTitle">Lobby Info</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">Connection Status</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.EasyTier">EasyTier official website</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.InfoTitle">Lobby information</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">Connection status</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Checking">Checking</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.PingToHost">Ping to Lobby Host</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.PingToHost">Ping to lobby host</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.PingMs">{0}ms</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.LobbyId">Lobby ID</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">Connection Type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">Connection type</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Connecting">Connecting</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.UserName">Username</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.UserType">User Type</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.Actions">Lobby Actions</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.CopyVirtualIp">Copy Virtual IP</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.CopyLobbyId">Copy Lobby ID</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.Exit">Exit Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.UserType">User type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Actions">Lobby actions</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyVirtualIp">Copy virtual IP</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyLobbyId">Copy lobby ID</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Exit">Exit lobby</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Connected">Connected</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Unavailable">Unavailable</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Host">Host</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Guest">Guest</sys:String>
-    <sys:String x:Key="Tools.GameLink.Finish.CloseLobby">Close Lobby</sys:String>
-    <sys:String x:Key="Tools.GameLink.Player.InfoTitle">Player {0} Details</sys:String>
-    <sys:String x:Key="Tools.GameLink.Player.InfoMessage">Username: {0}&#x0A;Client Identifier: {1}&#x0A;&#x0A;This data is for reference only. Actual gameplay experience shall prevail.&#x0A;&#x0A;To learn about NAT types and how they affect your lobby experience, please refer to the FAQ section on the left.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CloseLobby">Close lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoTitle">Player {0} details</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoMessage">Username: {0}&#x0A;Client identifier: {1}&#x0A;&#x0A;This data is for reference only. Actual gameplay may vary.&#x0A;&#x0A;To learn about NAT types and how they affect your lobby experience, see the FAQ section on the left.</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.Host">[Host]</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.Details">{0} {1}</sys:String>
-    <sys:String x:Key="Tools.GameLink.Member.ListLoading">Lobby Members (Retrieving information)</sys:String>
-    <sys:String x:Key="Tools.GameLink.Member.ListCount">Lobby Members ({0} total)</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListLoading">Lobby members (retrieving information)</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListCount">Lobby members ({0} total)</sys:String>
     <sys:String x:Key="Tools.GameLink.Eula.RevokeConfirm">Are you sure you want to revoke the lobby agreement authorization?</sys:String>
-    <sys:String x:Key="Tools.GameLink.Eula.RevokeTitle">Revoke Authorization</sys:String>
-    <sys:String x:Key="Tools.GameLink.Eula.Disabled">Lobby feature has been disabled!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.RevokeTitle">Revoke authorization</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.Disabled">Lobby feature disabled!</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessage">Are you sure you want to exit the lobby?</sys:String>
-    <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">Confirm Exit</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">Confirm exit</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.HostWarning">Since you are the lobby host, exiting will automatically disband this lobby.</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessageWithHost">Are you sure you want to exit the lobby?&#x0A;Since you are the lobby host, exiting will automatically disband this lobby.</sys:String>
-    <sys:String x:Key="Tools.GameLink.Exit.Disbanded">The lobby has been automatically disbanded because you closed the MC instance in the lobby.</sys:String>
-    <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">Lobby Disbanded</sys:String>
-    <sys:String x:Key="Tools.GameLink.CopyIp.Message">Lobby host's game address: {0}&#x0A;Note: IP connection is only recommended when the lobby broadcast doesn't appear in the MC multiplayer list! IP connection may require a licensed account.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.Disbanded">The lobby has been automatically disbanded because you closed the Minecraft instance in the lobby.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">Lobby disbanded</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Message">Lobby host's game address: {0}&#x0A;Note: IP connection is only recommended when the lobby broadcast does not appear in the Minecraft multiplayer list. IP connection may require a licensed account.</sys:String>
     <sys:String x:Key="Tools.GameLink.CopyIp.Title">Copy IP</sys:String>
     <sys:String x:Key="Tools.GameLink.CopyIp.Back">Back</sys:String>
     <sys:String x:Key="Tools.GameLink.Error.ServerExit">An error occurred while exiting the server!</sys:String>
-    <sys:String x:Key="Tools.GameLink.Error.UpdateRequired">Please update to the latest PCL CE to use the lobby</sys:String>
-    <sys:String x:Key="Tools.GameLink.Error.ConnectFailed">Failed to connect to lobby server</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.UpdateRequired">Please update to the latest PCL CE to use lobby features.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.ConnectFailed">Failed to connect to the lobby server</sys:String>
 
     <!-- Speed -->
 
@@ -2908,24 +2908,24 @@
     <sys:String x:Key="Tools.ServerQuery.Error.InvalidResponse">Server returned invalid information</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.AddressTooLong">Server address too long</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">Server returned empty data packet</sys:String>
-    <sys:String x:Key="Tools.ServerQuery.Error.StaleConnection">Server disconnected before returning pong packet, unable to calculate latency.</sys:String>
-    <sys:String x:Key="Tools.ServerQuery.Error.IncompleteConnection">Server disconnected before returning complete status packet.</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.StaleConnection">Server disconnected before returning the pong packet, so latency could not be calculated.</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.IncompleteConnection">Server disconnected before returning the complete status packet.</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.PongDataLength">Pong data must be exactly 8 bytes</sys:String>
 
     <!-- Update -->
 
     <sys:String x:Key="Update.Action">Update</sys:String>
-    <sys:String x:Key="Update.Check.Failed">Unable to get latest version info. Please check your network connection.</sys:String>
+    <sys:String x:Key="Update.Check.Failed">Unable to get latest version information. Please check your network connection.</sys:String>
     <sys:String x:Key="Update.Available">A new launcher version is available ({0} -&gt; {1})&#x0A;Update now?</sys:String>
-    <sys:String x:Key="Update.Title">Launcher Update</sys:String>
+    <sys:String x:Key="Update.Title">Launcher update</sys:String>
     <sys:String x:Key="Update.Error.FetchFailed">Failed to get launcher update. Please check your network connection.</sys:String>
-    <sys:String x:Key="Update.Error.UnableToGetUpdate">Unable to get update</sys:String>
+    <sys:String x:Key="Update.Error.UnableToGetUpdate">Unable to get update information</sys:String>
     <sys:String x:Key="Update.Error.FileNotFound">Update file not found</sys:String>
-    <sys:String x:Key="Update.Error.Sha256Mismatch">Update file SHA256 mismatch. Expected: {0}, Actual: {1}</sys:String>
-    <sys:String x:Key="Update.Error.UpdateBlocked">Update Failed</sys:String>
-    <sys:String x:Key="Update.Error.ViewHelp">View Help</sys:String>
-    <sys:String x:Key="Update.Error.UpdateBlockedMessage">PCL cannot update because it was blocked by Windows Security or has insufficient permissions.&#x0A;Please add the PCL folder to the exclusion list, or manually replace the current file with {0}PCL\Plain Craft Launcher Community Edition.exe!</sys:String>
-    <sys:String x:Key="Update.Service.PclCe">PCL CE Service</sys:String>
+    <sys:String x:Key="Update.Error.Sha256Mismatch">Update file SHA256 mismatch. Expected: {0}, actual: {1}</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlocked">Update failed</sys:String>
+    <sys:String x:Key="Update.Error.ViewHelp">View help</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlockedMessage">PCL cannot update because it was blocked by Windows Security or does not have sufficient permissions.&#x0A;Please add the PCL folder to the exclusion list, or manually replace the current file with {0}PCL\Plain Craft Launcher Community Edition.exe!</sys:String>
+    <sys:String x:Key="Update.Service.PclCe">PCL CE service</sys:String>
     <sys:String x:Key="Update.Task.Check">Verify update</sys:String>
     <sys:String x:Key="Update.Task.Install">Install update</sys:String>
     <sys:String x:Key="Update.Task.Prepare">Prepare update</sys:String>
@@ -2934,44 +2934,44 @@
     <sys:String x:Key="Update.Task.DownloadLatestStable">Download latest stable</sys:String>
     <sys:String x:Key="Update.Task.DownloadFile">Download file</sys:String>
     <sys:String x:Key="Update.Task.ApplyFile">Apply file</sys:String>
-    <sys:String x:Key="Update.Task.GetDownloadInfo">Get download info</sys:String>
+    <sys:String x:Key="Update.Task.GetDownloadInfo">Get download information</sys:String>
     <sys:String x:Key="Update.Task.DownloadUpdateFile">Download update file</sys:String>
-    <sys:String x:Key="Update.Task.GetVersionInfo">Get version info</sys:String>
-    <sys:String x:Key="Update.Task.GetVersionInfoFailed">Failed to get version info</sys:String>
-    <sys:String x:Key="Update.Task.GetAnnouncementFailed">Failed to get announcement info</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfo">Get version information</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfoFailed">Failed to get version information</sys:String>
+    <sys:String x:Key="Update.Task.GetAnnouncementFailed">Failed to get announcement information</sys:String>
     <sys:String x:Key="Update.Task.RefreshSettings">Refresh settings UI</sys:String>
-    <sys:String x:Key="Update.CommunityNotice.Title">Community Edition Notice</sys:String>
-    <sys:String x:Key="Update.CommunityNotice.Body">You are using the PCL Community Edition from PCL-Community. Please DO NOT report issues to the official repository!&#x0A;PCL-Community and its members have no affiliation with LTCat (龙腾猫跃) and do not guarantee your usage.&#x0A;&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;&#x0A;Differences from the official version:&#x0A;- Themes: Only some fixed blue themes; no plans to add new themes.&#x0A;- Toolbox: Some content from the official version is missing (Echo Cave, Don't Click).&#x0A;&#x0A;This message will be shown once after a launcher update.</sys:String>
-    <sys:String x:Key="Update.CommunityNotice.Confirm">I Understand</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Title">Community Edition notice</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Body">You are using PCL Community Edition from PCL-Community. Please DO NOT report issues to the official repository!&#x0A;PCL-Community and its members are not affiliated with LTCat (龙腾猫跃), and do not guarantee your usage.&#x0A;&#x0A;If you downloaded Community Edition by mistake, we recommend using the official PCL instead.&#x0A;If you downloaded Community Edition by mistake, we recommend using the official PCL instead.&#x0A;If you downloaded Community Edition by mistake, we recommend using the official PCL instead.&#x0A;&#x0A;Differences from the official version:&#x0A;- Themes: only some fixed blue themes; no plans to add new themes.&#x0A;- Toolbox: some content from the official version is missing (Echo Cave, Don't Click).&#x0A;&#x0A;This message will be shown once after a launcher update.</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Confirm">I understand</sys:String>
 
     <!-- LogPage -->
 
     <sys:String x:Key="LogPage.Title">Live logs</sys:String>
     <sys:String x:Key="LogPage.Empty.Title">No live logs</sys:String>
-    <sys:String x:Key="LogPage.Empty.Description">Go to Instance Settings → Overview → Test Game to display live game logs.</sys:String>
+    <sys:String x:Key="LogPage.Empty.Description">Go to Instance settings → Overview → Test game to display live game logs.</sys:String>
     <sys:String x:Key="LogPage.Left.InstancesTitle">Test instances</sys:String>
     <sys:String x:Key="LogPage.Action.Scroll">Scroll</sys:String>
     <sys:String x:Key="LogPage.Action.Export">Export</sys:String>
     <sys:String x:Key="LogPage.Action.Clear">Clear</sys:String>
     <sys:String x:Key="LogPage.Action.KillProcess">Kill</sys:String>
     <sys:String x:Key="LogPage.Action.ExportStack">Dump</sys:String>
-    <sys:String x:Key="LogPage.Action.GameClosed">Game {0} closed!</sys:String>
+    <sys:String x:Key="LogPage.Action.GameClosed">Game {0} closed.</sys:String>
     <sys:String x:Key="LogPage.Level.Debug">Debug</sys:String>
     <sys:String x:Key="LogPage.Level.Info">Info</sys:String>
     <sys:String x:Key="LogPage.Level.Warn">Warn</sys:String>
     <sys:String x:Key="LogPage.Level.Error">Error</sys:String>
     <sys:String x:Key="LogPage.Level.Fatal">Fatal</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Title">Max lines</sys:String>
-    <sys:String x:Key="LogPage.MaxLines.ToolTip">Maximum number of lines displayed; older logs are automatically removed when exceeded.</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.ToolTip">Maximum number of lines displayed. Older logs are automatically removed when this limit is exceeded.</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Unlimited">Unlimited</sys:String>
-    <sys:String x:Key="LogPage.MaxLines.Hint">Logs are limited to {0} lines by default. Adjust this in Max Log Lines settings.</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Hint">Logs are limited to {0} lines by default. Adjust this in the max log lines settings.</sys:String>
     <sys:String x:Key="LogPage.Export.SelectLocation">Select export location</sys:String>
     <sys:String x:Key="LogPage.Export.Success">Log exported!</sys:String>
     <sys:String x:Key="LogPage.Export.GameLog.FileName">Game log - {0}.log</sys:String>
-    <sys:String x:Key="LogPage.Export.GameLog.Filter">Game log(*.log)|*.log</sys:String>
+    <sys:String x:Key="LogPage.Export.GameLog.Filter">Game log (*.log)|*.log</sys:String>
     <sys:String x:Key="LogPage.ExportStack.FileName">Game stack dump - {0}.log</sys:String>
-    <sys:String x:Key="LogPage.ExportStack.Filter">Game stack dump(*.log)|*.log</sys:String>
-    <sys:String x:Key="LogPage.ExportStack.Progress">Exporting stack dump, please wait (may take 15s ~ 1min)</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Filter">Game stack dump (*.log)|*.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Progress">Exporting stack dump. Please wait (may take 15 seconds to 1 minute).</sys:String>
     <sys:String x:Key="LogPage.ExportStack.Success">Stack dump exported!</sys:String>
 
     <!-- Watcher -->
@@ -2989,19 +2989,19 @@
     <sys:String x:Key="Watcher.Progress.LwjglConfirmed">Log 3/5: LWJGL version confirmed</sys:String>
     <sys:String x:Key="Watcher.Progress.OpenAlLoaded">Log 4/5: OpenAL loaded</sys:String>
     <sys:String x:Key="Watcher.Progress.TexturesLoaded">Log 5/5: Textures loaded</sys:String>
-    <sys:String x:Key="Watcher.Log.CloseDetected">Identified close log: {0}</sys:String>
-    <sys:String x:Key="Watcher.Log.CrashDetected">Identified crash log: {0}</sys:String>
-    <sys:String x:Key="Watcher.Crash.Suspected">Minecraft hasn't finished loading, may have crashed</sys:String>
-    <sys:String x:Key="Watcher.Crash.AbnormalExit">Minecraft exit code abnormal, may have crashed</sys:String>
-    <sys:String x:Key="Watcher.Crash.Detected">Minecraft has crashed, crash analysis will start in 2 seconds</sys:String>
+    <sys:String x:Key="Watcher.Log.CloseDetected">Detected close log: {0}</sys:String>
+    <sys:String x:Key="Watcher.Log.CrashDetected">Detected crash log: {0}</sys:String>
+    <sys:String x:Key="Watcher.Crash.Suspected">Minecraft hasn't finished loading and may have crashed.</sys:String>
+    <sys:String x:Key="Watcher.Crash.AbnormalExit">Minecraft exited with an abnormal code and may have crashed.</sys:String>
+    <sys:String x:Key="Watcher.Crash.Detected">Minecraft has crashed. Crash analysis will start in 2 seconds.</sys:String>
     <sys:String x:Key="Watcher.Crash.AnalysisStart">Crash analysis started</sys:String>
-    <sys:String x:Key="Watcher.Crash.Hint">Minecraft error detected, analysis started...</sys:String>
-    <sys:String x:Key="Watcher.Kill.Attempt">Attempting to force kill Minecraft process</sys:String>
-    <sys:String x:Key="Watcher.Kill.TaskkillAttempt">Process still alive, trying taskkill.exe</sys:String>
+    <sys:String x:Key="Watcher.Crash.Hint">Minecraft error detected. Starting analysis...</sys:String>
+    <sys:String x:Key="Watcher.Kill.Attempt">Attempting to force-kill the Minecraft process</sys:String>
+    <sys:String x:Key="Watcher.Kill.TaskkillAttempt">Process is still alive. Trying taskkill.exe</sys:String>
     <sys:String x:Key="Watcher.Kill.TaskkillResult">taskkill.exe result: {0}</sys:String>
-    <sys:String x:Key="Watcher.Kill.Timeout">Force kill failed: process exit timeout</sys:String>
-    <sys:String x:Key="Watcher.Kill.Success">Minecraft process forcefully killed</sys:String>
-    <sys:String x:Key="Watcher.Kill.Failed">Failed to force kill Minecraft process</sys:String>
+    <sys:String x:Key="Watcher.Kill.Timeout">Force-kill failed: process exit timed out</sys:String>
+    <sys:String x:Key="Watcher.Kill.Success">Minecraft process force-killed</sys:String>
+    <sys:String x:Key="Watcher.Kill.Failed">Failed to force-kill the Minecraft process</sys:String>
 
     <!-- Link -->
 
@@ -3021,39 +3021,39 @@
     <sys:String x:Key="Link.Quality.Good">Good</sys:String>
     <sys:String x:Key="Link.Quality.Normal">Normal</sys:String>
     <sys:String x:Key="Link.Quality.Poor">Poor</sys:String>
-    <sys:String x:Key="Link.Quality.GoodDescription">Current network environment will not affect connection experience&#x0A;This environment is suitable as lobby host</sys:String>
-    <sys:String x:Key="Link.Quality.NormalDescription">Current network environment may affect your connection experience</sys:String>
-    <sys:String x:Key="Link.Quality.PoorDescription">Some router and firewall settings may affect your connection experience</sys:String>
-    <sys:String x:Key="Link.Natayark.TokenFetchEmpty">Failed to get AccessToken and RefreshToken, response is empty</sys:String>
-    <sys:String x:Key="Link.Natayark.TokenParseFailed">Failed to get AccessToken and RefreshToken, unable to parse response</sys:String>
-    <sys:String x:Key="Link.Natayark.UserInfoFetchEmpty">Failed to get Natayark user info, response is empty</sys:String>
-    <sys:String x:Key="Link.Natayark.UserInfoParseFailed">Failed to get Natayark user info, unable to parse response</sys:String>
+    <sys:String x:Key="Link.Quality.GoodDescription">The current network environment should not affect connection experience.&#x0A;This environment is suitable as the lobby host.</sys:String>
+    <sys:String x:Key="Link.Quality.NormalDescription">The current network environment may affect your connection experience.</sys:String>
+    <sys:String x:Key="Link.Quality.PoorDescription">Some router and firewall settings may affect your connection experience.</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenFetchEmpty">Failed to get AccessToken and RefreshToken: response is empty</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenParseFailed">Failed to get AccessToken and RefreshToken: unable to parse response</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoFetchEmpty">Failed to get Natayark user information: response is empty</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoParseFailed">Failed to get Natayark user information: unable to parse response</sys:String>
     <sys:String x:Key="Link.Lobby.InitFailed">Lobby service initialization failed. Please check your network.</sys:String>
-    <sys:String x:Key="Link.Lobby.LoginRequired">Please log in to your Natayark ID first!</sys:String>
-    <sys:String x:Key="Link.Lobby.CreateRoomFailed">An error occurred while creating the room. Please check logs and report to the developer!</sys:String>
+    <sys:String x:Key="Link.Lobby.LoginRequired">Please log in to Natayark ID first!</sys:String>
+    <sys:String x:Key="Link.Lobby.CreateRoomFailed">An error occurred while creating the room. Please check the logs and report this to the developer!</sys:String>
     <sys:String x:Key="Link.Lobby.CreateLobbyFailed">Failed to create lobby. Please check logs or report to the developer.</sys:String>
-    <sys:String x:Key="Link.Lobby.JoinFailed">Failed to join lobby. It may not exist or has been disbanded.</sys:String>
+    <sys:String x:Key="Link.Lobby.JoinFailed">Failed to join lobby. It may not exist or may have been disbanded.</sys:String>
     <sys:String x:Key="Link.Lobby.InvalidCodeFormat">Invalid lobby code format. Please check and try again!</sys:String>
     <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE Lobby{0}</sys:String>
     <sys:String x:Key="Link.Lobby.MotdDesc"> - {0}</sys:String>
     <sys:String x:Key="Link.Lobby.UnsupportedType">Unsupported lobby type: {0}</sys:String>
     <sys:String x:Key="Link.Lobby.WorldNameFormat">{0} / {1} ({2})</sys:String>
     <sys:String x:Key="Link.Mod.LobbyUnavailable">Lobby is currently unavailable. Please try again later.</sys:String>
-    <sys:String x:Key="Link.Mod.InvalidPlayerId">MC player ID cannot contain separator (|)!</sys:String>
+    <sys:String x:Key="Link.Mod.InvalidPlayerId">Minecraft player ID cannot contain separators (|)!</sys:String>
     <sys:String x:Key="Link.Mod.LoginFirst">Please go to multiplayer settings and log in to Natayark Network first!</sys:String>
-    <sys:String x:Key="Link.Mod.ReLoginRequired">Please re-login to your Natayark Network account and try again!</sys:String>
-    <sys:String x:Key="Link.Mod.NaidFetchFailed">Failed to fetch Natayark ID info</sys:String>
+    <sys:String x:Key="Link.Mod.ReLoginRequired">Please log in to your Natayark Network account again and try again!</sys:String>
+    <sys:String x:Key="Link.Mod.NaidFetchFailed">Failed to fetch Natayark ID information</sys:String>
     <sys:String x:Key="Link.Mod.RealNameRequired">Please complete real-name verification at the Natayark Account Center first!</sys:String>
-    <sys:String x:Key="Link.Mod.AccountBanned">Your Natayark Network account status is abnormal, may be banned!</sys:String>
-    <sys:String x:Key="Link.Mod.UsernameOrLogin">Please set a username in settings, or log in to Natayark Network first!</sys:String>
-    <sys:String x:Key="Link.Mod.DownloadingDeps">Downloading multiplayer dependencies, please wait...</sys:String>
+    <sys:String x:Key="Link.Mod.AccountBanned">Your Natayark Network account status is abnormal and may be banned!</sys:String>
+    <sys:String x:Key="Link.Mod.UsernameOrLogin">Please set a username in Settings, or log in to Natayark Network first!</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingDeps">Downloading multiplayer dependencies. Please wait...</sys:String>
     <sys:String x:Key="Link.Mod.EasyTierNotReady">EasyTier has not finished downloading. Please wait and try again!</sys:String>
-    <sys:String x:Key="Link.Mod.DownloadingEasyTier">Downloading EasyTier, please wait...</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingEasyTier">Downloading EasyTier. Please wait...</sys:String>
     <sys:String x:Key="Link.Mod.DownloadComplete">Multiplayer components downloaded!</sys:String>
     <sys:String x:Key="Link.Mod.DownloadEasyTierFailed">Failed to download EasyTier dependencies. Please check your network.</sys:String>
     <sys:String x:Key="Link.Mod.Task.DownloadEasyTier">Download EasyTier</sys:String>
     <sys:String x:Key="Link.Mod.Task.ExtractFiles">Extract files</sys:String>
-    <sys:String x:Key="Link.Mod.Task.CleanCache">Clean cache and redundant components</sys:String>
+    <sys:String x:Key="Link.Mod.Task.CleanCache">Clean caches and redundant components</sys:String>
     <sys:String x:Key="Link.Mod.Task.RefreshUi">Refresh UI</sys:String>
     <sys:String x:Key="Link.Mod.Task.InitLobby">Initialize lobby</sys:String>
     <sys:String x:Key="Link.Mod.Task.InitLobbyUi">Initialize lobby UI</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2671,6 +2671,13 @@
 
     <!-- Speed -->
 
+    <sys:String x:Key="Speed.Progress.Total">Total progress</sys:String>
+    <sys:String x:Key="Speed.Progress.Speed">Download speed</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingFiles">Remaining files</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingThreads">Remaining threads</sys:String>
+    <sys:String x:Key="Speed.Error.ClickToCopy">Click to copy error details</sys:String>
+    <sys:String x:Key="Speed.Error.Copied">Error details copied!</sys:String>
+
     <!-- Tools.ServerQuery -->
 
     <sys:String x:Key="Tools.ServerQuery.Address.Hint">Enter server address</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2903,9 +2903,35 @@
     <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">Server returned empty data packet</sys:String>
 
     <!-- Update -->
-    <!-- Update.Task -->
-    <!-- Update.Error -->
-    <!-- Update.CommunityNotice -->
+    <sys:String x:Key="Update.Action">Update</sys:String>
+    <sys:String x:Key="Update.Check.Failed">Unable to get latest version info. Please check your network connection.</sys:String>
+    <sys:String x:Key="Update.Available">A new launcher version is available ({0} -&gt; {1})&#x0A;Update now?</sys:String>
+    <sys:String x:Key="Update.Title">Launcher Update</sys:String>
+    <sys:String x:Key="Update.Error.FetchFailed">Failed to get launcher update. Please check your network connection.</sys:String>
+    <sys:String x:Key="Update.Error.UnableToGetUpdate">Unable to get update</sys:String>
+    <sys:String x:Key="Update.Error.FileNotFound">Update file not found</sys:String>
+    <sys:String x:Key="Update.Error.Sha256Mismatch">Update file SHA256 mismatch. Expected: {0}, Actual: {1}</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlocked">Update Failed</sys:String>
+    <sys:String x:Key="Update.Error.ViewHelp">View Help</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlockedMessage">PCL cannot update because it was blocked by Windows Security or has insufficient permissions.&#x0A;Please add the PCL folder to the exclusion list, or manually replace the current file with {0}PCL\Plain Craft Launcher Community Edition.exe!</sys:String>
+    <sys:String x:Key="Update.Service.PclCe">PCL CE Service</sys:String>
+    <sys:String x:Key="Update.Task.Check">Verify update</sys:String>
+    <sys:String x:Key="Update.Task.Install">Install update</sys:String>
+    <sys:String x:Key="Update.Task.Prepare">Prepare update</sys:String>
+    <sys:String x:Key="Update.Task.ShowButton">Show button</sys:String>
+    <sys:String x:Key="Update.Task.RestartInstall">Restart install</sys:String>
+    <sys:String x:Key="Update.Task.DownloadLatestStable">Download latest stable</sys:String>
+    <sys:String x:Key="Update.Task.DownloadFile">Download file</sys:String>
+    <sys:String x:Key="Update.Task.ApplyFile">Apply file</sys:String>
+    <sys:String x:Key="Update.Task.GetDownloadInfo">Get download info</sys:String>
+    <sys:String x:Key="Update.Task.DownloadUpdateFile">Download update file</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfo">Get version info</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfoFailed">Failed to get version info</sys:String>
+    <sys:String x:Key="Update.Task.GetAnnouncementFailed">Failed to get announcement info</sys:String>
+    <sys:String x:Key="Update.Task.RefreshSettings">Refresh settings UI</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Title">Community Edition Notice</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Body">You are using the PCL Community Edition from PCL-Community. Please DO NOT report issues to the official repository!&#x0A;PCL-Community and its members have no affiliation with LTCat (龙腾猫跃) and do not guarantee your usage.&#x0A;&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;If you downloaded the Community Edition by accident, we recommend using the official PCL instead.&#x0A;&#x0A;Differences from the official version:&#x0A;- Themes: Only some fixed blue themes; no plans to add new themes.&#x0A;- Toolbox: Some content from the official version is missing (Echo Cave, Don't Click).&#x0A;&#x0A;This message will be shown once after a launcher update.</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Confirm">I Understand</sys:String>
 
     <!-- LogPage -->
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2745,7 +2745,7 @@
     <sys:String x:Key="Tools.Test.Shortcut.Desktop">Desktop</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.StartMenu">Start menu</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.Created">Shortcut created on {0}</sys:String>
-    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL Community Edition</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL Community Edition{0}</sys:String>
 
     <!-- Tools.Test.Luck -->
 
@@ -2790,7 +2790,9 @@
     <sys:String x:Key="Tools.GameLink.Agreement.Title">PCL CE Lobby Terms &amp; Conditions</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Description">Listed below are the service documents and introductions used by PCL CE Lobby</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE Lobby Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">Learn how PCL CE handles your personal information</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network User Agreement &amp; Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">View Natayark OpenID Terms of Service</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I promise to strictly comply with relevant laws and regulations of Mainland China and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I promise to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE Lobby Privacy Policy and the Natayark OpenID Terms of Service.</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Accept">I have read and agree</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Title">NAT Type</sys:String>
@@ -2820,6 +2822,8 @@
     <sys:String x:Key="Tools.GameLink.Announcement.Important">Important</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Warning">Warning</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Notice">Notice</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Format">[{0}] {1}</sys:String>
+    <sys:String x:Key="Tools.GameLink.EasyTierVersion">Both parties are using different launcher versions, which may cause connectivity issues.&#x0A;It is strongly recommended that both parties upgrade to the latest version before continuing.</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Title">Join Lobby</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Description">1. Enter the lobby ID sent by your friend below and click [Join]&#x0A;2. Launch the game, select [Multiplayer], and join the lobby in LAN games</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Action">Join</sys:String>
@@ -2845,6 +2849,7 @@
     <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">Connection Status</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Checking">Checking</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.PingToHost">Ping to Lobby Host</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.PingMs">{0}ms</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.LobbyId">Lobby ID</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">Connection Type</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Connecting">Connecting</sys:String>
@@ -2862,6 +2867,7 @@
     <sys:String x:Key="Tools.GameLink.Player.InfoTitle">Player {0} Details</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.InfoMessage">Username: {0}&#x0A;Client Identifier: {1}&#x0A;&#x0A;This data is for reference only. Actual gameplay experience shall prevail.&#x0A;&#x0A;To learn about NAT types and how they affect your lobby experience, please refer to the FAQ section on the left.</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.Host">[Host]</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.Details">{0} {1}</sys:String>
     <sys:String x:Key="Tools.GameLink.Member.ListLoading">Lobby Members (Retrieving information)</sys:String>
     <sys:String x:Key="Tools.GameLink.Member.ListCount">Lobby Members ({0} total)</sys:String>
     <sys:String x:Key="Tools.GameLink.Eula.RevokeConfirm">Are you sure you want to revoke the lobby agreement authorization?</sys:String>
@@ -2870,6 +2876,7 @@
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessage">Are you sure you want to exit the lobby?</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">Confirm Exit</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.HostWarning">Since you are the lobby host, exiting will automatically disband this lobby.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessageWithHost">Are you sure you want to exit the lobby?&#x0A;Since you are the lobby host, exiting will automatically disband this lobby.</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.Disbanded">The lobby has been automatically disbanded because you closed the MC instance in the lobby.</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">Lobby Disbanded</sys:String>
     <sys:String x:Key="Tools.GameLink.CopyIp.Message">Lobby host's game address: {0}&#x0A;Note: IP connection is only recommended when the lobby broadcast doesn't appear in the MC multiplayer list! IP connection may require a licensed account.</sys:String>
@@ -2901,8 +2908,12 @@
     <sys:String x:Key="Tools.ServerQuery.Error.InvalidResponse">Server returned invalid information</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.AddressTooLong">Server address too long</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">Server returned empty data packet</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.StaleConnection">Server disconnected before returning pong packet, unable to calculate latency.</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.IncompleteConnection">Server disconnected before returning complete status packet.</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.PongDataLength">Pong data must be exactly 8 bytes</sys:String>
 
     <!-- Update -->
+
     <sys:String x:Key="Update.Action">Update</sys:String>
     <sys:String x:Key="Update.Check.Failed">Unable to get latest version info. Please check your network connection.</sys:String>
     <sys:String x:Key="Update.Available">A new launcher version is available ({0} -&gt; {1})&#x0A;Update now?</sys:String>
@@ -2945,6 +2956,11 @@
     <sys:String x:Key="LogPage.Action.KillProcess">Kill</sys:String>
     <sys:String x:Key="LogPage.Action.ExportStack">Dump</sys:String>
     <sys:String x:Key="LogPage.Action.GameClosed">Game {0} closed!</sys:String>
+    <sys:String x:Key="LogPage.Level.Debug">Debug</sys:String>
+    <sys:String x:Key="LogPage.Level.Info">Info</sys:String>
+    <sys:String x:Key="LogPage.Level.Warn">Warn</sys:String>
+    <sys:String x:Key="LogPage.Level.Error">Error</sys:String>
+    <sys:String x:Key="LogPage.Level.Fatal">Fatal</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Title">Max lines</sys:String>
     <sys:String x:Key="LogPage.MaxLines.ToolTip">Maximum number of lines displayed; older logs are automatically removed when exceeded.</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Unlimited">Unlimited</sys:String>
@@ -3018,8 +3034,10 @@
     <sys:String x:Key="Link.Lobby.CreateLobbyFailed">Failed to create lobby. Please check logs or report to the developer.</sys:String>
     <sys:String x:Key="Link.Lobby.JoinFailed">Failed to join lobby. It may not exist or has been disbanded.</sys:String>
     <sys:String x:Key="Link.Lobby.InvalidCodeFormat">Invalid lobby code format. Please check and try again!</sys:String>
-    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE Lobby</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE Lobby{0}</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdDesc"> - {0}</sys:String>
     <sys:String x:Key="Link.Lobby.UnsupportedType">Unsupported lobby type: {0}</sys:String>
+    <sys:String x:Key="Link.Lobby.WorldNameFormat">{0} / {1} ({2})</sys:String>
     <sys:String x:Key="Link.Mod.LobbyUnavailable">Lobby is currently unavailable. Please try again later.</sys:String>
     <sys:String x:Key="Link.Mod.InvalidPlayerId">MC player ID cannot contain separator (|)!</sys:String>
     <sys:String x:Key="Link.Mod.LoginFirst">Please go to multiplayer settings and log in to Natayark Network first!</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2647,16 +2647,141 @@
     <sys:String x:Key="Tools.Help.Search.Similarity">Similarity: {0}  |  {1}</sys:String>
 
     <!-- Tools.Test -->
+
+    <sys:String x:Key="Tools.Test.Title">Utilities</sys:String>
+    <sys:String x:Key="Tools.Test.CeNotice">For ease of maintenance, this feature is not included in the Community Edition...</sys:String>
+
     <!-- Tools.Test.CustomDownload -->
+
+    <sys:String x:Key="Tools.Test.CustomDownload.Title">Custom download</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Description">Use PCL's high-speed multi-threaded download engine to download any file. Note: some websites (e.g. Baidu Netdisk) may return error (403) Forbidden and cannot be downloaded.</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Url">Download URL</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.UserAgent">User-Agent</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.SaveTo">Save to</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Select">Select</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.SelectLocation">Select save location</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.FileName">File name</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Start">Start download</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.LoaderName">Custom download file: {0} </sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.LoaderTitle">Custom download ({0}) </sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Finished">{0} completed!</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Aborted">{0} aborted!</sys:String>
+
     <!-- Tools.Test.Skin -->
+
+    <sys:String x:Key="Tools.Test.Skin.Title">Download a player's official skin</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.PlayerName">Player name</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Save">Save skin</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Fetching">Fetching skin...</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.InvalidId">This is not a valid ID...</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.TooFrequent">Skin fetch rate limited, please try again in 5 minutes!</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Saved">Player {0}'s skin saved!</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.FileFilter">Skin image file(*.png)|*.png</sys:String>
+
     <!-- Tools.Test.ServerQuery -->
+
+    <sys:String x:Key="Tools.Test.ServerQuery.Title">Check server</sys:String>
+
     <!-- Tools.Test.Achievement -->
+
+    <sys:String x:Key="Tools.Test.Achievement.Title">Custom achievement image generator (English only)</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.ItemId">Item name (ID)</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Name">Achievement name</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Line1">Line 1</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Line2">Line 2 (optional)</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Preview">Preview achievement</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Save">Save image</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.InvalidId">Please enter a valid item ID!</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Saved">Custom achievement image saved!</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG image|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FetchFailed">Failed to get achievement image, check for special characters</sys:String>
+
     <!-- Tools.Test.Avatar -->
+
+    <sys:String x:Key="Tools.Test.Avatar.Title">Skin avatar generator</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Size">Avatar size:</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectSkin">Select skin</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectSkinFile">Select skin file</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.FileFilter">Image file(*.png)|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Save">Save avatar</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectFirst">Please select a skin first!</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.InvalidSize">Image size is incorrect! Please confirm you selected the correct file!</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Generated">Avatar generated!</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.GenerateFailed">Failed to generate avatar: {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Saved">Avatar saved!</sys:String>
+
     <!-- Tools.Test.Memory -->
+
+    <sys:String x:Key="Tools.Test.Memory.Title">Optimize memory</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.ToolTip">Memory optimization is a PCL CE exclusive, supercharged!&#xa;&#xa;Reduces physical memory usage by about 1/3, not just for MC!&#xa;If using an HDD, this may cause a brief period of severe lag.&#xa;Use the --memory flag to run memory optimization silently on launch.</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Deprecated">Memory optimization will be deprecated.\n\nThis feature relies on undocumented Windows NT kernel function calls, may become unavailable in future versions, and could cause undefined behavior.\n\nIt is recommended to use Mem Reduct instead, a professional third-party memory management tool.\n\nContinue using memory optimization anyway?</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.DeprecatedTitle">Feature deprecating</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.LearnMemReduct">Learn about Mem Reduct</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Optimizing">Optimizing memory...</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.StillRunning">Memory optimization is still running, please wait!</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Result">Memory optimization complete, freed {0}, available memory {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Failed">Memory optimization failed</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.FailedMessage">Memory optimization failed\n\nDetails: {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.PromoteFailed">Elevation failed, please grant administrator access to use memory optimization</sys:String>
+
     <!-- Tools.Test.Clean -->
+
+    <sys:String x:Key="Tools.Test.Clean.Title">Clean game junk</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ToolTip">Clean PCL cache and MC logs, crash reports, and other junk files</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmTitle">Confirm cleanup</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">About to clean game logs, error reports, caches, and other files.\nWhile nobody should put important files there, are you sure you want to continue?\n\nPCL will restart automatically after cleanup.</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.Cleared">Cache cleared</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ClearedMessage">Cleaned {0} files!\nPCL will restart...</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.NoFiles">No files to clean!</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.WaitForDownload">Please wait for all downloads to complete before cleaning...</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.CloseGameFirst">Please close all running games first...</sys:String>
+
     <!-- Tools.Test.Shortcut -->
+
+    <sys:String x:Key="Tools.Test.Shortcut.Title">Create shortcut</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.ToolTip">Create a shortcut to the PCL Community Edition executable</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.SelectLocation">Select shortcut location</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.ConfirmMessage">This shortcut will not be automatically removed. Please remove it manually before deleting/moving the launcher.\n\n{0} location: {1}\n{2} location: {3}</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.Desktop">Desktop</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.StartMenu">Start menu</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.Created">Shortcut created on {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL Community Edition</sys:String>
+
     <!-- Tools.Test.Luck -->
+
+    <sys:String x:Key="Tools.Test.Luck.Title">Today's luck</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MsgboxTitle">Today's luck - {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MessageGood">Your luck value is: {0}! {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MessageBad">Your luck value is: {0}... {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating100">100! 100!
+Hidden theme... oh wait, CE probably doesn't have this...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating95">So close to 100...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating90">Overwhelmingly positive!</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating60">Not bad, not bad</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating40">Barely okay...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating30">Aww...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating10">No way!</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating0">(It's on a 0-100 scale)</sys:String>
+
     <!-- Tools.Test.Crash -->
+
+    <sys:String x:Key="Tools.Test.Crash.Title">Crash test</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ToolTip">Clicking this will crash the launcher directly. Don't click unless you know what you're doing. No issues or problems caused by this will be accepted, and related issues will be closed immediately.</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ConfirmTitle">Crash confirmation</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">You must have clicked wrong, confirm below if not</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ManualCrash">Manual crash</sys:String>
+
+    <!-- Tools.Test.LaunchCount -->
+
+    <sys:String x:Key="Tools.Test.LaunchCount.Title">View launch count</sys:String>
+    <sys:String x:Key="Tools.Test.LaunchCount.Message">PCL has launched games for you {0} times.</sys:String>
+
+    <!-- Tools.Test.Dependency -->
+
+    <sys:String x:Key="Tools.Test.Dependency.Title">Dependency check</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.Checking">Checking environment...</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">Missing required dependency "{0}"\n\nClick OK to open Microsoft Store</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.Later">Later</sys:String>
 
     <!-- Tools.GameLink -->
     <!-- Tools.GameLink.Agreement -->

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2671,7 +2671,19 @@
 
     <!-- Speed -->
 
-    <!-- ServerQuery -->
+    <!-- Tools.ServerQuery -->
+
+    <sys:String x:Key="Tools.ServerQuery.Address.Hint">Enter server address</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Action.Query">Query</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.State.Querying">Querying...</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.State.NoInfo">No server information</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Title.MinecraftServer">Minecraft server</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.UnableToConnect">Unable to connect: {0}</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.Timeout.Connect">Connection timeout</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.Timeout.ReadWrite">Read/Write timeout</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.InvalidResponse">Server returned invalid information</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.AddressTooLong">Server address too long</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">Server returned empty data packet</sys:String>
 
     <!-- Update -->
     <!-- Update.Task -->

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2487,7 +2487,7 @@
     <sys:String x:Key="Instance.Server.Card.CopyAddressFailed">Failed to copy server address</sys:String>
     <sys:String x:Key="Instance.Server.Card.EditFailed">Failed to edit server info: {0}</sys:String>
     <sys:String x:Key="Instance.Server.Card.RemoveConfirmTitle">Confirm server removal</sys:String>
-    <sys:String x:Key="Instance.Server.Card.RemoveConfirmMessage">Are you sure you want to remove server {0}?\n'{1}' will be removed from your list, including the in-game list, and cannot be recovered.</sys:String>
+    <sys:String x:Key="Instance.Server.Card.RemoveConfirmMessage">Are you sure you want to remove server {0}?&#xa;'{1}' will be removed from your list, including the in-game list, and cannot be recovered.</sys:String>
 
     <!-- Instance.Server -->
 
@@ -2714,14 +2714,14 @@
 
     <sys:String x:Key="Tools.Test.Memory.Title">Optimize memory</sys:String>
     <sys:String x:Key="Tools.Test.Memory.ToolTip">Memory optimization is a PCL CE exclusive, supercharged!&#xa;&#xa;Reduces physical memory usage by about 1/3, not just for MC!&#xa;If using an HDD, this may cause a brief period of severe lag.&#xa;Use the --memory flag to run memory optimization silently on launch.</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.Deprecated">Memory optimization will be deprecated.\n\nThis feature relies on undocumented Windows NT kernel function calls, may become unavailable in future versions, and could cause undefined behavior.\n\nIt is recommended to use Mem Reduct instead, a professional third-party memory management tool.\n\nContinue using memory optimization anyway?</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Deprecated">Memory optimization will be deprecated.&#xa;&#xa;This feature relies on undocumented Windows NT kernel function calls, may become unavailable in future versions, and could cause undefined behavior.&#xa;&#xa;It is recommended to use Mem Reduct instead, a professional third-party memory management tool.&#xa;&#xa;Continue using memory optimization anyway?</sys:String>
     <sys:String x:Key="Tools.Test.Memory.DeprecatedTitle">Feature deprecating</sys:String>
     <sys:String x:Key="Tools.Test.Memory.LearnMemReduct">Learn about Mem Reduct</sys:String>
     <sys:String x:Key="Tools.Test.Memory.Optimizing">Optimizing memory...</sys:String>
     <sys:String x:Key="Tools.Test.Memory.StillRunning">Memory optimization is still running, please wait!</sys:String>
     <sys:String x:Key="Tools.Test.Memory.Result">Memory optimization complete, freed {0}, available memory {1}</sys:String>
     <sys:String x:Key="Tools.Test.Memory.Failed">Memory optimization failed</sys:String>
-    <sys:String x:Key="Tools.Test.Memory.FailedMessage">Memory optimization failed\n\nDetails: {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.FailedMessage">Memory optimization failed&#xa;&#xa;Details: {0}</sys:String>
     <sys:String x:Key="Tools.Test.Memory.PromoteFailed">Elevation failed, please grant administrator access to use memory optimization</sys:String>
 
     <!-- Tools.Test.Clean -->
@@ -2729,9 +2729,9 @@
     <sys:String x:Key="Tools.Test.Clean.Title">Clean game junk</sys:String>
     <sys:String x:Key="Tools.Test.Clean.ToolTip">Clean PCL cache and MC logs, crash reports, and other junk files</sys:String>
     <sys:String x:Key="Tools.Test.Clean.ConfirmTitle">Confirm cleanup</sys:String>
-    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">About to clean game logs, error reports, caches, and other files.\nWhile nobody should put important files there, are you sure you want to continue?\n\nPCL will restart automatically after cleanup.</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">About to clean game logs, error reports, caches, and other files.&#xa;While nobody should put important files there, are you sure you want to continue?&#xa;&#xa;PCL will restart automatically after cleanup.</sys:String>
     <sys:String x:Key="Tools.Test.Clean.Cleared">Cache cleared</sys:String>
-    <sys:String x:Key="Tools.Test.Clean.ClearedMessage">Cleaned {0} files!\nPCL will restart...</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ClearedMessage">Cleaned {0} files!&#xa;PCL will restart...</sys:String>
     <sys:String x:Key="Tools.Test.Clean.NoFiles">No files to clean!</sys:String>
     <sys:String x:Key="Tools.Test.Clean.WaitForDownload">Please wait for all downloads to complete before cleaning...</sys:String>
     <sys:String x:Key="Tools.Test.Clean.CloseGameFirst">Please close all running games first...</sys:String>
@@ -2741,7 +2741,7 @@
     <sys:String x:Key="Tools.Test.Shortcut.Title">Create shortcut</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.ToolTip">Create a shortcut to the PCL Community Edition executable</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.SelectLocation">Select shortcut location</sys:String>
-    <sys:String x:Key="Tools.Test.Shortcut.ConfirmMessage">This shortcut will not be automatically removed. Please remove it manually before deleting/moving the launcher.\n\n{0} location: {1}\n{2} location: {3}</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.ConfirmMessage">This shortcut will not be automatically removed. Please remove it manually before deleting/moving the launcher.&#xa;&#xa;{0} location: {1}&#xa;{2} location: {3}</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.Desktop">Desktop</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.StartMenu">Start menu</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.Created">Shortcut created on {0}</sys:String>
@@ -2753,8 +2753,7 @@
     <sys:String x:Key="Tools.Test.Luck.MsgboxTitle">Today's luck - {0}</sys:String>
     <sys:String x:Key="Tools.Test.Luck.MessageGood">Your luck value is: {0}! {1}</sys:String>
     <sys:String x:Key="Tools.Test.Luck.MessageBad">Your luck value is: {0}... {1}</sys:String>
-    <sys:String x:Key="Tools.Test.Luck.Rating100">100! 100!
-Hidden theme... oh wait, CE probably doesn't have this...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating100">100! 100!&#xa;Hidden theme... oh wait, CE probably doesn't have this...</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating95">So close to 100...</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating90">Overwhelmingly positive!</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating60">Not bad, not bad</sys:String>
@@ -2780,19 +2779,105 @@ Hidden theme... oh wait, CE probably doesn't have this...</sys:String>
 
     <sys:String x:Key="Tools.Test.Dependency.Title">Dependency check</sys:String>
     <sys:String x:Key="Tools.Test.Dependency.Checking">Checking environment...</sys:String>
-    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">Missing required dependency "{0}"\n\nClick OK to open Microsoft Store</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">Missing required dependency "{0}"&#xa;&#xa;Click OK to open Microsoft Store</sys:String>
     <sys:String x:Key="Tools.Test.Dependency.Later">Later</sys:String>
 
     <!-- Tools.GameLink -->
-    <!-- Tools.GameLink.Agreement -->
-    <!-- Tools.GameLink.Natayark -->
-    <!-- Tools.GameLink.Nat -->
-    <!-- Tools.GameLink.Join -->
-    <!-- Tools.GameLink.Create -->
-    <!-- Tools.GameLink.Finish -->
-    <!-- Tools.GameLink.Player -->
-    <!-- Tools.GameLink.Member -->
-    <!-- Tools.GameLink.Error -->
+
+    <sys:String x:Key="Tools.GameLink.Loading.Creating">Creating lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Loading.DownloadingModule">Downloading lobby module</sys:String>
+    <sys:String x:Key="Tools.GameLink.Loading.ConnectingServer">Connecting to lobby server...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Title">PCL CE Lobby Terms &amp; Conditions</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Description">Listed below are the service documents and introductions used by PCL CE Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE Lobby Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network User Agreement &amp; Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I promise to strictly comply with relevant laws and regulations of Mainland China and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I promise to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE Lobby Privacy Policy and the Natayark OpenID Terms of Service.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Accept">I have read and agree</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Title">NAT Type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Test">Click to test</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Testing">Testing</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Failed">Test failed</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Result">UDP: {0}, TCP: {1}</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Account">Natayark Account</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Login">Click to login Natayark account</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginPrompt">PCL will open a login page. Please complete the login in your browser, then return to the launcher to continue.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginTitle">Login to Natayark Network</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Continue">Continue</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.BrowserContinue">Please continue in browser...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginComplete">Login completed</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutConfirm">Are you sure you want to log out?</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutTitle">Logout</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutComplete">Logged out!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Loading">Loading...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Abnormal">(Abnormal)</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenExpired">Natayark ID token expired, please login again</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.ProfileLoadFailed">Failed to load Natayark user data, please try to re-login in settings</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenInvalid">Naid Access Token invalid, try refreshing login</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.InvalidAuthCode">Naid authorization code invalid</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.AccountExpired">Natayark account info expired, please re-login in settings!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginFailed">Naid login failed, please try to login again in settings</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.FetchFailed">Failed to fetch info</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Important">Important</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Warning">Warning</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Notice">Notice</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Title">Join Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Description">1. Enter the lobby ID sent by your friend below and click [Join]&#x0A;2. Launch the game, select [Multiplayer], and join the lobby in LAN games</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Action">Join</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Paste">Paste</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Clear">Clear</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.IdHint">ID should look like: U/NNNN-AAAA-SSSS-EEEE</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.InvalidText">Invalid lobby ID, please check and re-enter</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Title">Create Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Description">1. After entering a world, select [Open to LAN] in the game menu&#x0A;2. Select this game instance below and click [Create]&#x0A;3. After the lobby is created, copy the lobby ID and send it to your friend</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Action">Create</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.ManualInput">Manual Input</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.EnterPort">Enter port</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.NoWorld">Please select a world to play together!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.NotMcPort">This doesn't seem to be an MC service port...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Report">Report violation</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Terms">Natayark Network User Agreement &amp; Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Privacy">Lobby Privacy Policy</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Disable">Disable Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Faq">FAQ</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Friends">Links: </sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.EasyTier">EasyTier Official Website</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.InfoTitle">Lobby Info</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">Connection Status</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Checking">Checking</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.PingToHost">Ping to Lobby Host</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.LobbyId">Lobby ID</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">Connection Type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Connecting">Connecting</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.UserName">Username</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.UserType">User Type</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Actions">Lobby Actions</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyVirtualIp">Copy Virtual IP</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyLobbyId">Copy Lobby ID</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Exit">Exit Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Connected">Connected</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Unavailable">Unavailable</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Host">Host</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Guest">Guest</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CloseLobby">Close Lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoTitle">Player {0} Details</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoMessage">Username: {0}&#x0A;Client Identifier: {1}&#x0A;&#x0A;This data is for reference only. Actual gameplay experience shall prevail.&#x0A;&#x0A;To learn about NAT types and how they affect your lobby experience, please refer to the FAQ section on the left.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.Host">[Host]</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListLoading">Lobby Members (Retrieving information)</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListCount">Lobby Members ({0} total)</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.RevokeConfirm">Are you sure you want to revoke the lobby agreement authorization?</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.RevokeTitle">Revoke Authorization</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.Disabled">Lobby feature has been disabled!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessage">Are you sure you want to exit the lobby?</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">Confirm Exit</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.HostWarning">Since you are the lobby host, exiting will automatically disband this lobby.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.Disbanded">The lobby has been automatically disbanded because you closed the MC instance in the lobby.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">Lobby Disbanded</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Message">Lobby host's game address: {0}&#x0A;Note: IP connection is only recommended when the lobby broadcast doesn't appear in the MC multiplayer list! IP connection may require a licensed account.</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Title">Copy IP</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Back">Back</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.ServerExit">An error occurred while exiting the server!</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.UpdateRequired">Please update to the latest PCL CE to use the lobby</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.ConnectFailed">Failed to connect to lobby server</sys:String>
 
     <!-- Speed -->
 
@@ -2875,5 +2960,59 @@ Hidden theme... oh wait, CE probably doesn't have this...</sys:String>
     <sys:String x:Key="Watcher.Kill.Timeout">Force kill failed: process exit timeout</sys:String>
     <sys:String x:Key="Watcher.Kill.Success">Minecraft process forcefully killed</sys:String>
     <sys:String x:Key="Watcher.Kill.Failed">Failed to force kill Minecraft process</sys:String>
+
+    <!-- Link -->
+
+    <sys:String x:Key="Link.Nat.Type.Open">Open</sys:String>
+    <sys:String x:Key="Link.Nat.Type.FullCone">Moderate (full cone)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Restricted">Moderate (restricted)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.PortRestricted">Moderate (port restricted)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.SymmetricEasy">Strict (loose symmetric)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Symmetric">Strict (symmetric)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.SymmetricFirewall">Strict (symmetric firewall)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.UdpBlocked">Strict (UDP blocked)</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Unknown">Unknown</sys:String>
+    <sys:String x:Key="Link.Connection.Local">Local</sys:String>
+    <sys:String x:Key="Link.Connection.P2P">P2P</sys:String>
+    <sys:String x:Key="Link.Connection.Relay">Relay</sys:String>
+    <sys:String x:Key="Link.Connection.Unknown">Unknown</sys:String>
+    <sys:String x:Key="Link.Quality.Good">Good</sys:String>
+    <sys:String x:Key="Link.Quality.Normal">Normal</sys:String>
+    <sys:String x:Key="Link.Quality.Poor">Poor</sys:String>
+    <sys:String x:Key="Link.Quality.GoodDescription">Current network environment will not affect connection experience&#x0A;This environment is suitable as lobby host</sys:String>
+    <sys:String x:Key="Link.Quality.NormalDescription">Current network environment may affect your connection experience</sys:String>
+    <sys:String x:Key="Link.Quality.PoorDescription">Some router and firewall settings may affect your connection experience</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenFetchEmpty">Failed to get AccessToken and RefreshToken, response is empty</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenParseFailed">Failed to get AccessToken and RefreshToken, unable to parse response</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoFetchEmpty">Failed to get Natayark user info, response is empty</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoParseFailed">Failed to get Natayark user info, unable to parse response</sys:String>
+    <sys:String x:Key="Link.Lobby.InitFailed">Lobby service initialization failed. Please check your network.</sys:String>
+    <sys:String x:Key="Link.Lobby.LoginRequired">Please log in to your Natayark ID first!</sys:String>
+    <sys:String x:Key="Link.Lobby.CreateRoomFailed">An error occurred while creating the room. Please check logs and report to the developer!</sys:String>
+    <sys:String x:Key="Link.Lobby.CreateLobbyFailed">Failed to create lobby. Please check logs or report to the developer.</sys:String>
+    <sys:String x:Key="Link.Lobby.JoinFailed">Failed to join lobby. It may not exist or has been disbanded.</sys:String>
+    <sys:String x:Key="Link.Lobby.InvalidCodeFormat">Invalid lobby code format. Please check and try again!</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE Lobby</sys:String>
+    <sys:String x:Key="Link.Lobby.UnsupportedType">Unsupported lobby type: {0}</sys:String>
+    <sys:String x:Key="Link.Mod.LobbyUnavailable">Lobby is currently unavailable. Please try again later.</sys:String>
+    <sys:String x:Key="Link.Mod.InvalidPlayerId">MC player ID cannot contain separator (|)!</sys:String>
+    <sys:String x:Key="Link.Mod.LoginFirst">Please go to multiplayer settings and log in to Natayark Network first!</sys:String>
+    <sys:String x:Key="Link.Mod.ReLoginRequired">Please re-login to your Natayark Network account and try again!</sys:String>
+    <sys:String x:Key="Link.Mod.NaidFetchFailed">Failed to fetch Natayark ID info</sys:String>
+    <sys:String x:Key="Link.Mod.RealNameRequired">Please complete real-name verification at the Natayark Account Center first!</sys:String>
+    <sys:String x:Key="Link.Mod.AccountBanned">Your Natayark Network account status is abnormal, may be banned!</sys:String>
+    <sys:String x:Key="Link.Mod.UsernameOrLogin">Please set a username in settings, or log in to Natayark Network first!</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingDeps">Downloading multiplayer dependencies, please wait...</sys:String>
+    <sys:String x:Key="Link.Mod.EasyTierNotReady">EasyTier has not finished downloading. Please wait and try again!</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingEasyTier">Downloading EasyTier, please wait...</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadComplete">Multiplayer components downloaded!</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadEasyTierFailed">Failed to download EasyTier dependencies. Please check your network.</sys:String>
+    <sys:String x:Key="Link.Mod.Task.DownloadEasyTier">Download EasyTier</sys:String>
+    <sys:String x:Key="Link.Mod.Task.ExtractFiles">Extract files</sys:String>
+    <sys:String x:Key="Link.Mod.Task.CleanCache">Clean cache and redundant components</sys:String>
+    <sys:String x:Key="Link.Mod.Task.RefreshUi">Refresh UI</sys:String>
+    <sys:String x:Key="Link.Mod.Task.InitLobby">Initialize lobby</sys:String>
+    <sys:String x:Key="Link.Mod.Task.InitLobbyUi">Initialize lobby UI</sys:String>
+    <sys:String x:Key="Link.Mod.Task.FetchAnnouncement">Fetch lobby announcement</sys:String>
 
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2671,6 +2671,13 @@
 
     <!-- Speed -->
 
+    <sys:String x:Key="Speed.Progress.Total">总进度</sys:String>
+    <sys:String x:Key="Speed.Progress.Speed">下载速度</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingFiles">剩余文件</sys:String>
+    <sys:String x:Key="Speed.Progress.RemainingThreads">剩余线程</sys:String>
+    <sys:String x:Key="Speed.Error.ClickToCopy">单击复制错误详情</sys:String>
+    <sys:String x:Key="Speed.Error.Copied">已复制错误详情！</sys:String>
+
     <!-- Tools.ServerQuery -->
 
     <sys:String x:Key="Tools.ServerQuery.Address.Hint">输入服务器地址</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2745,7 +2745,7 @@
     <sys:String x:Key="Tools.Test.Shortcut.Desktop">桌面</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.StartMenu">开始菜单</sys:String>
     <sys:String x:Key="Tools.Test.Shortcut.Created">已在{0}创建快捷方式</sys:String>
-    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL 社区版</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL 社区版{0}</sys:String>
 
     <!-- Tools.Test.Luck -->
 
@@ -2790,7 +2790,9 @@
     <sys:String x:Key="Tools.GameLink.Agreement.Title">PCL CE 联机大厅说明与条款</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Description">此处列出了 PCL CE 大厅使用的相关服务文档及介绍</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE 大厅相关隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">了解 PCL CE 如何处理您的个人信息</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network 用户协议与隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">查看 Natayark OpenID 服务条款</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Body">使用大厅功能即代表你同意下列条款：&#x0A;&#x0A;我承诺严格遵守中国大陆相关法律法规，不会将大厅功能用于违法违规用途。&#x0A;我承诺使用大厅功能带来的一切风险自行承担。&#x0A;我已知晓并同意 PCL CE 收集经处理的本机识别码、Natayark ID 与其他信息并在必要时提供给执法部门。&#x0A;为保护未成年人个人信息，使用联机大厅前，我确认我已满十四周岁。&#x0A;&#x0A;另外，你还需要同意 PCL CE 大厅相关隐私政策及《Natayark OpenID 服务条款》。</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Accept">我已阅读并同意</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Title">NAT 类型</sys:String>
@@ -2820,6 +2822,8 @@
     <sys:String x:Key="Tools.GameLink.Announcement.Important">重要</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Warning">注意</sys:String>
     <sys:String x:Key="Tools.GameLink.Announcement.Notice">提示</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Format">[{0}] {1}</sys:String>
+    <sys:String x:Key="Tools.GameLink.EasyTierVersion">联机双方目前使用的启动器版本不同，这可能会导致一些连接问题&#x0A;强烈建议双方升级到最新版本后再继续联机</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Title">加入大厅</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Description">1、在下方输入朋友发送给你的大厅编号，单击【加入】&#x0A;2、启动游戏，选择【多人游戏】，在局域网游戏中加入大厅</sys:String>
     <sys:String x:Key="Tools.GameLink.Join.Action">加入</sys:String>
@@ -2845,6 +2849,7 @@
     <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">连接状况</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Checking">检测中</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.PingToHost">与大厅创建者的延迟</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.PingMs">{0}ms</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.LobbyId">大厅编号</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">连接方式</sys:String>
     <sys:String x:Key="Tools.GameLink.Finish.Connecting">连接中</sys:String>
@@ -2862,6 +2867,7 @@
     <sys:String x:Key="Tools.GameLink.Player.InfoTitle">玩家 {0} 的详细信息</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.InfoMessage">用户名：{0}&#x0A;联机协议客户端标识：{1}&#x0A;&#x0A;此处数据仅供参考，请以实际游玩体验为准。&#x0A;&#x0A;若想了解 NAT 类型与其如何影响联机体验，请前往界面左侧的常见问题一栏。</sys:String>
     <sys:String x:Key="Tools.GameLink.Player.Host">[主机]</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.Details">{0} {1}</sys:String>
     <sys:String x:Key="Tools.GameLink.Member.ListLoading">大厅成员列表（正在获取信息）</sys:String>
     <sys:String x:Key="Tools.GameLink.Member.ListCount">大厅成员列表（共 {0} 人）</sys:String>
     <sys:String x:Key="Tools.GameLink.Eula.RevokeConfirm">你确定要撤销联机协议授权吗？</sys:String>
@@ -2870,6 +2876,7 @@
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessage">你确定要退出大厅吗？</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">确认退出</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.HostWarning">由于你是大厅创建者，退出后此大厅将会自动解散。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessageWithHost">你确定要退出大厅吗？&#x0A;由于你是大厅创建者，退出后此大厅将会自动解散。</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.Disbanded">由于你关闭了联机中的 MC 实例，大厅已自动解散。</sys:String>
     <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">大厅已解散</sys:String>
     <sys:String x:Key="Tools.GameLink.CopyIp.Message">大厅创建者的游戏地址：{0}&#x0A;注意：仅推荐在 MC 多人游戏列表不显示大厅广播时使用 IP 连接！通过 IP 连接将可能要求使用正版档案。</sys:String>
@@ -2901,8 +2908,12 @@
     <sys:String x:Key="Tools.ServerQuery.Error.InvalidResponse">服务器返回了错误的信息</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.AddressTooLong">服务器地址过长</sys:String>
     <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">服务器返回了空数据包</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.StaleConnection">服务器在返回状态后提前断开连接，未返回 pong 数据包，无法计算延迟。</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.IncompleteConnection">服务器在返回完整状态数据包前提前断开连接。</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.PongDataLength">Pong 数据长度必须为 8 字节</sys:String>
 
     <!-- Update -->
+
     <sys:String x:Key="Update.Action">更新</sys:String>
     <sys:String x:Key="Update.Check.Failed">无法获取最新版本信息，请检查网络连接</sys:String>
     <sys:String x:Key="Update.Available">启动器有新版本可用（{0} -&gt; {1}）&#x0A;是否立即更新？</sys:String>
@@ -2945,6 +2956,11 @@
     <sys:String x:Key="LogPage.Action.KillProcess">结束进程</sys:String>
     <sys:String x:Key="LogPage.Action.ExportStack">导出运行栈</sys:String>
     <sys:String x:Key="LogPage.Action.GameClosed">已关闭游戏 {0}！</sys:String>
+    <sys:String x:Key="LogPage.Level.Debug">Debug</sys:String>
+    <sys:String x:Key="LogPage.Level.Info">Info</sys:String>
+    <sys:String x:Key="LogPage.Level.Warn">Warn</sys:String>
+    <sys:String x:Key="LogPage.Level.Error">Error</sys:String>
+    <sys:String x:Key="LogPage.Level.Fatal">Fatal</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Title">最大行数</sys:String>
     <sys:String x:Key="LogPage.MaxLines.ToolTip">实时日志功能中最大显示行数，超过该值会自动删除旧的日志。</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Unlimited">无限制</sys:String>
@@ -3018,8 +3034,10 @@
     <sys:String x:Key="Link.Lobby.CreateLobbyFailed">创建大厅失败，请检查日志或向开发者反馈。</sys:String>
     <sys:String x:Key="Link.Lobby.JoinFailed">加入大厅失败，可能是大厅不存在或已被解散</sys:String>
     <sys:String x:Key="Link.Lobby.InvalidCodeFormat">大厅编号格式不正确，请检查后再试！</sys:String>
-    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE 大厅</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE 大厅{0}</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdDesc"> - {0}</sys:String>
     <sys:String x:Key="Link.Lobby.UnsupportedType">不支持的大厅类型: {0}</sys:String>
+    <sys:String x:Key="Link.Lobby.WorldNameFormat">{0} / {1} ({2})</sys:String>
     <sys:String x:Key="Link.Mod.LobbyUnavailable">大厅功能暂不可用，请稍后再试</sys:String>
     <sys:String x:Key="Link.Mod.InvalidPlayerId">MC 玩家 ID 不可包含分隔符 (|) ！</sys:String>
     <sys:String x:Key="Link.Mod.LoginFirst">请先前往联机设置并登录至 Natayark Network 再进行联机！</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2647,16 +2647,141 @@
     <sys:String x:Key="Tools.Help.Search.Similarity">相似度：{0}  |  {1}</sys:String>
 
     <!-- Tools.Test -->
+
+    <sys:String x:Key="Tools.Test.Title">百宝箱</sys:String>
+    <sys:String x:Key="Tools.Test.CeNotice">为便于维护，社区版中不包含百宝箱功能……</sys:String>
+
     <!-- Tools.Test.CustomDownload -->
+
+    <sys:String x:Key="Tools.Test.CustomDownload.Title">下载自定义文件</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Description">使用 PCL 的高速多线程下载引擎下载任意文件。请注意，部分网站（例如百度网盘）可能会报错 (403) 已禁止，无法正常下载。</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Url">下载地址</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.UserAgent">User-Agent</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.SaveTo">保存到</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Select">选择</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.SelectLocation">选择文件保存位置</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.FileName">文件名</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Start">开始下载</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.LoaderName">自定义下载文件：{0} </sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.LoaderTitle">自定义下载 ({0}) </sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Finished">{0}完成！</sys:String>
+    <sys:String x:Key="Tools.Test.CustomDownload.Aborted">{0}已取消！</sys:String>
+
     <!-- Tools.Test.Skin -->
+
+    <sys:String x:Key="Tools.Test.Skin.Title">下载正版玩家的皮肤</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.PlayerName">正版玩家名</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Save">保存皮肤</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Fetching">正在获取皮肤...</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.InvalidId">这不是一个有效的 ID...</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.TooFrequent">获取皮肤太过频繁，请 5 分钟之后再试！</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.Saved">玩家 {0} 的皮肤已保存！</sys:String>
+    <sys:String x:Key="Tools.Test.Skin.FileFilter">皮肤图片文件(*.png)|*.png</sys:String>
+
     <!-- Tools.Test.ServerQuery -->
+
+    <sys:String x:Key="Tools.Test.ServerQuery.Title">瞅眼服务器</sys:String>
+
     <!-- Tools.Test.Achievement -->
+
+    <sys:String x:Key="Tools.Test.Achievement.Title">自定义成就图片生成器 (仅支持英文)</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.ItemId">物品名（ID）</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Name">成就名</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Line1">第一行</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Line2">第二行（可选）</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Preview">预览成就图像</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Save">保存图片</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.InvalidId">请输入正确的物品 ID！</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.Saved">自定义成就图片已保存！</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG 图片|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FetchFailed">获取成就图片失败，请检查文字是否包含特殊字符</sys:String>
+
     <!-- Tools.Test.Avatar -->
+
+    <sys:String x:Key="Tools.Test.Avatar.Title">皮肤头像生成器</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Size">头像大小：</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectSkin">选择皮肤</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectSkinFile">选择皮肤文件</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.FileFilter">图像文件(*.png)|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Save">保存头像</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.SelectFirst">请先选择皮肤！</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.InvalidSize">图片的大小不正确！请确认你选择了正确的文件！</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Generated">头像生成成功！</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.GenerateFailed">生成头像失败：{0}</sys:String>
+    <sys:String x:Key="Tools.Test.Avatar.Saved">头像保存成功！</sys:String>
+
     <!-- Tools.Test.Memory -->
+
+    <sys:String x:Key="Tools.Test.Memory.Title">内存优化</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.ToolTip">内存优化为 PCL CE 特供版，效果加强！&#xa;&#xa;将物理内存占用降低约 1/3，不仅限于 MC！&#xa;如果使用机械硬盘，这可能会导致一小段时间的严重卡顿。&#xa;使用 --memory 参数启动 PCL 可以静默执行内存优化。</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Deprecated">内存优化功能即将被废弃。\n\n该功能依赖未文档化的 Windows NT 内核函数调用，可能在未来版本中不可用，且存在引发未定义行为的可能。\n\n建议使用 Mem Reduct 替代，这是一个专业的第三方内存管理工具。\n\n是否仍然继续使用内存优化？</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.DeprecatedTitle">功能即将废弃</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.LearnMemReduct">了解 Mem Reduct</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Optimizing">正在进行内存优化</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.StillRunning">内存优化尚未结束，请稍等！</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Result">内存优化结束，共优化 {0}，目前可用内存 {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.Failed">内存优化失败</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.FailedMessage">内存优化失败\n\n详细信息：{0}</sys:String>
+    <sys:String x:Key="Tools.Test.Memory.PromoteFailed">提权进程启动失败，请允许管理员权限以使用内存优化</sys:String>
+
     <!-- Tools.Test.Clean -->
+
+    <sys:String x:Key="Tools.Test.Clean.Title">清理游戏垃圾</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ToolTip">清理 PCL 的缓存与 MC 的日志、崩溃报告等垃圾文件</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmTitle">清理确认</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ConfirmMessage">即将清理游戏日志、错误报告、缓存等文件。\n虽然应该没人往这些地方放重要文件，但还是问一下，是否确认继续？\n\n在完成清理后，PCL 将自动重启。</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.Cleared">缓存已清理</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.ClearedMessage">清理了 {0} 个文件！\nPCL 即将自动重启……</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.NoFiles">没有找到任何可以清理的文件！</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.WaitForDownload">请在所有下载任务完成后再来清理吧……</sys:String>
+    <sys:String x:Key="Tools.Test.Clean.CloseGameFirst">请先关闭所有运行中的游戏……</sys:String>
+
     <!-- Tools.Test.Shortcut -->
+
+    <sys:String x:Key="Tools.Test.Shortcut.Title">创建快捷方式</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.ToolTip">创建一个指向 PCL 社区版可执行文件的快捷方式</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.SelectLocation">选择快捷方式位置</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.ConfirmMessage">这个快捷方式不会自动移除，在删除/移动启动器前请手动移除快捷方式。\n\n{0}位置: {1}\n{2}位置: {3}</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.Desktop">桌面</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.StartMenu">开始菜单</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.Created">已在{0}创建快捷方式</sys:String>
+    <sys:String x:Key="Tools.Test.Shortcut.FileName">PCL 社区版</sys:String>
+
     <!-- Tools.Test.Luck -->
+
+    <sys:String x:Key="Tools.Test.Luck.Title">今日人品</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MsgboxTitle">今日人品 - {0}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MessageGood">你今天的人品值是：{0}！{1}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.MessageBad">你今天的人品值是：{0}... {1}</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating100">100！100！
+隐藏主题 欧皇…… 不对，社区版应该没有这玩意……</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating95">差一点就到100了呢...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating90">好评如潮！</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating60">还行啦，还行啦</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating40">勉强还行吧...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating30">呜...</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating10">不会吧！</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating0">（是百分制哦）</sys:String>
+
     <!-- Tools.Test.Crash -->
+
+    <sys:String x:Key="Tools.Test.Crash.Title">崩溃测试</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ToolTip">点这个按钮会让启动器直接崩掉，没事别点，造成的一切问题均不受理，相关 issue 会被直接关闭</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ConfirmTitle">崩溃确认</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">你一定是点错了，如果没错请在下方确认</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ManualCrash">手动崩溃</sys:String>
+
+    <!-- Tools.Test.LaunchCount -->
+
+    <sys:String x:Key="Tools.Test.LaunchCount.Title">查看启动计数</sys:String>
+    <sys:String x:Key="Tools.Test.LaunchCount.Message">PCL 已经为你启动了 {0} 次游戏了。</sys:String>
+
+    <!-- Tools.Test.Dependency -->
+
+    <sys:String x:Key="Tools.Test.Dependency.Title">依赖检查</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.Checking">开始环境检查……</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.MissingMessage">当前系统环境缺失软件运行所需依赖"{0}"\n\n点击确定打开微软应用商店安装</sys:String>
+    <sys:String x:Key="Tools.Test.Dependency.Later">稍后</sys:String>
 
     <!-- Tools.GameLink -->
     <!-- Tools.GameLink.Agreement -->

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2630,7 +2630,7 @@
 
     <!-- Tools -->
 
-    <sys:String x:Key="Tools.Left.Online">联机</sys:String>
+    <sys:String x:Key="Tools.Left.Multiplayer">联机</sys:String>
     <sys:String x:Key="Tools.Left.Lobby">大厅</sys:String>
     <sys:String x:Key="Tools.Left.Utilities">奇妙小工具</sys:String>
     <sys:String x:Key="Tools.Left.Utilities.Title">百宝箱</sys:String>
@@ -2693,7 +2693,7 @@
     <sys:String x:Key="Tools.Test.Achievement.Save">保存图片</sys:String>
     <sys:String x:Key="Tools.Test.Achievement.InvalidId">请输入正确的物品 ID！</sys:String>
     <sys:String x:Key="Tools.Test.Achievement.Saved">自定义成就图片已保存！</sys:String>
-    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG 图片|*.png</sys:String>
+    <sys:String x:Key="Tools.Test.Achievement.FileFilter">PNG 图片 (*.png)|*.png</sys:String>
     <sys:String x:Key="Tools.Test.Achievement.FetchFailed">获取成就图片失败，请检查文字是否包含特殊字符</sys:String>
 
     <!-- Tools.Test.Avatar -->
@@ -2791,7 +2791,7 @@
     <sys:String x:Key="Tools.GameLink.Agreement.Description">此处列出了 PCL CE 大厅使用的相关服务文档及介绍</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE 大厅相关隐私政策</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">了解 PCL CE 如何处理您的个人信息</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network 用户协议与隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark OpenID 服务条款</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">查看 Natayark OpenID 服务条款</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Body">使用大厅功能即代表你同意下列条款：&#x0A;&#x0A;我承诺严格遵守中国大陆相关法律法规，不会将大厅功能用于违法违规用途。&#x0A;我承诺使用大厅功能带来的一切风险自行承担。&#x0A;我已知晓并同意 PCL CE 收集经处理的本机识别码、Natayark ID 与其他信息并在必要时提供给执法部门。&#x0A;为保护未成年人个人信息，使用联机大厅前，我确认我已满十四周岁。&#x0A;&#x0A;另外，你还需要同意 PCL CE 大厅相关隐私政策及《Natayark OpenID 服务条款》。</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Accept">我已阅读并同意</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2698,7 +2698,79 @@
     <!-- Update.CommunityNotice -->
 
     <!-- LogPage -->
+
+    <!-- LogPage.Title -->
+    <sys:String x:Key="LogPage.Title">实时日志</sys:String>
+
+    <!-- LogPage.Empty -->
+    <sys:String x:Key="LogPage.Empty.Title">无实时日志</sys:String>
+    <sys:String x:Key="LogPage.Empty.Description">请点击 实例设置 → 概览 → 测试游戏 以显示游戏的实时日志。</sys:String>
+
+    <!-- LogPage.Left -->
+    <sys:String x:Key="LogPage.Left.InstancesTitle">测试实例列表</sys:String>
+
     <!-- LogPage.Action -->
+    <sys:String x:Key="LogPage.Action.Scroll">滚动</sys:String>
+    <sys:String x:Key="LogPage.Action.Export">导出</sys:String>
+    <sys:String x:Key="LogPage.Action.Clear">清空</sys:String>
+    <sys:String x:Key="LogPage.Action.KillProcess">结束进程</sys:String>
+    <sys:String x:Key="LogPage.Action.ExportStack">导出运行栈</sys:String>
+    <sys:String x:Key="LogPage.Action.GameClosed">已关闭游戏 {0}！</sys:String>
+
+    <!-- LogPage.MaxLines -->
+    <sys:String x:Key="LogPage.MaxLines.Title">最大行数</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.ToolTip">实时日志功能中最大显示行数，超过该值会自动删除旧的日志。</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Unlimited">无限制</sys:String>
+    <sys:String x:Key="LogPage.MaxLines.Hint">实时日志默认只保留 {0} 行，你可以在 实时日志行数 设置中修改！</sys:String>
+
     <!-- LogPage.Export -->
+    <sys:String x:Key="LogPage.Export.SelectLocation">选择导出位置</sys:String>
+    <sys:String x:Key="LogPage.Export.Success">日志已导出！</sys:String>
+
+    <!-- LogPage.Export.GameLog -->
+    <sys:String x:Key="LogPage.Export.GameLog.FileName">游戏日志 - {0}.log</sys:String>
+    <sys:String x:Key="LogPage.Export.GameLog.Filter">游戏日志(*.log)|*.log</sys:String>
+
+    <!-- LogPage.ExportStack -->
+    <sys:String x:Key="LogPage.ExportStack.FileName">游戏运行栈 - {0}.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Filter">游戏运行栈(*.log)|*.log</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Progress">正在导出运行栈，请稍等（可能需要 15 秒 ~ 1 分钟）</sys:String>
+    <sys:String x:Key="LogPage.ExportStack.Success">运行栈已导出！</sys:String>
+
+    <!-- Watcher -->
+    <sys:String x:Key="Watcher.Start">开始 Minecraft 日志监控</sys:String>
+    <sys:String x:Key="Watcher.Exited">Minecraft 日志监控已退出</sys:String>
+    <sys:String x:Key="Watcher.ProcessExited">Minecraft 已退出，返回值：{0}</sys:String>
+    <sys:String x:Key="Watcher.LoadComplete">Minecraft 加载已完成</sys:String>
+    <sys:String x:Key="Watcher.WindowLoaded">Minecraft 窗口已加载：{0}（{1}）</sys:String>
+    <sys:String x:Key="Watcher.FmlWindowLoaded">FML 窗口已加载：{0}（{1}）</sys:String>
+    <sys:String x:Key="Watcher.WindowMaximized">已最大化 Minecraft 窗口：{0}</sys:String>
+    <sys:String x:Key="Watcher.SecurityBlocked">由于反作弊或安全软件拦截，PCL 无法操作游戏窗口</sys:String>
+
+    <!-- Watcher.Progress -->
+    <sys:String x:Key="Watcher.Progress.LogAppeared">日志 1/5：已出现日志输出</sys:String>
+    <sys:String x:Key="Watcher.Progress.UserSet">日志 2/5：游戏用户已设置</sys:String>
+    <sys:String x:Key="Watcher.Progress.LwjglConfirmed">日志 3/5：LWJGL 版本已确认</sys:String>
+    <sys:String x:Key="Watcher.Progress.OpenAlLoaded">日志 4/5：OpenAL 已加载</sys:String>
+    <sys:String x:Key="Watcher.Progress.TexturesLoaded">日志 5/5：材质已加载</sys:String>
+
+    <!-- Watcher.Log -->
+    <sys:String x:Key="Watcher.Log.CloseDetected">识别为关闭的 Log：{0}</sys:String>
+    <sys:String x:Key="Watcher.Log.CrashDetected">识别为崩溃的 Log：{0}</sys:String>
+
+    <!-- Watcher.Crash -->
+    <sys:String x:Key="Watcher.Crash.Suspected">Minecraft 尚未加载完成，可能已崩溃</sys:String>
+    <sys:String x:Key="Watcher.Crash.AbnormalExit">Minecraft 返回值异常，可能已崩溃</sys:String>
+    <sys:String x:Key="Watcher.Crash.Detected">Minecraft 已崩溃，将在 2 秒后开始崩溃分析</sys:String>
+    <sys:String x:Key="Watcher.Crash.AnalysisStart">崩溃分析开始</sys:String>
+    <sys:String x:Key="Watcher.Crash.Hint">检测到 Minecraft 出现错误，错误分析已开始……</sys:String>
+
+    <!-- Watcher.Kill -->
+    <sys:String x:Key="Watcher.Kill.Attempt">尝试强制结束 Minecraft 进程</sys:String>
+    <sys:String x:Key="Watcher.Kill.TaskkillAttempt">进程仍未退出，尝试使用 taskkill.exe</sys:String>
+    <sys:String x:Key="Watcher.Kill.TaskkillResult">执行 taskkill.exe 结果：{0}</sys:String>
+    <sys:String x:Key="Watcher.Kill.Timeout">强制结束 Minecraft 进程失败：等待进程退出超时</sys:String>
+    <sys:String x:Key="Watcher.Kill.Success">已强制结束 Minecraft 进程</sys:String>
+    <sys:String x:Key="Watcher.Kill.Failed">强制结束 Minecraft 进程失败</sys:String>
 
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2671,7 +2671,19 @@
 
     <!-- Speed -->
 
-    <!-- ServerQuery -->
+    <!-- Tools.ServerQuery -->
+
+    <sys:String x:Key="Tools.ServerQuery.Address.Hint">输入服务器地址</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Action.Query">查询</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.State.Querying">查询中...</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.State.NoInfo">未返回服务器信息</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Title.MinecraftServer">Minecraft 服务器</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.UnableToConnect">无法连接: {0}</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.Timeout.Connect">连接超时</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.Timeout.ReadWrite">数据读写超时</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.InvalidResponse">服务器返回了错误的信息</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.AddressTooLong">服务器地址过长</sys:String>
+    <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">服务器返回了空数据包</sys:String>
 
     <!-- Update -->
     <!-- Update.Task -->

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2753,8 +2753,7 @@
     <sys:String x:Key="Tools.Test.Luck.MsgboxTitle">今日人品 - {0}</sys:String>
     <sys:String x:Key="Tools.Test.Luck.MessageGood">你今天的人品值是：{0}！{1}</sys:String>
     <sys:String x:Key="Tools.Test.Luck.MessageBad">你今天的人品值是：{0}... {1}</sys:String>
-    <sys:String x:Key="Tools.Test.Luck.Rating100">100！100！
-隐藏主题 欧皇…… 不对，社区版应该没有这玩意……</sys:String>
+    <sys:String x:Key="Tools.Test.Luck.Rating100">100！100！&#xa;隐藏主题 欧皇…… 不对，社区版应该没有这玩意……</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating95">差一点就到100了呢...</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating90">好评如潮！</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating60">还行啦，还行啦</sys:String>
@@ -2784,15 +2783,101 @@
     <sys:String x:Key="Tools.Test.Dependency.Later">稍后</sys:String>
 
     <!-- Tools.GameLink -->
-    <!-- Tools.GameLink.Agreement -->
-    <!-- Tools.GameLink.Natayark -->
-    <!-- Tools.GameLink.Nat -->
-    <!-- Tools.GameLink.Join -->
-    <!-- Tools.GameLink.Create -->
-    <!-- Tools.GameLink.Finish -->
-    <!-- Tools.GameLink.Player -->
-    <!-- Tools.GameLink.Member -->
-    <!-- Tools.GameLink.Error -->
+
+    <sys:String x:Key="Tools.GameLink.Loading.Creating">正在创建大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Loading.DownloadingModule">下载联机模块中……</sys:String>
+    <sys:String x:Key="Tools.GameLink.Loading.ConnectingServer">正在连接到大厅服务器...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Title">PCL CE 联机大厅说明与条款</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Description">此处列出了 PCL CE 大厅使用的相关服务文档及介绍</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicy">PCL CE 大厅相关隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark Network 用户协议与隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">使用大厅功能即代表你同意下列条款：&#x0A;&#x0A;我承诺严格遵守中国大陆相关法律法规，不会将大厅功能用于违法违规用途。&#x0A;我承诺使用大厅功能带来的一切风险自行承担。&#x0A;我已知晓并同意 PCL CE 收集经处理的本机识别码、Natayark ID 与其他信息并在必要时提供给执法部门。&#x0A;为保护未成年人个人信息，使用联机大厅前，我确认我已满十四周岁。&#x0A;&#x0A;另外，你还需要同意 PCL CE 大厅相关隐私政策及《Natayark OpenID 服务条款》。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Accept">我已阅读并同意</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Title">NAT 类型</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Test">点击测试</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Testing">正在测试</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Failed">测试失败</sys:String>
+    <sys:String x:Key="Tools.GameLink.Nat.Result">UDP: {0}, TCP: {1}</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Account">Natayark 账户</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Login">点击登录 Natayark 账户</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginPrompt">PCL 将会打开一个登录页面，请在浏览器中完成登录操作，然后回到启动器继续操作。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginTitle">登录至 Natayark Network</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Continue">继续</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.BrowserContinue">请在浏览器中继续...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginComplete">已完成登录操作</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutConfirm">你确定要退出登录吗？</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutTitle">退出登录</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LogoutComplete">已退出登录！</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Loading">正在加载...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.Abnormal">（异常）</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenExpired">Natayark ID 令牌已过期，请重新登录</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.ProfileLoadFailed">获取 Natayark 用户数据失败，请尝试前往设置重新登录</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.TokenInvalid">Naid Access Token 无效，尝试刷新登录</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.InvalidAuthCode">Naid 验证代码无效</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.AccountExpired">Natayark 账号信息已过期，请前往设置重新登录！</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.LoginFailed">Naid 登录失败，请尝试前往设置重新登录</sys:String>
+    <sys:String x:Key="Tools.GameLink.Natayark.FetchFailed">获取信息失败</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Important">重要</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Warning">注意</sys:String>
+    <sys:String x:Key="Tools.GameLink.Announcement.Notice">提示</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Title">加入大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Description">1、在下方输入朋友发送给你的大厅编号，单击【加入】&#x0A;2、启动游戏，选择【多人游戏】，在局域网游戏中加入大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Action">加入</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Paste">粘贴</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.Clear">清除</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.IdHint">编号应该长得像这样：U/NNNN-AAAA-SSSS-EEEE</sys:String>
+    <sys:String x:Key="Tools.GameLink.Join.InvalidText">大厅编号不正确，请检查后重新输入</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Title">创建大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Description">1、进入世界后，在游戏菜单中选择【对局域网开放】&#x0A;2、在下方选择此游戏实例，单击【创建】&#x0A;3、成功创建大厅后，复制大厅编号并发送给你的朋友</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.Action">创建</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.ManualInput">手动输入</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.EnterPort">请输入端口</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.NoWorld">请先选择一个要联机的世界！</sys:String>
+    <sys:String x:Key="Tools.GameLink.Create.NotMcPort">这似乎不是个 MC 服务端口...</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Report">违法违规举报</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Terms">Natayark Network 用户协议与隐私政策</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Privacy">大厅隐私协议</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Disable">停用联机功能</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Faq">常见问题解答</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.Friends">友情链接：</sys:String>
+    <sys:String x:Key="Tools.GameLink.Link.EasyTier">EasyTier 工具官网</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.InfoTitle">大厅信息</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionStatus">连接状况</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Checking">检测中</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.PingToHost">与大厅创建者的延迟</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.LobbyId">大厅编号</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.ConnectionType">连接方式</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Connecting">连接中</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.UserName">用户名</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.UserType">用户类型</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Actions">大厅操作</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyVirtualIp">复制虚拟 IP</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CopyLobbyId">复制大厅编号</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Exit">退出大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Connected">已连接</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Unavailable">暂不可用</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Host">创建者</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.Guest">加入者</sys:String>
+    <sys:String x:Key="Tools.GameLink.Finish.CloseLobby">关闭大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoTitle">玩家 {0} 的详细信息</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.InfoMessage">用户名：{0}&#x0A;联机协议客户端标识：{1}&#x0A;&#x0A;此处数据仅供参考，请以实际游玩体验为准。&#x0A;&#x0A;若想了解 NAT 类型与其如何影响联机体验，请前往界面左侧的常见问题一栏。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Player.Host">[主机]</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListLoading">大厅成员列表（正在获取信息）</sys:String>
+    <sys:String x:Key="Tools.GameLink.Member.ListCount">大厅成员列表（共 {0} 人）</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.RevokeConfirm">你确定要撤销联机协议授权吗？</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.RevokeTitle">撤销授权确认</sys:String>
+    <sys:String x:Key="Tools.GameLink.Eula.Disabled">联机功能已停用！</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmMessage">你确定要退出大厅吗？</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.ConfirmTitle">确认退出</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.HostWarning">由于你是大厅创建者，退出后此大厅将会自动解散。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.Disbanded">由于你关闭了联机中的 MC 实例，大厅已自动解散。</sys:String>
+    <sys:String x:Key="Tools.GameLink.Exit.DisbandedTitle">大厅已解散</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Message">大厅创建者的游戏地址：{0}&#x0A;注意：仅推荐在 MC 多人游戏列表不显示大厅广播时使用 IP 连接！通过 IP 连接将可能要求使用正版档案。</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Title">复制 IP</sys:String>
+    <sys:String x:Key="Tools.GameLink.CopyIp.Back">返回</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.ServerExit">在服务器退出时发生了错误！</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.UpdateRequired">请更新到最新版 PCL CE 以使用大厅</sys:String>
+    <sys:String x:Key="Tools.GameLink.Error.ConnectFailed">无法连接到大厅服务器</sys:String>
 
     <!-- Speed -->
 
@@ -2824,45 +2909,31 @@
 
     <!-- LogPage -->
 
-    <!-- LogPage.Title -->
     <sys:String x:Key="LogPage.Title">实时日志</sys:String>
-
-    <!-- LogPage.Empty -->
     <sys:String x:Key="LogPage.Empty.Title">无实时日志</sys:String>
     <sys:String x:Key="LogPage.Empty.Description">请点击 实例设置 → 概览 → 测试游戏 以显示游戏的实时日志。</sys:String>
-
-    <!-- LogPage.Left -->
     <sys:String x:Key="LogPage.Left.InstancesTitle">测试实例列表</sys:String>
-
-    <!-- LogPage.Action -->
     <sys:String x:Key="LogPage.Action.Scroll">滚动</sys:String>
     <sys:String x:Key="LogPage.Action.Export">导出</sys:String>
     <sys:String x:Key="LogPage.Action.Clear">清空</sys:String>
     <sys:String x:Key="LogPage.Action.KillProcess">结束进程</sys:String>
     <sys:String x:Key="LogPage.Action.ExportStack">导出运行栈</sys:String>
     <sys:String x:Key="LogPage.Action.GameClosed">已关闭游戏 {0}！</sys:String>
-
-    <!-- LogPage.MaxLines -->
     <sys:String x:Key="LogPage.MaxLines.Title">最大行数</sys:String>
     <sys:String x:Key="LogPage.MaxLines.ToolTip">实时日志功能中最大显示行数，超过该值会自动删除旧的日志。</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Unlimited">无限制</sys:String>
     <sys:String x:Key="LogPage.MaxLines.Hint">实时日志默认只保留 {0} 行，你可以在 实时日志行数 设置中修改！</sys:String>
-
-    <!-- LogPage.Export -->
     <sys:String x:Key="LogPage.Export.SelectLocation">选择导出位置</sys:String>
     <sys:String x:Key="LogPage.Export.Success">日志已导出！</sys:String>
-
-    <!-- LogPage.Export.GameLog -->
     <sys:String x:Key="LogPage.Export.GameLog.FileName">游戏日志 - {0}.log</sys:String>
     <sys:String x:Key="LogPage.Export.GameLog.Filter">游戏日志(*.log)|*.log</sys:String>
-
-    <!-- LogPage.ExportStack -->
     <sys:String x:Key="LogPage.ExportStack.FileName">游戏运行栈 - {0}.log</sys:String>
     <sys:String x:Key="LogPage.ExportStack.Filter">游戏运行栈(*.log)|*.log</sys:String>
     <sys:String x:Key="LogPage.ExportStack.Progress">正在导出运行栈，请稍等（可能需要 15 秒 ~ 1 分钟）</sys:String>
     <sys:String x:Key="LogPage.ExportStack.Success">运行栈已导出！</sys:String>
 
     <!-- Watcher -->
+
     <sys:String x:Key="Watcher.Start">开始 Minecraft 日志监控</sys:String>
     <sys:String x:Key="Watcher.Exited">Minecraft 日志监控已退出</sys:String>
     <sys:String x:Key="Watcher.ProcessExited">Minecraft 已退出，返回值：{0}</sys:String>
@@ -2871,31 +2942,77 @@
     <sys:String x:Key="Watcher.FmlWindowLoaded">FML 窗口已加载：{0}（{1}）</sys:String>
     <sys:String x:Key="Watcher.WindowMaximized">已最大化 Minecraft 窗口：{0}</sys:String>
     <sys:String x:Key="Watcher.SecurityBlocked">由于反作弊或安全软件拦截，PCL 无法操作游戏窗口</sys:String>
-
-    <!-- Watcher.Progress -->
     <sys:String x:Key="Watcher.Progress.LogAppeared">日志 1/5：已出现日志输出</sys:String>
     <sys:String x:Key="Watcher.Progress.UserSet">日志 2/5：游戏用户已设置</sys:String>
     <sys:String x:Key="Watcher.Progress.LwjglConfirmed">日志 3/5：LWJGL 版本已确认</sys:String>
     <sys:String x:Key="Watcher.Progress.OpenAlLoaded">日志 4/5：OpenAL 已加载</sys:String>
     <sys:String x:Key="Watcher.Progress.TexturesLoaded">日志 5/5：材质已加载</sys:String>
-
-    <!-- Watcher.Log -->
     <sys:String x:Key="Watcher.Log.CloseDetected">识别为关闭的 Log：{0}</sys:String>
     <sys:String x:Key="Watcher.Log.CrashDetected">识别为崩溃的 Log：{0}</sys:String>
-
-    <!-- Watcher.Crash -->
     <sys:String x:Key="Watcher.Crash.Suspected">Minecraft 尚未加载完成，可能已崩溃</sys:String>
     <sys:String x:Key="Watcher.Crash.AbnormalExit">Minecraft 返回值异常，可能已崩溃</sys:String>
     <sys:String x:Key="Watcher.Crash.Detected">Minecraft 已崩溃，将在 2 秒后开始崩溃分析</sys:String>
     <sys:String x:Key="Watcher.Crash.AnalysisStart">崩溃分析开始</sys:String>
     <sys:String x:Key="Watcher.Crash.Hint">检测到 Minecraft 出现错误，错误分析已开始……</sys:String>
-
-    <!-- Watcher.Kill -->
     <sys:String x:Key="Watcher.Kill.Attempt">尝试强制结束 Minecraft 进程</sys:String>
     <sys:String x:Key="Watcher.Kill.TaskkillAttempt">进程仍未退出，尝试使用 taskkill.exe</sys:String>
     <sys:String x:Key="Watcher.Kill.TaskkillResult">执行 taskkill.exe 结果：{0}</sys:String>
     <sys:String x:Key="Watcher.Kill.Timeout">强制结束 Minecraft 进程失败：等待进程退出超时</sys:String>
     <sys:String x:Key="Watcher.Kill.Success">已强制结束 Minecraft 进程</sys:String>
     <sys:String x:Key="Watcher.Kill.Failed">强制结束 Minecraft 进程失败</sys:String>
+
+    <!-- Link -->
+
+    <sys:String x:Key="Link.Nat.Type.Open">开放</sys:String>
+    <sys:String x:Key="Link.Nat.Type.FullCone">中等（完全圆锥）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Restricted">中等（受限圆锥）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.PortRestricted">中等（端口受限圆锥）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.SymmetricEasy">严格（宽松对称）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Symmetric">严格（对称）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.SymmetricFirewall">严格（对称防火墙）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.UdpBlocked">严格（阻止 UDP）</sys:String>
+    <sys:String x:Key="Link.Nat.Type.Unknown">未知</sys:String>
+    <sys:String x:Key="Link.Connection.Local">本机</sys:String>
+    <sys:String x:Key="Link.Connection.P2P">P2P</sys:String>
+    <sys:String x:Key="Link.Connection.Relay">中继</sys:String>
+    <sys:String x:Key="Link.Connection.Unknown">未知</sys:String>
+    <sys:String x:Key="Link.Quality.Good">优秀</sys:String>
+    <sys:String x:Key="Link.Quality.Normal">一般</sys:String>
+    <sys:String x:Key="Link.Quality.Poor">较差</sys:String>
+    <sys:String x:Key="Link.Quality.GoodDescription">当前网络环境不会影响联机体验&#x0A;该网络环境适合作为大厅创建者</sys:String>
+    <sys:String x:Key="Link.Quality.NormalDescription">当前网络环境可能会影响您的联机体验</sys:String>
+    <sys:String x:Key="Link.Quality.PoorDescription">部分路由器和防火墙设置可能会影响您的联机体验</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenFetchEmpty">获取 AccessToken 与 RefreshToken 失败，返回内容为空</sys:String>
+    <sys:String x:Key="Link.Natayark.TokenParseFailed">获取 AccessToken 与 RefreshToken 失败，解析返回内容失败</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoFetchEmpty">获取 Natayark 用户信息失败，返回内容为空</sys:String>
+    <sys:String x:Key="Link.Natayark.UserInfoParseFailed">获取 Natayark 用户信息失败，解析返回内容失败</sys:String>
+    <sys:String x:Key="Link.Lobby.InitFailed">大厅服务初始化失败，请检查网络连接。</sys:String>
+    <sys:String x:Key="Link.Lobby.LoginRequired">请先登录 Natayark ID 再使用大厅！</sys:String>
+    <sys:String x:Key="Link.Lobby.CreateRoomFailed">在创建房间的时候遇到了问题，请查看日志并将此问题反馈给开发者！</sys:String>
+    <sys:String x:Key="Link.Lobby.CreateLobbyFailed">创建大厅失败，请检查日志或向开发者反馈。</sys:String>
+    <sys:String x:Key="Link.Lobby.JoinFailed">加入大厅失败，可能是大厅不存在或已被解散</sys:String>
+    <sys:String x:Key="Link.Lobby.InvalidCodeFormat">大厅编号格式不正确，请检查后再试！</sys:String>
+    <sys:String x:Key="Link.Lobby.MotdFormat">PCL CE 大厅</sys:String>
+    <sys:String x:Key="Link.Lobby.UnsupportedType">不支持的大厅类型: {0}</sys:String>
+    <sys:String x:Key="Link.Mod.LobbyUnavailable">大厅功能暂不可用，请稍后再试</sys:String>
+    <sys:String x:Key="Link.Mod.InvalidPlayerId">MC 玩家 ID 不可包含分隔符 (|) ！</sys:String>
+    <sys:String x:Key="Link.Mod.LoginFirst">请先前往联机设置并登录至 Natayark Network 再进行联机！</sys:String>
+    <sys:String x:Key="Link.Mod.ReLoginRequired">请重新登录 Natayark Network 账号再试！</sys:String>
+    <sys:String x:Key="Link.Mod.NaidFetchFailed">尝试获取 Natayark ID 信息失败</sys:String>
+    <sys:String x:Key="Link.Mod.RealNameRequired">请先前往 Natayark 账户中心进行实名验证再尝试操作！</sys:String>
+    <sys:String x:Key="Link.Mod.AccountBanned">你的 Natayark Network 账号状态异常，可能已被封禁！</sys:String>
+    <sys:String x:Key="Link.Mod.UsernameOrLogin">请先前往设置输入一个用户名，或登录至 Natayark Network 再进行联机！</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingDeps">正在下载联机依赖组件，请稍后...</sys:String>
+    <sys:String x:Key="Link.Mod.EasyTierNotReady">EasyTier 尚未下载完成，请等待其下载完成后再试！</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadingEasyTier">正在下载 EasyTier，请稍后...</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadComplete">联机组件下载完成！</sys:String>
+    <sys:String x:Key="Link.Mod.DownloadEasyTierFailed">下载 EasyTier 依赖文件失败，请检查网络连接</sys:String>
+    <sys:String x:Key="Link.Mod.Task.DownloadEasyTier">下载 EasyTier</sys:String>
+    <sys:String x:Key="Link.Mod.Task.ExtractFiles">解压文件</sys:String>
+    <sys:String x:Key="Link.Mod.Task.CleanCache">清理缓存与冗余组件</sys:String>
+    <sys:String x:Key="Link.Mod.Task.RefreshUi">刷新界面</sys:String>
+    <sys:String x:Key="Link.Mod.Task.InitLobby">大厅初始化</sys:String>
+    <sys:String x:Key="Link.Mod.Task.InitLobbyUi">大厅界面初始化</sys:String>
+    <sys:String x:Key="Link.Mod.Task.FetchAnnouncement">大厅公告获取</sys:String>
 
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2628,4 +2628,58 @@
     <sys:String x:Key="Instance.Export.MrpackFilter">Modrinth 整合包文件(*.mrpack)|*.mrpack</sys:String>
     <sys:String x:Key="Instance.Export.PackPathInvalid.Title">无法使用配置文件中指定的导出路径</sys:String>
 
+    <!-- Tools -->
+
+    <sys:String x:Key="Tools.Left.Online">联机</sys:String>
+    <sys:String x:Key="Tools.Left.Lobby">大厅</sys:String>
+    <sys:String x:Key="Tools.Left.Utilities">奇妙小工具</sys:String>
+    <sys:String x:Key="Tools.Left.Utilities.Title">百宝箱</sys:String>
+    <sys:String x:Key="Tools.Left.Help">帮助库</sys:String>
+
+    <!-- Tools.Help -->
+
+    <sys:String x:Key="Tools.Help.Search.Hint">搜索帮助</sys:String>
+    <sys:String x:Key="Tools.Help.Loading">正在加载帮助列表</sys:String>
+    <sys:String x:Key="Tools.Help.Category.Guide">指南</sys:String>
+    <sys:String x:Key="Tools.Help.Search.NoResults">无搜索结果</sys:String>
+    <sys:String x:Key="Tools.Help.Search.Results">搜索结果</sys:String>
+    <sys:String x:Key="Tools.Help.Search.ExactMatch">完全匹配  |  相似度：{0}  |  {1}</sys:String>
+    <sys:String x:Key="Tools.Help.Search.Similarity">相似度：{0}  |  {1}</sys:String>
+
+    <!-- Tools.Test -->
+    <!-- Tools.Test.CustomDownload -->
+    <!-- Tools.Test.Skin -->
+    <!-- Tools.Test.ServerQuery -->
+    <!-- Tools.Test.Achievement -->
+    <!-- Tools.Test.Avatar -->
+    <!-- Tools.Test.Memory -->
+    <!-- Tools.Test.Clean -->
+    <!-- Tools.Test.Shortcut -->
+    <!-- Tools.Test.Luck -->
+    <!-- Tools.Test.Crash -->
+
+    <!-- Tools.GameLink -->
+    <!-- Tools.GameLink.Agreement -->
+    <!-- Tools.GameLink.Natayark -->
+    <!-- Tools.GameLink.Nat -->
+    <!-- Tools.GameLink.Join -->
+    <!-- Tools.GameLink.Create -->
+    <!-- Tools.GameLink.Finish -->
+    <!-- Tools.GameLink.Player -->
+    <!-- Tools.GameLink.Member -->
+    <!-- Tools.GameLink.Error -->
+
+    <!-- Speed -->
+
+    <!-- ServerQuery -->
+
+    <!-- Update -->
+    <!-- Update.Task -->
+    <!-- Update.Error -->
+    <!-- Update.CommunityNotice -->
+
+    <!-- LogPage -->
+    <!-- LogPage.Action -->
+    <!-- LogPage.Export -->
+
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2903,9 +2903,35 @@
     <sys:String x:Key="Tools.ServerQuery.Error.EmptyPacket">服务器返回了空数据包</sys:String>
 
     <!-- Update -->
-    <!-- Update.Task -->
-    <!-- Update.Error -->
-    <!-- Update.CommunityNotice -->
+    <sys:String x:Key="Update.Action">更新</sys:String>
+    <sys:String x:Key="Update.Check.Failed">无法获取最新版本信息，请检查网络连接</sys:String>
+    <sys:String x:Key="Update.Available">启动器有新版本可用（{0} -&gt; {1}）&#x0A;是否立即更新？</sys:String>
+    <sys:String x:Key="Update.Title">启动器更新</sys:String>
+    <sys:String x:Key="Update.Error.FetchFailed">获取启动器更新失败，请检查网络连接</sys:String>
+    <sys:String x:Key="Update.Error.UnableToGetUpdate">无法获取更新</sys:String>
+    <sys:String x:Key="Update.Error.FileNotFound">找不到更新文件</sys:String>
+    <sys:String x:Key="Update.Error.Sha256Mismatch">更新文件 SHA256 不正确，应该为 {0}，实际为 {1}</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlocked">更新失败</sys:String>
+    <sys:String x:Key="Update.Error.ViewHelp">查看帮助</sys:String>
+    <sys:String x:Key="Update.Error.UpdateBlockedMessage">由于被 Windows 安全中心拦截，或者存在权限问题，导致 PCL 无法更新。&#x0A;请将 PCL 所在文件夹加入白名单，或者手动用 {0}PCL\Plain Craft Launcher Community Edition.exe 替换当前文件！</sys:String>
+    <sys:String x:Key="Update.Service.PclCe">PCL CE 服务</sys:String>
+    <sys:String x:Key="Update.Task.Check">校验更新</sys:String>
+    <sys:String x:Key="Update.Task.Install">安装更新</sys:String>
+    <sys:String x:Key="Update.Task.Prepare">准备更新</sys:String>
+    <sys:String x:Key="Update.Task.ShowButton">显示按钮</sys:String>
+    <sys:String x:Key="Update.Task.RestartInstall">重启安装</sys:String>
+    <sys:String x:Key="Update.Task.DownloadLatestStable">下载最新稳定版</sys:String>
+    <sys:String x:Key="Update.Task.DownloadFile">下载文件</sys:String>
+    <sys:String x:Key="Update.Task.ApplyFile">应用文件</sys:String>
+    <sys:String x:Key="Update.Task.GetDownloadInfo">获取下载信息</sys:String>
+    <sys:String x:Key="Update.Task.DownloadUpdateFile">下载更新文件</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfo">获取版本信息</sys:String>
+    <sys:String x:Key="Update.Task.GetVersionInfoFailed">获取版本信息失败</sys:String>
+    <sys:String x:Key="Update.Task.GetAnnouncementFailed">获取公告信息失败</sys:String>
+    <sys:String x:Key="Update.Task.RefreshSettings">刷新设置 UI</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Title">社区版本说明</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Body">你正在使用来自 PCL-Community 的 PCL 社区版本，遇到问题请不要向官方仓库反馈！&#x0A;PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的使用做担保。&#x0A;&#x0A;如果你是意外下载的社区版，建议下载官方版 PCL 使用。&#x0A;如果你是意外下载的社区版，建议下载官方版 PCL 使用。&#x0A;如果你是意外下载的社区版，建议下载官方版 PCL 使用。&#x0A;&#x0A;该版本与官方版本的特性区别：&#x0A;- 主题切换：仅部分固定蓝色系主题，没有计划新增其它主题。&#x0A;- 百宝箱：缺失部分官方版中的内容（回声洞、千万别点）。&#x0A;&#x0A;此提示会在启动器更新后展示一次。</sys:String>
+    <sys:String x:Key="Update.CommunityNotice.Confirm">我知道了</sys:String>
 
     <!-- LogPage -->
 

--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -44,7 +44,7 @@ public sealed partial class DependencyCheckService
         Context.Info($"正在打开微软应用商店 (id = {id})");
         var psi = new ProcessStartInfo()
         {
-            FileName = $"ms-windows-store://pdp?launch=true&hl=zh-cn&gl=cn&referrer=storeforweb&productid={id}&mode=full",
+            FileName = $"ms-windows-store://pdp?launch=true&productid={id}&mode=full",
             UseShellExecute = true
         };
         using var ps = new Process() { StartInfo = psi };

--- a/PCL.Core/App/Tools/DependencyCheckService.cs
+++ b/PCL.Core/App/Tools/DependencyCheckService.cs
@@ -1,11 +1,11 @@
-﻿using PCL.Core.App.IoC;
-using PCL.Core.UI;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using PCL.Core.App.IoC;
 using PCL.Core.App.Localization;
+using PCL.Core.UI;
 using PCL.Core.Utils;
 
 namespace PCL.Core.App.Tools;
@@ -17,7 +17,7 @@ public sealed partial class DependencyCheckService
     [LifecycleStart]
     private static async Task _Start()
     {
-        Context.Info("开始环境检查……");
+        Context.Info(Lang.Text("Tools.Test.Dependency.Checking"));
 
         if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
             await _CheckAndAsk("Microsoft.D3DMappingLayers", "OpenGL 兼容包", "9nqpsl29bfff")
@@ -33,8 +33,8 @@ public sealed partial class DependencyCheckService
         {
             Context.Info($"检测到依赖缺失 (package-id = {packageId})");
             var selection = MsgBoxWrapper.Show(
-                $"当前系统环境缺失软件运行所需依赖“{packageName}”\n\n点击确定打开微软应用商店安装",
-                buttons: [Lang.Text("Common.Action.Confirm"), "稍后"]);
+                Lang.Text("Tools.Test.Dependency.MissingMessage", packageName),
+                buttons: [Lang.Text("Common.Action.Confirm"), Lang.Text("Tools.Test.Dependency.Later")]);
             if (selection == 1) _LaunchMsStore(storeId);
         }
     }

--- a/PCL.Core/App/Tools/MemSwapService.cs
+++ b/PCL.Core/App/Tools/MemSwapService.cs
@@ -4,6 +4,7 @@ using PCL.Core.Utils.OS;
 using System;
 using System.Threading;
 using PCL.Core.App.Essentials;
+using PCL.Core.App.Localization;
 using PCL.Core.Logging;
 using PCL.Core.UI;
 
@@ -25,11 +26,11 @@ public sealed partial class MemSwapService
         if (!_MemSwapLock.Wait(0))
         {
             Context.Warn("检测到正在进行的内存处理，取消当前处理");
-            if (showHint) HintWrapper.Show("内存优化尚未结束，请稍等！");
+            if (showHint) HintWrapper.Show(Lang.Text("Tools.Test.Memory.StillRunning"));
             return false;
         }
         Context.Info("收到内存交换请求，开始处理");
-        if (showHint) HintWrapper.Show("正在进行内存优化");
+        if (showHint) HintWrapper.Show(Lang.Text("Tools.Test.Memory.Optimizing"));
 
         try
         {
@@ -49,11 +50,11 @@ public sealed partial class MemSwapService
                         var afterStr = ByteStream.GetReadableLength((long)after);
                         var diffStr = ByteStream.GetReadableLength((long)diff);
                         Context.Info($"处理结束，总共处理 {diffStr}");
-                        if (showHint) MsgBoxWrapper.Show($"内存优化结束，共优化 {diffStr}，目前可用内存 {afterStr}");
+                        if (showHint) MsgBoxWrapper.Show(Lang.Text("Tools.Test.Memory.Result", diffStr, afterStr));
                     }
                     else
                     {
-                        Context.Error($"内存优化失败\n\n详细信息: {result}", actionLevel: ActionLevel.MsgBoxErr);
+                        Context.Error(Lang.Text("Tools.Test.Memory.FailedMessage", result), actionLevel: ActionLevel.MsgBoxErr);
                     }
                 }
                 catch (Exception ex) { Context.Error("内存优化失败", ex); }
@@ -63,7 +64,7 @@ public sealed partial class MemSwapService
             // 执行操作
             if (PromoteService.Activate()) return true;
             _MemSwapLock.Release();
-            if (showHint) MsgBoxWrapper.Show("提权进程启动失败，请允许管理员权限以使用内存优化", "内存优化失败");
+            if (showHint) MsgBoxWrapper.Show(Lang.Text("Tools.Test.Memory.PromoteFailed"), Lang.Text("Tools.Test.Memory.Failed"));
             return false;
         }
         catch (Exception)

--- a/PCL.Core/Link/EasyTier/ETController.cs
+++ b/PCL.Core/Link/EasyTier/ETController.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.IO.Net;
 using PCL.Core.Logging;
 using PCL.Core.Utils;
@@ -82,7 +83,7 @@ public static class ETController
                     name = "terracotta-mc-" + name;
                     break;
                 default:
-                    throw new NotSupportedException("不支持的大厅类型: " + TargetLobby.Type);
+                    throw new NotSupportedException(Lang.Text("Link.Lobby.UnsupportedType", TargetLobby.Type));
             }
 
             arguments.AddFlag("no-tun");

--- a/PCL.Core/Link/Lobby/LobbyController.cs
+++ b/PCL.Core/Link/Lobby/LobbyController.cs
@@ -1,4 +1,5 @@
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Link.EasyTier;
 using PCL.Core.Link.Scaffolding;
 using PCL.Core.Link.Scaffolding.Client.Models;
@@ -89,7 +90,7 @@ public sealed class LobbyController
 
             var tcpPortForForward = NetworkHelper.NewTcpPort();
             McForward = new TcpForward(IPAddress.Loopback, tcpPortForForward, IPAddress.Loopback, localPort);
-            McBroadcast = new BroadcastLocal($"§ePCL CE 大厅{desc}", tcpPortForForward);
+            McBroadcast = new BroadcastLocal($"§e{Lang.Text("Link.Lobby.MotdFormat")}{desc}", tcpPortForForward);
             McForward.Start();
             McBroadcast.Start();
 

--- a/PCL.Core/Link/Lobby/LobbyController.cs
+++ b/PCL.Core/Link/Lobby/LobbyController.cs
@@ -84,13 +84,16 @@ public sealed class LobbyController
                 }
             }
 
-            var localPort = await scfEntity.EasyTier.AddPortForwardAsync(scfEntity.HostInfo.Ip, port)
+            var localPort = await scfEntity.EasyTier
+                .AddPortForwardAsync(scfEntity.HostInfo.Ip, port)
                 .ConfigureAwait(false);
-            var desc = hostname.IsNullOrWhiteSpace() ? " - " + hostname : string.Empty;
-
+            var desc = hostname.IsNullOrWhiteSpace()
+                ? string.Empty
+                : Lang.Text("Link.Lobby.MotdDesc", hostname);
             var tcpPortForForward = NetworkHelper.NewTcpPort();
+
             McForward = new TcpForward(IPAddress.Loopback, tcpPortForForward, IPAddress.Loopback, localPort);
-            McBroadcast = new BroadcastLocal($"§e{Lang.Text("Link.Lobby.MotdFormat")}{desc}", tcpPortForForward);
+            McBroadcast = new BroadcastLocal(Lang.Text("Link.Lobby.MotdFormat", desc), tcpPortForForward);
             McForward.Start();
             McBroadcast.Start();
 

--- a/PCL.Core/Link/Lobby/LobbyService.cs
+++ b/PCL.Core/Link/Lobby/LobbyService.cs
@@ -218,7 +218,10 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
                         throw new ArgumentNullException(nameof(pingRes), "Failed to ping minecraft entity.");
                     }
 
-                    var worldName = $"{pingRes.Description} / {pingRes.Version.Name} ({info.Address.Port})";
+                    var worldName = Lang.Text("Link.Lobby.WorldNameFormat",
+                        pingRes.Description,
+                        pingRes.Version.Name,
+                        info.Address.Port);
                     await _RunInUiAsync(() => DiscoveredWorlds.Add(new FoundWorld(worldName, info.Address.Port)))
                         .ConfigureAwait(false);
                 }

--- a/PCL.Core/Link/Lobby/LobbyService.cs
+++ b/PCL.Core/Link/Lobby/LobbyService.cs
@@ -1,4 +1,5 @@
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Link.Natayark;
 using PCL.Core.Link.Scaffolding;
 using PCL.Core.Link.Scaffolding.Client.Models;
@@ -157,7 +158,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
                     Convert.ToDateTime(expTime).CompareTo(DateTime.Now) < 0)
                 {
                     States.Link.NaidRefreshToken = string.Empty;
-                    HintWrapper.Show("Natayark ID 令牌已过期，请重新登录", HintTheme.Error);
+                    HintWrapper.Show(Lang.Text("Tools.GameLink.Natayark.TokenExpired"), HintTheme.Error);
                 }
                 else
                 {
@@ -173,7 +174,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
         catch (Exception ex)
         {
             LogWrapper.Error(ex, "LobbyService", "Lobby service initialization failed.");
-            HintWrapper.Show("大厅服务初始化失败，请检查网络连接。", HintTheme.Error);
+            HintWrapper.Show(Lang.Text("Link.Lobby.InitFailed"), HintTheme.Error);
             _SetState(LobbyState.Error);
         }
     }
@@ -249,7 +250,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
     {
         if (_NotHaveNaid())
         {
-            HintWrapper.Show("请先登录 Natayark ID 再使用大厅！", HintTheme.Error);
+            HintWrapper.Show(Lang.Text("Link.Lobby.LoginRequired"), HintTheme.Error);
             return false;
         }
 
@@ -263,7 +264,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
             var serverEntity = await _LobbyController.LaunchServerAsync(username, port).ConfigureAwait(false);
             if (serverEntity is null)
             {
-                HintWrapper.Show("在创建房间的时候遇到了问题，请查看日志并将此问题反馈给开发者！", HintTheme.Error);
+                HintWrapper.Show(Lang.Text("Link.Lobby.CreateRoomFailed"), HintTheme.Error);
                 return false;
             }
 
@@ -287,7 +288,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
         catch (Exception ex)
         {
             LogWrapper.Error(ex, "LobbyService", "Failed to create lobby.");
-            HintWrapper.Show("创建大厅失败，请检查日志或向开发者反馈。", HintTheme.Error);
+            HintWrapper.Show(Lang.Text("Link.Lobby.CreateLobbyFailed"), HintTheme.Error);
             await LeaveLobbyAsync().ConfigureAwait(false);
 
             return false;
@@ -375,7 +376,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
             if (clientEntity is null)
             {
                 throw new InvalidOperationException(
-                    "加入大厅失败，可能是大厅不存在或已被解散");
+                    Lang.Text("Link.Lobby.JoinFailed"));
             }
 
             clientEntity.Client.Heartbeat += _ClientOnHeartbeat;
@@ -386,7 +387,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
         catch (ArgumentException codeEx)
         {
             LogWrapper.Error(codeEx, "LobbyService", $"Failed to join lobby {lobbyCode}.");
-            HintWrapper.Show("大厅编号格式不正确，请检查后再试！", HintTheme.Error);
+            HintWrapper.Show(Lang.Text("Link.Lobby.InvalidCodeFormat"), HintTheme.Error);
             await LeaveLobbyAsync().ConfigureAwait(false);
 
             return false;

--- a/PCL.Core/Link/Lobby/LobbyTextHandler.cs
+++ b/PCL.Core/Link/Lobby/LobbyTextHandler.cs
@@ -1,35 +1,51 @@
-﻿using PCL.Core.Link.EasyTier;
+﻿using System;
+using PCL.Core.App.Localization;
+using PCL.Core.Link.EasyTier;
 
 namespace PCL.Core.Link.Lobby;
 
 public static class LobbyTextHandler
 {
-    public static string GetNatTypeChinese(string type)
+    public static string GetNatTypeName(string type)
     {
-        if (type.Contains("Open") || type.Contains("NoP")) return "开放";
-        if (type.Contains("FullCone")) return "中等 (完全圆锥)";
-        if (type.Contains("PortRestricted")) return "中等 (端口受限圆锥)";
-        if (type.Contains("Restricted")) return "中等 (受限圆锥)";
-        if (type.Contains("SymmetricEasy")) return "严格 (宽松对称)";
-        if (type.Contains("Symmetric")) return "严格 (对称)";
-        return "未知";
+        return Lang.Text(type switch
+        {
+            _ when type.Contains("Open") || type.Contains("NoP") => "Link.Nat.Type.Open",
+            _ when type.Contains("FullCone") => "Link.Nat.Type.FullCone",
+            _ when type.Contains("PortRestricted") => "Link.Nat.Type.PortRestricted",
+            _ when type.Contains("Restricted") => "Link.Nat.Type.Restricted",
+            _ when type.Contains("SymmetricEasy") => "Link.Nat.Type.SymmetricEasy",
+            _ when type.Contains("Symmetric") => "Link.Nat.Type.Symmetric",
+            _ => "Link.Nat.Type.Unknown"
+        });
     }
 
-    public static string GetConnectTypeChinese(ETConnectionType type) => type switch
+    public static string GetConnectTypeName(ETConnectionType type)
     {
-        ETConnectionType.Local => "本机",
-        ETConnectionType.P2P => "P2P",
-        ETConnectionType.Relay => "中继",
-        _ => "未知"
-    };
+        return Lang.Text(type switch
+        {
+            ETConnectionType.Local => "Link.Connection.Local",
+            ETConnectionType.P2P => "Link.Connection.P2P",
+            ETConnectionType.Relay => "Link.Connection.Relay",
+            _ => "Link.Connection.Unknown"
+        });
+    }
 
     /// <summary>
-    /// 依据网络质量指数获取大厅连接状况文本
+    ///     依据网络质量指数获取大厅连接状况文本。
     /// </summary>
-    public static (string Keyword, string Desc) GetQualityDesc(int quality) => quality switch
+    public static (string Keyword, string Desc) GetQualityDesc(int quality)
     {
-        >= 3 => ("优秀", "当前网络环境不会影响联机体验\n该网络环境适合作为大厅创建者"),
-        >= 2 => ("一般", "当前网络环境可能会影响您的联机体验"),
-        _ => ("较差", "部分路由器和防火墙设置可能会影响您的联机体验")
-    };
+        var keySuffix = quality switch
+        {
+            >= 3 => "Good",
+            >= 2 => "Normal",
+            _ => "Poor"
+        };
+
+        return (
+            Lang.Text($"Link.Quality.{keySuffix}"),
+            Lang.Text($"Link.Quality.{keySuffix}Description")
+        );
+    }
 }

--- a/PCL.Core/Link/McPing/McPingService.cs
+++ b/PCL.Core/Link/McPing/McPingService.cs
@@ -246,10 +246,10 @@ public class McPingService : IMcPingService
         catch (EndOfStreamException ex)
         {
             if (statusPayload is not null && latency is null)
-                throw new EndOfStreamException("服务器在返回状态后提前断开连接，未返回 pong 数据包，无法计算延迟。", ex);
+                throw new EndOfStreamException(Lang.Text("Tools.ServerQuery.Error.StaleConnection"), ex);
 
             if (statusPayload is null)
-                throw new EndOfStreamException("服务器在返回完整状态数据包前提前断开连接。", ex);
+                throw new EndOfStreamException(Lang.Text("Tools.ServerQuery.Error.IncompleteConnection"), ex);
 
             throw;
         }
@@ -259,10 +259,9 @@ public class McPingService : IMcPingService
 
     private static long _ReadInt64BigEndian(byte[] data)
     {
-        if (data.Length != 8)
-            throw new ArgumentException("Pong 数据长度必须为 8 字节", nameof(data));
-
-        return BinaryPrimitives.ReadInt64BigEndian(data);
+        return data.Length != 8
+            ? throw new ArgumentException(Lang.Text("Tools.ServerQuery.Error.PongDataLength"), nameof(data))
+            : BinaryPrimitives.ReadInt64BigEndian(data);
     }
 
     private static async Task<byte[]> _ReadExactAsync(Stream stream, int length, CancellationToken cancellationToken)

--- a/PCL.Core/Link/McPing/McPingService.cs
+++ b/PCL.Core/Link/McPing/McPingService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using PCL.Core.App.Localization;
 using PCL.Core.Link.McPing.Model;
 using PCL.Core.Logging;
 using PCL.Core.Utils;
@@ -74,7 +75,7 @@ public class McPingService : IMcPingService
         }
         catch (OperationCanceledException)
         {
-            LogWrapper.Error(new TimeoutException("连接超时"), ModuleName, $"Failed to connect to the {_endpoint}");
+            LogWrapper.Error(new TimeoutException(Lang.Text("Tools.ServerQuery.Error.Timeout.Connect")), ModuleName, $"Failed to connect to the {_endpoint}");
             return null;
         }
         catch (Exception e)
@@ -109,7 +110,7 @@ public class McPingService : IMcPingService
         }
         catch (OperationCanceledException)
         {
-            LogWrapper.Error(new TimeoutException("数据读写超时"), "McPing", $"Operation timed out on {_endpoint}");
+            LogWrapper.Error(new TimeoutException(Lang.Text("Tools.ServerQuery.Error.Timeout.ReadWrite")), "McPing", $"Operation timed out on {_endpoint}");
             return null;
         }
         catch (Exception e)
@@ -124,10 +125,10 @@ public class McPingService : IMcPingService
 
         so.Close();
 
-        if (statusPayload is null || statusPayload.Length == 0) throw new InvalidDataException("未返回服务器信息");
+        if (statusPayload is null || statusPayload.Length == 0) throw new InvalidDataException(Lang.Text("Tools.ServerQuery.State.NoInfo"));
         var retCtx = Encoding.UTF8.GetString(statusPayload);
 
-        var retJson = JsonCompat.ParseNode(retCtx) ?? throw new NullReferenceException("服务器返回了错误的信息");
+        var retJson = JsonCompat.ParseNode(retCtx) ?? throw new NullReferenceException(Lang.Text("Tools.ServerQuery.Error.InvalidResponse"));
 #if DEBUG
         var resJsonDebug = retJson.DeepClone();
         if (resJsonDebug is JsonObject jsonObject && jsonObject.ContainsKey("favicon"))
@@ -145,7 +146,7 @@ public class McPingService : IMcPingService
 
         var response = JsonSerializer.Deserialize<McPingResult>(retJson, JsonCompat.SerializerOptions);
         if (response?.Version is null)
-            throw new NullReferenceException("服务器返回了错误的字段，缺失: version");
+            throw new NullReferenceException(Lang.Text("Tools.ServerQuery.Error.InvalidResponse"));
 
         response = response with
         {
@@ -174,7 +175,7 @@ public class McPingService : IMcPingService
         handshake.AddRange(VarIntHelper.Encode(0)); //状态头 表明这是一个握手包
         handshake.AddRange(VarIntHelper.Encode(772)); //协议头 表明请求客户端的版本
         var binaryIp = Encoding.UTF8.GetBytes(serverIp);
-        if (binaryIp.Length > 255) throw new Exception("服务器地址过长");
+        if (binaryIp.Length > 255) throw new Exception(Lang.Text("Tools.ServerQuery.Error.AddressTooLong"));
         handshake.AddRange(VarIntHelper.Encode((uint)binaryIp.Length)); //服务器地址长度
         handshake.AddRange(binaryIp); //服务器地址
         handshake.AddRange(BitConverter.GetBytes((ushort)serverPort).AsEnumerable().Reverse()); //服务器端口
@@ -213,7 +214,7 @@ public class McPingService : IMcPingService
             {
                 var packetLength = checked((int)await VarIntHelper.ReadFromStreamAsync(stream, cancellationToken));
                 LogWrapper.Debug(ModuleName, $"Packet length: {packetLength}");
-                if (packetLength <= 0) throw new InvalidDataException("服务器返回了空数据包");
+                if (packetLength <= 0) throw new InvalidDataException(Lang.Text("Tools.ServerQuery.Error.EmptyPacket"));
 
                 var packetData = await _ReadExactAsync(stream, packetLength, cancellationToken);
                 using var packetStream = new MemoryStream(packetData, writable: false);

--- a/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
+++ b/PCL.Core/Link/Natayark/NatayarkProfileManager.cs
@@ -1,4 +1,5 @@
 ﻿using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Logging;
 using PCL.Core.UI;
 using PCL.Core.Utils.OS;
@@ -64,13 +65,13 @@ public static class NatayarkProfileManager
                 oauthResponse.EnsureSuccessStatusCode();
 
                 var result = await oauthResponse.AsStringAsync().ConfigureAwait(false) 
-                    ?? throw new Exception("获取 AccessToken 与 RefreshToken 失败，返回内容为空");
+                    ?? throw new Exception(Lang.Text("Link.Natayark.TokenFetchEmpty"));
                 var data = JsonCompat.ParseNode(result);
                 var accessToken = data?["access_token"]?.ToString();
                 var refreshToken = data?["refresh_token"]?.ToString();
 
                 if (data is null || accessToken is null || refreshToken is null)
-                    throw new Exception("获取 AccessToken 与 RefreshToken 失败，解析返回内容失败");
+                    throw new Exception(Lang.Text("Link.Natayark.TokenParseFailed"));
 
                 NaidProfile.AccessToken = accessToken;
                 NaidProfile.RefreshToken = refreshToken;
@@ -86,9 +87,9 @@ public static class NatayarkProfileManager
                 userDataResponse.EnsureSuccessStatusCode();
 
                 var receivedUserData = await userDataResponse.AsStringAsync()
-                    ?? throw new Exception("获取 Natayark 用户信息失败，返回内容为空");
+                    ?? throw new Exception(Lang.Text("Link.Natayark.UserInfoFetchEmpty"));
                 var userData = (JsonCompat.ParseNode(receivedUserData)?["data"])
-                    ?? throw new Exception("获取 Natayark 用户信息失败，解析返回内容失败");
+                    ?? throw new Exception(Lang.Text("Link.Natayark.UserInfoParseFailed"));
 
                 NaidProfile.Id = JsonCompat.ToObject<int>(userData["id"]);
                 NaidProfile.Username = userData["username"]?.ToString() ?? string.Empty;
@@ -107,31 +108,31 @@ public static class NatayarkProfileManager
                 {
                     NaidProfile = new NaidUser();
                     States.Link.NaidRefreshToken = string.Empty;
-                    WarnLog("获取 Natayark 用户数据失败，请尝试前往设置重新登录");
+                    WarnLog(Lang.Text("Tools.GameLink.Natayark.ProfileLoadFailed"));
                 }
                 else
                 {
                     if (ex.Message.Contains("invalid access token"))
                     {
-                        WarnLog("Naid Access Token 无效，尝试刷新登录");
+                        WarnLog(Lang.Text("Tools.GameLink.Natayark.TokenInvalid"));
                         await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false); // 搁这让电脑休息半秒吗
                         await GetNaidDataAsync(States.Link.NaidRefreshToken, true, true).ConfigureAwait(false);
                     }
                     else if (ex.Message.Contains("invalid_grant"))
                     {
-                        WarnLog("Naid 验证代码无效");
+                        WarnLog(Lang.Text("Tools.GameLink.Natayark.InvalidAuthCode"));
                     }
                     else if (ex is HttpRequestException { StatusCode: System.Net.HttpStatusCode.Unauthorized })
                     {
                         NaidProfile = new NaidUser();
                         States.Link.NaidRefreshToken = string.Empty;
-                        WarnLog("Natayark 账号信息已过期，请前往设置重新登录！");
+                        WarnLog(Lang.Text("Tools.GameLink.Natayark.AccountExpired"));
                     }
                     else
                     {
                         NaidProfile = new NaidUser();
                         States.Link.NaidRefreshToken = string.Empty;
-                        WarnLog("Naid 登录失败，请尝试前往设置重新登录");
+                        WarnLog(Lang.Text("Tools.GameLink.Natayark.LoginFailed"));
                     }
                 }
                 throw;

--- a/PCL.Core/Link/Scaffolding/EasyTier/CliNetTest.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/CliNetTest.cs
@@ -4,6 +4,7 @@ using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using PCL.Core.App.Localization;
 using PCL.Core.Logging;
 using PCL.Core.Utils;
 
@@ -91,18 +92,20 @@ public class CliNetTest
         8 => NatType.UdpBlocked,
         _ => NatType.Unknown
     };
-    
-    public static string GetNatTypeString(NatType type) => type switch
+
+    public static string GetNatTypeString(NatType type)
     {
-        NatType.OpenInternet => "开放",
-        NatType.NoPat => "开放",
-        NatType.FullCone => "中等（完全圆锥）",
-        NatType.PortRestricted => "中等（端口受限圆锥）",
-        NatType.Restricted => "中等（受限圆锥）",
-        NatType.SymmetricEasy => "严格（宽松对称）",
-        NatType.Symmetric => "严格（对称）",
-        NatType.SymmetricFirewall => "严格（对称防火墙）",
-        NatType.UdpBlocked => "严格（阻止 UDP）",
-        _ => "未知"
-    };
+        return Lang.Text(type switch
+        {
+            NatType.OpenInternet or NatType.NoPat => "Link.Nat.Type.Open",
+            NatType.FullCone => "Link.Nat.Type.FullCone",
+            NatType.PortRestricted => "Link.Nat.Type.PortRestricted",
+            NatType.Restricted => "Link.Nat.Type.Restricted",
+            NatType.SymmetricEasy => "Link.Nat.Type.SymmetricEasy",
+            NatType.Symmetric => "Link.Nat.Type.Symmetric",
+            NatType.SymmetricFirewall => "Link.Nat.Type.SymmetricFirewall",
+            NatType.UdpBlocked => "Link.Nat.Type.UdpBlocked",
+            _ => "Link.Nat.Type.Unknown"
+        });
+    }
 }

--- a/PCL.Core/Utils/Validate/RegexValidator.cs
+++ b/PCL.Core/Utils/Validate/RegexValidator.cs
@@ -1,20 +1,25 @@
 ﻿using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Results;
+using PCL.Core.App.Localization;
 
 namespace PCL.Core.Utils.Validate;
 
 public class RegexValidator(string pattern = "", string errorMessage = "正则检查失败！") : AbstractValidator<string>
 {
+    public RegexValidator() : this(string.Empty)
+    {
+    }
+
     public string Pattern { get; set; } = pattern;
     public string ErrorMessage { get; set; } = errorMessage;
-
-    public RegexValidator() : this(string.Empty) {}
+    public string ErrorKey { get; set; } = "";
 
     private void _BuildRules()
     {
+        var message = string.IsNullOrEmpty(ErrorKey) ? ErrorMessage : Lang.Text(ErrorKey);
         RuleFor(x => x)
-            .Must(x => Regex.IsMatch(x, Pattern)).WithMessage(ErrorMessage);
+            .Must(x => Regex.IsMatch(x, Pattern)).WithMessage(message);
     }
 
     protected override bool PreValidate(ValidationContext<string> context, ValidationResult result)

--- a/Plain Craft Launcher 2/Controls/MinecraftServer.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MinecraftServer.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
+using PCL.Core.App.Localization;
 using PCL.Core.Link.McPing;
 using PCL.Core.Link.McPing.Model;
 using PCL.Core.Minecraft;
@@ -41,7 +42,7 @@ public partial class MinecraftServer : Grid
         address = address.Replace("：", ":");
         // 预先重置UI状态
         LabServerDesc.Foreground = Brushes.White;
-        LabServerDesc.Text = "查询中...";
+        LabServerDesc.Text = Lang.Text("Tools.ServerQuery.State.Querying");
         LabServerPlayer.Text = "-/-";
         LabServerPlayer.ToolTip = null;
         ImageLoaderHelper.SetFallbackImage(ImgServerLogo, fallbackImageUri);
@@ -56,7 +57,7 @@ public partial class MinecraftServer : Grid
             {
                 var ret = await query.PingAsync();
 
-                if (ret is null) throw new Exception("未返回服务器信息");
+                if (ret is null) throw new Exception(Lang.Text("Tools.ServerQuery.State.NoInfo"));
 
                 // 处理服务器图标
                 await ImageLoaderHelper.SetServerLogoAsync(ret.Favicon, ImgServerLogo);
@@ -68,7 +69,7 @@ public partial class MinecraftServer : Grid
         catch (Exception ex)
         {
             ModBase.Log(ex, "[MinecraftServer] 信息查询失败");
-            LabServerDesc.Text = $"无法连接: {ex.Message}";
+            LabServerDesc.Text = Lang.Text("Tools.ServerQuery.Error.UnableToConnect", ex.Message);
             LabServerDesc.Foreground = Brushes.Red;
             ImageLoaderHelper.SetFallbackImage(ImgServerLogo, fallbackImageUri);
         }
@@ -80,7 +81,7 @@ public partial class MinecraftServer : Grid
         var latencyColor = ret.Latency < 150 ? "a" : ret.Latency < 400 ? "6" : "c";
 
         // 更新描述
-        LabServerDesc.Text = "Minecraft 服务器";
+        LabServerDesc.Text = Lang.Text("Tools.ServerQuery.Title.MinecraftServer");
         MotdRenderer.RenderMotd(ret.Description, false, 2, 14);
         MotdRenderer.RenderCanvas();
 

--- a/Plain Craft Launcher 2/Controls/MinecraftServerQuery.xaml
+++ b/Plain Craft Launcher 2/Controls/MinecraftServerQuery.xaml
@@ -16,7 +16,7 @@
         <ColumnDefinition Width="*" />
         <ColumnDefinition Width="Auto" />
     </Grid.ColumnDefinitions>
-    <local:MyTextBox x:Name="LabServerIp" HintText="输入服务器地址" Margin="0,0,15,0" Grid.Column="0">
+    <local:MyTextBox x:Name="LabServerIp" HintText="{DynamicResource Tools.ServerQuery.Address.Hint}" Margin="0,0,15,0" Grid.Column="0">
         <local:MyTextBox.ValidateRules>
             <val:BlacklistValidator>
                 <val:BlacklistValidator.Blacklist>
@@ -25,7 +25,7 @@
             </val:BlacklistValidator>
         </local:MyTextBox.ValidateRules>
     </local:MyTextBox>
-    <local:MyButton x:Name="BtnServerQuery" Text="查询" Width="60" Grid.Column="1" />
+    <local:MyButton x:Name="BtnServerQuery" Text="{DynamicResource Tools.ServerQuery.Action.Query}" Width="60" Grid.Column="1" />
     <Border x:Name="ServerInfo" Margin="0,7,0,0" Visibility="Collapsed" Grid.Row="1" Grid.ColumnSpan="2"
             CornerRadius="5" BorderThickness="2" BorderBrush="{DynamicResource ColorBrush5}">
         <Border.Background>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
@@ -239,7 +239,7 @@ public static class ModWatcher
             pid = loader.input.Id;
             this.jStackPath = jStackPath;
 
-            WatcherLog("开始 Minecraft 日志监控");
+            WatcherLog(Lang.Text("Watcher.Start"));
             if (string.IsNullOrWhiteSpace(windowTitle))
                 WatcherLog("要求窗口标题：" + windowTitle);
 
@@ -292,7 +292,7 @@ public static class ModWatcher
                         Thread.Sleep(10);
                     }
 
-                    WatcherLog("Minecraft 日志监控已退出");
+                    WatcherLog(Lang.Text("Watcher.Exited"));
                 }
                 catch (Exception ex)
                 {
@@ -411,12 +411,12 @@ public static class ModWatcher
                 // 游戏退出检查
                 if (gameProcess.HasExited)
                 {
-                    WatcherLog("Minecraft 已退出，返回值：" + gameProcess.ExitCode);
+                    WatcherLog(Lang.Text("Watcher.ProcessExited", gameProcess.ExitCode));
                     // 实时日志输出
                     if (realTime)
                     {
                         var arglevel = GameLogLevel.Info;
-                        LogRealTime($"Minecraft 已退出，返回值：{gameProcess.ExitCode}", ref arglevel);
+                        LogRealTime(Lang.Text("Watcher.ProcessExited", gameProcess.ExitCode), ref arglevel);
                     }
 
                     GameExit?.Invoke();
@@ -428,14 +428,14 @@ public static class ModWatcher
                     if (State == MinecraftState.Loading)
                     {
                         // 窗口未出现
-                        WatcherLog("Minecraft 尚未加载完成，可能已崩溃");
+                        WatcherLog(Lang.Text("Watcher.Crash.Suspected"));
                         Crashed();
                     }
                     else if (gameProcess.ExitCode != 0 && State == MinecraftState.Running &&
                              version.releaseTime.Year >= 2012)
                     {
                         // 返回值不为 0 且未结束
-                        WatcherLog("Minecraft 返回值异常，可能已崩溃");
+                        WatcherLog(Lang.Text("Watcher.Crash.AbnormalExit"));
                         Crashed();
                     }
                     else if (State != MinecraftState.Crashed)
@@ -466,31 +466,31 @@ public static class ModWatcher
             // 进度处理
             if (logProgress < 1)
             {
-                WatcherLog("日志 1/5：已出现日志输出");
+                WatcherLog(Lang.Text("Watcher.Progress.LogAppeared"));
                 logProgress = 1;
             } // 可能第一句就是后面需要判断的 Log（重现：启动 1.15.2 原版）
 
             if (logProgress < 2 && text.Contains("Setting user:"))
             {
-                WatcherLog("日志 2/5：游戏用户已设置"); // 仅确保支持 Minecraft 1.7+
+                WatcherLog(Lang.Text("Watcher.Progress.UserSet")); // 仅确保支持 Minecraft 1.7+
                 logProgress = 2;
             }
             else if (logProgress < 3 && text.ContainsF("lwjgl version", true))
             {
-                WatcherLog("日志 3/5：LWJGL 版本已确认");
+                WatcherLog(Lang.Text("Watcher.Progress.LwjglConfirmed"));
                 logProgress = 3;
             }
             else if (logProgress < 4 &&
                      (text.Contains("OpenAL initialized") || text.Contains("Starting up SoundSystem")))
             {
-                WatcherLog("日志 4/5：OpenAL 已加载"); // 仅确保支持 Minecraft 1.7+
+                WatcherLog(Lang.Text("Watcher.Progress.OpenAlLoaded")); // 仅确保支持 Minecraft 1.7+
                 logProgress = 4;
             }
             else if (logProgress < 5 &&
                      ((text.Contains("Created") && text.Contains("textures") && text.Contains("-atlas")) ||
                       text.Contains("Found animation info")))
             {
-                WatcherLog("日志 5/5：材质已加载"); // 仅确保支持 Minecraft 1.7+
+                WatcherLog(Lang.Text("Watcher.Progress.TexturesLoaded")); // 仅确保支持 Minecraft 1.7+
                 logProgress = 5;
             }
 
@@ -502,7 +502,7 @@ public static class ModWatcher
                 if (text.Contains("Someone is closing me!") ||
                     text.Contains("Restarting Minecraft with command")) // #1258
                 {
-                    WatcherLog("识别为关闭的 Log：" + text);
+                    WatcherLog(Lang.Text("Watcher.Log.CloseDetected", text));
                     State = MinecraftState.Ended;
                 }
                 else if (text.Contains("Crash report saved to") ||
@@ -510,24 +510,19 @@ public static class ModWatcher
                 {
                     // Text.Contains("Minecraft ran into a problem! Report saved to:") Then
                     // Minecraft 崩溃，忽略 VanillaFix
-                    WatcherLog("识别为崩溃的 Log：" + text);
+                    WatcherLog(Lang.Text("Watcher.Log.CrashDetected", text));
                     Crashed();
                 }
                 else if (text.Contains("Could not save crash report to"))
                 {
-                    // Minecraft 崩溃，无法保存崩溃日志
-                    WatcherLog("识别为崩溃的 Log：" + text);
+                    WatcherLog(Lang.Text("Watcher.Log.CrashDetected", text));
                     Crashed();
                 }
                 else if (text.Contains("/ERROR]: Unable to launch") ||
                          text.Contains("An exception was thrown, the game will display an error screen and halt."))
                 {
-                    // Forge 崩溃
-                    WatcherLog("识别为崩溃的 Log：" + text);
+                    WatcherLog(Lang.Text("Watcher.Log.CrashDetected", text));
                     Crashed();
-                    // ElseIf Text.Contains("Shutdown failure!") Then
-                    // 'Minecraft 强行崩溃，由于点 X 强行关闭也会触发这句话，所以不可用
-                    // Crashed(Nothing)
                 }
             }
         }
@@ -543,7 +538,7 @@ public static class ModWatcher
             if (isWindowAppeared || logProgress >= 4)
             {
                 currentProgress = 0.95d;
-                WatcherLog("Minecraft 加载已完成");
+                WatcherLog(Lang.Text("Watcher.LoadComplete"));
                 State = MinecraftState.Running;
             }
             else
@@ -571,7 +566,7 @@ public static class ModWatcher
                 catch (Win32Exception ex)
                 {
                     // 拒绝访问（#1062）
-                    ModBase.Log(ex, "由于反作弊或安全软件拦截，PCL 无法操作游戏窗口", ModBase.LogLevel.Hint);
+                    ModBase.Log(ex, Lang.Text("Watcher.SecurityBlocked"), ModBase.LogLevel.Hint);
                     isWindowFinished = true;
                 }
 
@@ -584,7 +579,7 @@ public static class ModWatcher
                 {
                     // 已找到 Minecraft 窗口
                     windowHandle = minecraftWindowHandle;
-                    WatcherLog($"Minecraft 窗口已加载：{minecraftWindowName}（{minecraftWindowHandle.ToInt64()}）");
+                    WatcherLog(Lang.Text("Watcher.WindowLoaded", minecraftWindowName, minecraftWindowHandle.ToInt64()));
                     isWindowFinished = true;
                     // 最大化
                     if (Config.Launch.GameWindowMode == GameWindowSizeMode.Maximized)
@@ -596,7 +591,7 @@ public static class ModWatcher
                             {
                                 Thread.Sleep(2000);
                                 ShowWindow(windowHandle, 3U);
-                                WatcherLog($"已最大化 Minecraft 窗口：{minecraftWindowHandle.ToInt64()}");
+                                 WatcherLog(Lang.Text("Watcher.WindowMaximized", minecraftWindowHandle.ToInt64()));
                             }
                             catch (Exception ex)
                             {
@@ -607,7 +602,7 @@ public static class ModWatcher
                 else if (!isWindowAppeared)
                 {
                     // 已找到 FML 窗口
-                    WatcherLog("FML 窗口已加载：" + minecraftWindowName + "（" + minecraftWindowHandle.ToInt64() + "）");
+                    WatcherLog(Lang.Text("Watcher.FmlWindowLoaded", minecraftWindowName, minecraftWindowHandle.ToInt64()));
                 }
 
                 isWindowAppeared = true;
@@ -693,15 +688,15 @@ public static class ModWatcher
                 return;
             State = MinecraftState.Crashed;
             // 崩溃分析
-            WatcherLog("Minecraft 已崩溃，将在 2 秒后开始崩溃分析");
-            ModMain.Hint("检测到 Minecraft 出现错误，错误分析已开始……");
+            WatcherLog(Lang.Text("Watcher.Crash.Detected"));
+            ModMain.Hint(Lang.Text("Watcher.Crash.Hint"));
             ModBase.FeedbackInfo();
             ModBase.RunInNewThread(() =>
             {
                 try
                 {
                     Thread.Sleep(2000);
-                    WatcherLog("崩溃分析开始");
+                    WatcherLog(Lang.Text("Watcher.Crash.AnalysisStart"));
                     ;
                     var analyzer = new CrashAnalyzer(pid);
                     analyzer.Collect(version.PathIndie, latestLog.ToList());
@@ -737,7 +732,7 @@ public static class ModWatcher
             State = MinecraftState.Canceled;
             ModBase.RunInNewThread(() =>
             {
-                WatcherLog("尝试强制结束 Minecraft 进程");
+                WatcherLog(Lang.Text("Watcher.Kill.Attempt"));
                 try
                 {
                     if (CheckAlive(gameProcess))
@@ -745,7 +740,7 @@ public static class ModWatcher
                     gameProcess.WaitForExit(5000);
                     if (CheckAlive(gameProcess))
                     {
-                        WatcherLog("进程仍未退出，尝试使用 taskkill.exe");
+                        WatcherLog(Lang.Text("Watcher.Kill.TaskkillAttempt"));
                         var taskkillInfo = new ProcessStartInfo
                         {
                             FileName = "taskkill.exe",
@@ -755,27 +750,27 @@ public static class ModWatcher
                         };
                         var taskkillProcess = Process.Start(taskkillInfo);
                         var output = taskkillProcess.StandardOutput.ReadToEnd();
-                        WatcherLog($"执行 taskkill.exe 结果:\n{output}");
+                        WatcherLog(Lang.Text("Watcher.Kill.TaskkillResult", output));
                         gameProcess.WaitForExit(5000);
                         if (CheckAlive(gameProcess))
                         {
-                            WatcherLog("强制结束 Minecraft 进程失败: 等待进程退出超时");
+                            WatcherLog(Lang.Text("Watcher.Kill.Timeout"));
                             return;
                         }
                     }
 
-                    WatcherLog("已强制结束 Minecraft 进程");
+                    WatcherLog(Lang.Text("Watcher.Kill.Success"));
                     if (realTime)
                     {
                         var arglevel = GameLogLevel.Info;
-                        LogRealTime($"Minecraft 已退出，返回值：{gameProcess.ExitCode}", ref arglevel);
+                        LogRealTime(Lang.Text("Watcher.ProcessExited", gameProcess.ExitCode), ref arglevel);
                     }
 
                     GameExit?.Invoke();
                 }
                 catch (Exception ex)
                 {
-                    ModBase.Log(ex, "强制结束 Minecraft 进程失败", ModBase.LogLevel.Hint);
+                    ModBase.Log(ex, Lang.Text("Watcher.Kill.Failed"), ModBase.LogLevel.Hint);
                 }
             });
         }

--- a/Plain Craft Launcher 2/Modules/ModLink.cs
+++ b/Plain Craft Launcher 2/Modules/ModLink.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Link.EasyTier;
 using PCL.Core.Link.Lobby;
 using PCL.Core.Link.McPing;
@@ -23,14 +24,14 @@ public static class ModLink
     {
         if (!LobbyInfoProvider.IsLobbyAvailable)
         {
-            ModMain.Hint("大厅功能暂不可用，请稍后再试", ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Link.Mod.LobbyUnavailable"), ModMain.HintType.Critical);
             return false;
         }
 
         if (ModProfile.selectedProfile is not null)
             if (ModProfile.selectedProfile.Username.Contains("|"))
             {
-                ModMain.Hint("MC 玩家 ID 不可包含分隔符 (|) ！");
+                ModMain.Hint(Lang.Text("Link.Mod.InvalidPlayerId"));
                 return false;
             }
 
@@ -38,7 +39,7 @@ public static class ModLink
         {
             if (string.IsNullOrWhiteSpace(States.Link.NaidRefreshToken))
             {
-                ModMain.Hint("请先前往联机设置并登录至 Natayark Network 再进行联机！", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Link.Mod.LoginFirst"), ModMain.HintType.Critical);
                 return false;
             }
 
@@ -50,7 +51,7 @@ public static class ModLink
             catch (Exception ex)
             {
                 ModBase.Log("[Link] 刷新 Natayark ID 信息失败，需要重新登录");
-                ModMain.Hint("请重新登录 Natayark Network 账号再试！", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Link.Mod.ReLoginRequired"), ModMain.HintType.Critical);
                 return false;
             }
 
@@ -65,32 +66,32 @@ public static class ModLink
 
             if (string.IsNullOrWhiteSpace(NatayarkProfileManager.NaidProfile.Username))
             {
-                ModMain.Hint("尝试获取 Natayark ID 信息失败", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Link.Mod.NaidFetchFailed"), ModMain.HintType.Critical);
                 return false;
             }
 
             if (LobbyInfoProvider.RequiresRealName && !NatayarkProfileManager.NaidProfile.IsRealNamed)
             {
-                ModMain.Hint("请先前往 Natayark 账户中心进行实名验证再尝试操作！", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Link.Mod.RealNameRequired"), ModMain.HintType.Critical);
                 return false;
             }
 
             if (NatayarkProfileManager.NaidProfile.Status != 0)
             {
-                ModMain.Hint("你的 Natayark Network 账号状态异常，可能已被封禁！", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Link.Mod.AccountBanned"), ModMain.HintType.Critical);
                 return false;
             }
         }
 
         if (string.IsNullOrWhiteSpace(Config.Link.Username) && string.IsNullOrWhiteSpace(NatayarkProfileManager.NaidProfile.Username))
         {
-            ModMain.Hint("请先前往设置输入一个用户名，或登录至 Natayark Network 再进行联机！", ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Link.Mod.UsernameOrLogin"), ModMain.HintType.Critical);
             return false;
         }
 
         if (ETController.Precheck() == 1)
         {
-            ModMain.Hint("正在下载联机依赖组件，请稍后...");
+            ModMain.Hint(Lang.Text("Link.Mod.DownloadingDeps"));
             DownloadEasyTier();
             return false;
         }
@@ -99,14 +100,14 @@ public static class ModLink
         {
             if (dlEasyTierLoader.State == ModBase.LoadState.Loading)
             {
-                ModMain.Hint("EasyTier 尚未下载完成，请等待其下载完成后再试！");
+                ModMain.Hint(Lang.Text("Link.Mod.EasyTierNotReady"));
                 return false;
             }
 
             if (dlEasyTierLoader.State == ModBase.LoadState.Failed ||
                 dlEasyTierLoader.State == ModBase.LoadState.Aborted)
             {
-                ModMain.Hint("正在下载 EasyTier，请稍后...");
+                ModMain.Hint(Lang.Text("Link.Mod.DownloadingEasyTier"));
                 DownloadEasyTier();
                 return false;
             }
@@ -331,31 +332,31 @@ public static class ModLink
                 };
 
                 // 1. Download EasyTier
-                loaders.Add(new LoaderDownload("下载 EasyTier", new List<DownloadFile>
+                loaders.Add(new LoaderDownload(Lang.Text("Link.Mod.Task.DownloadEasyTier"), new List<DownloadFile>
                 {
                     new(addresses.ToArray(), dlTargetPath, new ModBase.FileChecker(1024 * 64))
                 }) { ProgressWeight = 15 });
 
                 // 2. Extract files
-                loaders.Add(new ModLoader.LoaderTask<int, int>("解压文件", _ =>
+                loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Link.Mod.Task.ExtractFiles"), _ =>
                     ModBase.ExtractFile(dlTargetPath,
                         Path.Combine(Paths.SharedLocalData, "EasyTier", ETInfoProvider.ETVersion))
                 ) { block = true });
 
                 // 3. Cleanup
-                loaders.Add(new ModLoader.LoaderTask<int, int>("清理缓存与冗余组件", _ =>
+                loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Link.Mod.Task.CleanCache"), _ =>
                 {
                     File.Delete(dlTargetPath);
                     CleanupEasyTierCache();
                 }));
 
                 // 4. Update UI hint
-                loaders.Add(new ModLoader.LoaderTask<int, int>("刷新界面", _ =>
-                    HintWrapper.Show("联机组件下载完成！", HintTheme.Error)
+            loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Link.Mod.Task.RefreshUi"), _ =>
+                HintWrapper.Show(Lang.Text("Link.Mod.DownloadComplete"), HintTheme.Error)
                 ) { show = false });
 
                 // Start loader combo
-                dlEasyTierLoader = new ModLoader.LoaderCombo<JsonObject>("大厅初始化", loaders);
+                dlEasyTierLoader = new ModLoader.LoaderCombo<JsonObject>(Lang.Text("Link.Mod.Task.InitLobby"), loaders);
                 dlEasyTierLoader.Start();
 
                 // Taskbar and UI notification
@@ -367,7 +368,7 @@ public static class ModLink
             {
                 // Error handling with concise English logs
                 LogWrapper.Warn(ex, "Failed to download EasyTier dependency files");
-                HintWrapper.Show("下载 EasyTier 依赖文件失败，请检查网络连接", HintTheme.Error);
+                HintWrapper.Show(Lang.Text("Link.Mod.DownloadEasyTierFailed"), HintTheme.Error);
             }
         });
 

--- a/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdateManager.cs
@@ -59,7 +59,7 @@ public static class UpdateManager
         }
         catch (Exception ex)
         {
-            ModBase.Log(ex, "无法获取最新版本信息，请检查网络连接", ModBase.LogLevel.Hint);
+            ModBase.Log(ex, Lang.Text("Update.Check.Failed"), ModBase.LogLevel.Hint);
             return UpdateEnums.VersionStatus.Unknown;
         }
     }
@@ -87,9 +87,12 @@ public static class UpdateManager
                     ModBase.RunInUi(() =>
                     {
                         if (ModMain.MyMsgBox(
-                                $"启动器有新版本可用（{ModBase.versionBaseName} -> {version.VersionName}){"\r\n"}是否立即更新？",
-                                "启动器更新", "更新", Lang.Text("Common.Action.Cancel")) ==
-                            1) ModMain.frmMain.PageChange(FormMain.PageType.Setup, FormMain.PageSubType.SetupUpdate);
+                                Lang.Text("Update.Available", ModBase.versionBaseName, version.VersionName),
+                                Lang.Text("Update.Title"),
+                                Lang.Text("Update.Action"),
+                                Lang.Text("Common.Action.Cancel")
+                            ) == 1)
+                            ModMain.frmMain.PageChange(FormMain.PageType.Setup, FormMain.PageSubType.SetupUpdate);
                     });
                     return;
                     // 构造步骤加载器
@@ -100,18 +103,18 @@ public static class UpdateManager
                 loaders.AddRange(remoteServer.GetDownloadLoader(
                     IsCurrentVersionBeta ? UpdateChannel.beta : UpdateChannel.stable,
                     SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, dlTargetPath));
-                loaders.Add(new ModLoader.LoaderTask<int, int>("校验更新", _ =>
+                loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Update.Task.Check"), _ =>
                 {
                     var curHash = ModBase.GetFileSHA256(dlTargetPath);
                     if ((curHash ?? "") != (version.Sha256 ?? ""))
-                        throw new Exception($"更新文件 SHA256 不正确，应该为 {version.Sha256}，实际为 {curHash}");
+                        throw new Exception(Lang.Text("Update.Error.Sha256Mismatch", version.Sha256, curHash));
                 }));
                 if (type == UpdateEnums.UpdateType.UpdateNow)
-                    loaders.Add(new ModLoader.LoaderTask<int, int>("安装更新", _ => UpdateRestart(true)));
+                    loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Update.Task.Install"), _ => UpdateRestart(true)));
                 else if (type == UpdateEnums.UpdateType.Silent)
-                    loaders.Add(new ModLoader.LoaderTask<int, int>("准备更新", _ => isUpdateWaitingRestart = true));
+                    loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Update.Task.Prepare"), _ => isUpdateWaitingRestart = true));
                 else if (type == UpdateEnums.UpdateType.DownloadAndPrompt)
-                    loaders.Add(new ModLoader.LoaderTask<int, int>("显示按钮", _ =>
+                    loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Update.Task.ShowButton"), _ =>
                     {
                         isUpdateWaitingRestart = true;
                         ModBase.RunInUi(() =>
@@ -125,12 +128,12 @@ public static class UpdateManager
                     {
                         show = false
                     });
-                loaders.Add(new ModLoader.LoaderTask<int, int>("刷新设置 UI", _ =>
+                loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Update.Task.RefreshSettings"), _ =>
                 {
                     if (ModMain.frmSetupUpdate is not null)
                         ModBase.RunInUi(() =>
                         {
-                            ModMain.frmSetupUpdate.BtnUpdate.Text = "重启安装";
+                            ModMain.frmSetupUpdate.BtnUpdate.Text = Lang.Text("Update.Task.RestartInstall");
                             ModMain.frmSetupUpdate.BtnUpdate.IsEnabled = true;
                         });
                 })
@@ -138,7 +141,7 @@ public static class UpdateManager
                     show = false
                 });
                 // 启动
-                updateLoader = new ModLoader.LoaderCombo<JsonObject>("启动器更新", loaders);
+                updateLoader = new ModLoader.LoaderCombo<JsonObject>(Lang.Text("Update.Title"), loaders);
                 updateLoader.Start();
                 if (type == UpdateEnums.UpdateType.UpdateNow)
                 {
@@ -151,7 +154,7 @@ public static class UpdateManager
             {
                 ModBase.Log(ex, "[Update] 获取启动器更新失败");
                 if (type != UpdateEnums.UpdateType.Silent)
-                    ModMain.Hint("获取启动器更新失败，请检查网络连接", ModMain.HintType.Critical);
+                    ModMain.Hint(Lang.Text("Update.Error.FetchFailed"), ModMain.HintType.Critical);
             }
         });
     }
@@ -181,11 +184,14 @@ public static class UpdateManager
         }
         catch (Win32Exception ex)
         {
-            ModBase.Log(ex, "自动更新时触发 Win32 错误，疑似被拦截", ModBase.LogLevel.Debug, "出现错误");
-            if (ModMain.MyMsgBox(string.Format("由于被 Windows 安全中心拦截，或者存在权限问题，导致 PCL 无法更新。{0}请将 PCL 所在文件夹加入白名单，或者手动用 {1}PCL\\Plain Craft Launcher Community Edition.exe 替换当前文件！", Environment.NewLine, ModBase.exePath), "更新失败", "查看帮助", Lang.Text("Common.Action.Confirm"), "", true, true, false, null, null, null) == 1)
-            {
+            ModBase.Log(ex, "自动更新时触发 Win32 错误，疑似被拦截");
+            if (ModMain.MyMsgBox(Lang.Text("Update.Error.UpdateBlockedMessage", ModBase.exePath),
+                    Lang.Text("Update.Error.UpdateBlocked"),
+                    Lang.Text("Update.Error.ViewHelp"),
+                    Lang.Text("Common.Action.Confirm"),
+                    "", true
+                ) == 1)
                 CustomEvent.Raise(CustomEvent.EventType.打开帮助, "启动器/Microsoft Defender 添加排除项.json");
-            }
         }
     }
 
@@ -200,7 +206,7 @@ public static class UpdateManager
         var target = remoteServer.GetLatestVersion(UpdateChannel.stable,
             SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64);
         if (target is null)
-            throw new Exception("无法获取更新");
+            throw new Exception(Lang.Text("Update.Error.UnableToGetUpdate"));
         if (File.Exists(latestPCLPath) && (ModBase.GetFileSHA256(latestPCLPath) ?? "") == (target.Sha256 ?? ""))
         {
             ModBase.Log("[System] 最新版 PCL 已存在，跳过下载");
@@ -215,13 +221,15 @@ public static class UpdateManager
 
         var loaders = remoteServer.GetDownloadLoader(UpdateChannel.stable,
             SystemInfo.IsArm64System ? UpdateArch.arm64 : UpdateArch.x64, latestPCLPath);
-        var loader = new ModLoader.LoaderCombo<int>("下载最新稳定版", loaders);
+        var loader = new ModLoader.LoaderCombo<int>(Lang.Text("Update.Task.DownloadLatestStable"), loaders);
         loader.Start();
         loader.WaitForExit();
     }
-    
-    public static ModLoader.LoaderTask<int, int> serverLoader = new("PCL CE 服务", _ => LoadOnlineInfo(),
-        priority: ThreadPriority.BelowNormal);
+
+    public static ModLoader.LoaderTask<int, int> serverLoader =
+        new(Lang.Text("Update.Service.PclCe"),
+            _ => LoadOnlineInfo(),
+            priority: ThreadPriority.BelowNormal);
 
     private static void LoadOnlineInfo()
     {
@@ -258,17 +266,8 @@ public static class UpdateManager
     /// <param name="IsUpdate">是否为更新时启动</param>
     public static void ShowCEAnnounce()
     {
-        ModMain.MyMsgBox(@"你正在使用来自 PCL-Community 的 PCL 社区版本，遇到问题请不要向官方仓库反馈！
-PCL-Community 及其成员与龙腾猫跃无从属关系，且均不会为您的使用做担保。
-
-如果你是意外下载的社区版，建议下载官方版 PCL 使用。
-如果你是意外下载的社区版，建议下载官方版 PCL 使用。
-如果你是意外下载的社区版，建议下载官方版 PCL 使用。
-
-该版本与官方版本的特性区别：
-- 主题切换：仅部分固定蓝色系主题，没有计划新增其它主题。
-- 百宝箱：缺失部分官方版中的内容（回声洞、千万别点）。
-
-此提示会在启动器更新后展示一次。", "社区版本说明", "我知道了");
+        ModMain.MyMsgBox(Lang.Text("Update.CommunityNotice.Body"),
+            Lang.Text("Update.CommunityNotice.Title"),
+            Lang.Text("Update.CommunityNotice.Confirm"));
     }
 }

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMinioModel.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Diff;
 using PCL.Network;
@@ -72,7 +73,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
         var loaders = new List<ModLoader.LoaderBase>();
         var patchUpdate = true;
         var tempPath = $@"{ModBase.pathTemp}Cache\Update\Download\";
-        loaders.Add(new ModLoader.LoaderTask<int, List<DownloadFile>>("获取版本信息", load =>
+        loaders.Add(new ModLoader.LoaderTask<int, List<DownloadFile>>(Lang.Text("Update.Task.GetVersionInfo"), load =>
         {
             var channelName = GetChannelName(channel, arch);
             var deJsonData = GetRemoteInfoByName($"updates-{channelName}", "updates/")
@@ -99,8 +100,8 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
                 load.output = new List<DownloadFile> { new(RandomUtils.Shuffle(deJsonData.Downloads), tempPath) };
             }
         }));
-        loaders.Add(new LoaderDownload("下载文件", new List<DownloadFile>()));
-        loaders.Add(new ModLoader.LoaderTask<string, int>("应用文件", _ =>
+        loaders.Add(new LoaderDownload(Lang.Text("Update.Task.DownloadFile"), new List<DownloadFile>()));
+        loaders.Add(new ModLoader.LoaderTask<string, int>(Lang.Text("Update.Task.ApplyFile"), _ =>
         {
             if (patchUpdate)
             {
@@ -128,7 +129,7 @@ public class UpdatesMinioModel : IUpdateSource // 社区自己的更新系统格
                         .FirstOrDefault(x => x.Name.Contains(".exe"));
 
                     if (entry is null)
-                        throw new Exception("找不到更新文件");
+                        throw new Exception(Lang.Text("Update.Error.FileNotFound"));
 
                     // 解压到指定文件（覆盖已存在文件）
                     entry.ExtractToFile(output, true);

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesMirrorChyanModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesMirrorChyanModel.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.Utils;
 using PCL.Network;
 using PCL.Network.Loaders;
@@ -64,7 +65,7 @@ public class UpdatesMirrorChyanModel : IUpdateSource // Mirror 酱的更新格�
     public List<ModLoader.LoaderBase> GetDownloadLoader(UpdateChannel channel, UpdateArch arch, string output)
     {
         var loaders = new List<ModLoader.LoaderBase>();
-        loaders.Add(new ModLoader.LoaderTask<int, List<DownloadFile>>("获取下载信息", load =>
+        loaders.Add(new ModLoader.LoaderTask<int, List<DownloadFile>>(Lang.Text("Update.Task.GetDownloadInfo"), load =>
         {
             var ret = (JsonObject)Requester.FetchJson(GetUrl(channel, arch), RequestParam.WithRetry);
             var dlUrl = ret["data"]["url"]?.ToString();
@@ -72,7 +73,7 @@ public class UpdatesMirrorChyanModel : IUpdateSource // Mirror 酱的更新格�
                 throw new Exception("Mirror 酱下载源不可用");
             load.output = new List<DownloadFile> { new(new[] { dlUrl }, output) };
         }));
-        loaders.Add(new LoaderDownload("下载更新文件", new List<DownloadFile>()));
+        loaders.Add(new LoaderDownload(Lang.Text("Update.Task.DownloadUpdateFile"), new List<DownloadFile>()));
         return loaders;
     }
 

--- a/Plain Craft Launcher 2/Modules/Updates/UpdatesWrapperModel.cs
+++ b/Plain Craft Launcher 2/Modules/Updates/UpdatesWrapperModel.cs
@@ -1,3 +1,4 @@
+using PCL.Core.App.Localization;
 using PCL.Core.Utils;
 
 namespace PCL;
@@ -71,7 +72,7 @@ public class UpdatesWrapperModel : IUpdateSource
             }
 
         ModBase.Log("[Update] 错误！所有的版本源都无法使用！");
-        throw new Exception("获取版本信息失败");
+        throw new Exception(Lang.Text("Update.Task.GetVersionInfoFailed"));
     }
 
     public bool IsLatest(UpdateChannel channel, UpdateArch arch, SemVer currentVersion, int currentVersionCode)
@@ -99,7 +100,7 @@ public class UpdatesWrapperModel : IUpdateSource
             }
 
         ModBase.Log("[Update] 错误！所有的版本源都无法使用！");
-        throw new Exception("获取版本信息失败");
+        throw new Exception(Lang.Text("Update.Task.GetVersionInfoFailed"));
     }
 
     public VersionAnnouncementDataModel GetAnnouncementList()
@@ -127,7 +128,7 @@ public class UpdatesWrapperModel : IUpdateSource
             }
 
         ModBase.Log("[Update] 错误！所有的公告源都无法使用！");
-        throw new Exception("获取公告信息失败");
+        throw new Exception(Lang.Text("Update.Task.GetAnnouncementFailed"));
     }
 
     public List<ModLoader.LoaderBase> GetDownloadLoader(UpdateChannel channel, UpdateArch arch, string output)
@@ -155,7 +156,7 @@ public class UpdatesWrapperModel : IUpdateSource
             }
 
         ModBase.Log("[Update] 错误！所有的版本源都无法使用！");
-        throw new Exception("获取版本信息失败");
+        throw new Exception(Lang.Text("Update.Task.GetVersionInfoFailed"));
     }
 
     public async Task<bool> IsLatestAsync(UpdateChannel channel, UpdateArch arch, SemVer currentVersion,

--- a/Plain Craft Launcher 2/Pages/PageLogLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLogLeft.xaml.cs
@@ -49,9 +49,8 @@ public partial class PageLogLeft
             ModMain.frmLogLeft.PanList.Children.Clear();
 
             // 测试实例列表
-            // TODO(i18n): 文本 @ PageLog 左侧 - 列表标题
             ModMain.frmLogLeft.PanList.Children.Add(new TextBlock
-                { Text = "测试实例列表", Margin = new Thickness(13d, 18d, 5d, 4d), Opacity = 0.6d, FontSize = 12d });
+                { Text = Lang.Text("LogPage.Left.InstancesTitle"), Margin = new Thickness(13d, 18d, 5d, 4d), Opacity = 0.6d, FontSize = 12d });
             foreach (var item in shownLogs)
             {
                 // 添加控件
@@ -75,11 +74,10 @@ public partial class PageLogLeft
             }
 
             // 通知日志保留设置
-            // TODO(i18n): 文本 @ PageLog 左侧 - 日志保留设置通知
             if (!States.Hint.MaxGameLog)
             {
                 States.Hint.MaxGameLog = true;
-                ModMain.Hint("实时日志默认只保留 500 行，你可以在 实时日志行数 设置中修改！");
+                ModMain.Hint(Lang.Text("LogPage.MaxLines.Hint", 500));
             }
 
             isLoading -= 1;

--- a/Plain Craft Launcher 2/Pages/PageLogRight.xaml
+++ b/Plain Craft Launcher 2/Pages/PageLogRight.xaml
@@ -6,7 +6,6 @@
     mc:Ignorable="d" x:Class="PCL.PageLogRight">
     <Grid>
         <Grid x:Name="PanAllBack">
-            <!-- TODO(i18n): 文本 @ PageLog 右侧 - 上方卡片标题 -->
             <local:MyCard Margin="16,16,16,100" x:Name="PanLogCard">
                 <local:MyScrollViewer Margin="12,40,12,20"
                                       VerticalScrollBarVisibility="Auto"
@@ -31,9 +30,9 @@
 
         <!--<local:MyCard HorizontalAlignment="Center" VerticalAlignment="Center" Margin="40" x:Name="PanEmpty" UseAnimation="False">
             <StackPanel Margin="20,17">
-                <TextBlock Name="LabEmptyTitle" Margin="0,0,0,9" HorizontalAlignment="Center" Text="无实时日志" FontSize="19" UseLayoutRounding="True" SnapsToDevicePixels="True" Foreground="{DynamicResource ColorBrush3}" />
+                <TextBlock Name="LabEmptyTitle" Margin="0,0,0,9" HorizontalAlignment="Center" Text="{DynamicResource LogPage.Empty.Title}" FontSize="19" UseLayoutRounding="True" SnapsToDevicePixels="True" Foreground="{DynamicResource ColorBrush3}" />
                 <Rectangle HorizontalAlignment="Stretch" Height="2" Fill="{DynamicResource ColorBrush3}" />
-                <TextBlock Name="LabEmptyContent" Margin="10,15,10,5" Text="请点击 实例设置 → 概览 → 测试游戏 以显示游戏的实时日志。" TextWrapping="Wrap" />
+                <TextBlock Name="LabEmptyContent" Margin="10,15,10,5" Text="{DynamicResource LogPage.Empty.Description}" TextWrapping="Wrap" />
             </StackPanel>
         </local:MyCard>-->
 
@@ -43,25 +42,25 @@
             <StackPanel Margin="0,6,0,6">
                 <StackPanel x:Name="OperationsContainer" Orientation="Horizontal" Margin="10,8,10,8"
                             HorizontalAlignment="Center">
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 下方勾选框 # 自动滚屏 -->
-                    <local:MyCheckBox x:Name="CheckAutoScroll" Margin="5,0,5,0" Text="滚动" Checked="True" />
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 下方按钮1 # 导出 -->
-                    <local:MyIconTextButton x:Name="BtnOperationExport" Margin="5,0,0,0" Text="导出"
+                    <local:MyCheckBox x:Name="CheckAutoScroll" Margin="5,0,5,0"
+                                      Text="{DynamicResource LogPage.Action.Scroll}" Checked="True" />
+                    <local:MyIconTextButton x:Name="BtnOperationExport" Margin="5,0,0,0"
+                                            Text="{DynamicResource LogPage.Action.Export}"
                                             Click="BtnOperationExport_Click"
                                             LogoScale="1"
                                             Logo="M819.392 0L1024 202.752v652.16a168.96 168.96 0 0 1-168.832 168.768h-104.192a47.296 47.296 0 0 1-10.752 0H283.776a47.232 47.232 0 0 1-10.752 0H168.832A168.96 168.96 0 0 1 0 854.912V168.768A168.96 168.96 0 0 1 168.832 0h650.56z m110.208 854.912V242.112l-149.12-147.776H168.896c-41.088 0-74.432 33.408-74.432 74.432v686.144c0 41.024 33.344 74.432 74.432 74.432h62.4v-190.528c0-33.408 27.136-60.544 60.544-60.544h440.448c33.408 0 60.544 27.136 60.544 60.544v190.528h62.4c41.088 0 74.432-33.408 74.432-74.432z m-604.032 74.432h372.864v-156.736H325.568v156.736z m403.52-596.48a47.168 47.168 0 1 1 0 94.336H287.872a47.168 47.168 0 1 1 0-94.336h441.216z m0-153.728a47.168 47.168 0 1 1 0 94.4H287.872a47.168 47.168 0 1 1 0-94.4h441.216z" />
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 下方按钮2 # 清空记录 -->
-                    <local:MyIconTextButton x:Name="BtnOperationClear" Margin="5,0,0,0" Text="清空"
+                    <local:MyIconTextButton x:Name="BtnOperationClear" Margin="5,0,0,0"
+                                            Text="{DynamicResource LogPage.Action.Clear}"
                                             Click="BtnOperationClear_Click"
                                             LogoScale="1.1"
                                             Logo="M520.192 0C408.43 0 317.44 82.87 313.563 186.734H52.736c-29.038 0-52.663 21.943-52.663 49.079s23.625 49.152 52.663 49.152h58.075v550.473c0 103.35 75.118 187.757 167.717 187.757h472.43c92.599 0 167.716-83.894 167.716-187.757V285.477h52.59c29.038 0 52.59-21.943 52.663-49.08-0.073-27.135-23.625-49.151-52.663-49.151H726.235C723.237 83.017 631.955 0 520.192 0zM404.846 177.957c3.803-50.03 50.176-89.015 107.447-89.015 57.197 0 103.57 38.985 106.788 89.015H404.92zM284.379 933.669c-33.353 0-69.997-39.351-69.997-95.525v-549.01H833.39v549.522c0 56.247-36.645 95.525-69.998 95.525H284.379v-0.512z M357.23 800.695a48.274 48.274 0 0 0 47.616-49.006V471.7a48.274 48.274 0 0 0-47.543-49.08 48.274 48.274 0 0 0-47.69 49.006V751.69c0 27.282 20.846 49.006 47.617 49.006z m166.62 0a48.274 48.274 0 0 0 47.688-49.006V471.7a48.274 48.274 0 0 0-47.689-49.08 48.274 48.274 0 0 0-47.543 49.006V751.69c0 27.282 21.431 49.006 47.543 49.006z m142.92 0a48.274 48.274 0 0 0 47.543-49.006V471.7a48.274 48.274 0 0 0-47.543-49.08 48.274 48.274 0 0 0-47.616 49.006V751.69c0 27.282 20.773 49.006 47.543 49.006z" />
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 下方按钮3 # 结束游戏进程 -->
-                    <local:MyIconTextButton x:Name="BtnOperationKill" Margin="5,0,0,0" Text="结束进程"
+                    <local:MyIconTextButton x:Name="BtnOperationKill" Margin="5,0,0,0"
+                                            Text="{DynamicResource LogPage.Action.KillProcess}"
                                             Click="BtnOperationKill_Click"
                                             LogoScale="0.85"
                                             Logo="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z" />
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 下方按钮4 # 导出运行栈 -->
-                    <local:MyIconTextButton x:Name="BtnOperationExportStackDump" Margin="5,0,0,0" Text="导出运行栈"
+                    <local:MyIconTextButton x:Name="BtnOperationExportStackDump" Margin="5,0,0,0"
+                                            Text="{DynamicResource LogPage.Action.ExportStack}"
                                             Click="BtnOperationExportStackDump_Click"
                                             LogoScale="0.85"
                                             Logo="M913.066667 264.533333l-371.2-209.066666c-25.6-12.8-59.733333-12.8-85.333334 0L89.6 264.533333C34.133333 298.666667 34.133333 379.733333 89.6 413.866667l371.2 209.066666c25.6 12.8 59.733333 12.8 85.333333 0l371.2-209.066666c55.466667-34.133333 55.466667-119.466667-4.266666-149.333334z m-413.866667 281.6L132.266667 337.066667 499.2 128l371.2 209.066667-371.2 209.066666z M46.933333 516.266667c12.8-21.333333 38.4-25.6 59.733334-17.066667l384 221.866667c12.8 8.533333 29.866667 8.533333 42.666666 0l388.266667-217.6c21.333333-12.8 46.933333-4.266667 59.733333 17.066666 12.8 21.333333 4.266667 46.933333-17.066666 59.733334l-388.266667 217.6c-38.4 21.333333-89.6 21.333333-128 0l-384-221.866667c-21.333333-12.8-25.6-38.4-17.066667-59.733333z M106.666667 669.866667c-21.333333-12.8-46.933333-4.266667-59.733334 17.066666-12.8 21.333333-4.266667 46.933333 17.066667 59.733334l388.266667 217.6c38.4 21.333333 85.333333 21.333333 128 0l379.733333-217.6c21.333333-12.8 25.6-38.4 17.066667-59.733334-12.8-21.333333-38.4-25.6-59.733334-17.066666l-379.733333 217.6c-12.8 8.533333-29.866667 8.533333-42.666667 0l-388.266666-217.6z" />
@@ -71,12 +70,12 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
-                    <!-- TODO(i18n): 文本 @ PageLog 右侧 - 滑动条1 # 实时日志行数 -->
-                    <TextBlock Grid.Column="0" HorizontalAlignment="Left" Text="最大行数" Margin="0,0,25,0" />
+                    <TextBlock Grid.Column="0" HorizontalAlignment="Left"
+                               Text="{DynamicResource LogPage.MaxLines.Title}" Margin="0,0,25,0" />
                     <local:MySlider x:Name="SliderMaxLog" Grid.Column="1" HorizontalAlignment="Stretch"
                                     Change="SliderMaxLog_ValueChanged"
                                     Tag="SystemMaxLog" MaxValue="29" Value="13"
-                                    ToolTip="实时日志功能中最大显示行数，超过该值会自动删除旧的日志。" />
+                                    ToolTip="{DynamicResource LogPage.MaxLines.ToolTip}" />
                 </Grid>
             </StackPanel>
         </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media;
 using PCL.Core.App;
+using PCL.Core.App.Localization;
 using PCL.Core.UI;
 using System.Globalization;
 
@@ -26,8 +27,7 @@ public partial class PageLogRight
     public void Init()
     {
         PanLogCard.Inlines.Clear();
-        // TODO(i18n): 文本 @ 标题栏 - 实时日志卡片标题
-        PanLogCard.Inlines.Add(new Run("实时日志"));
+        PanLogCard.Inlines.Add(new Run(Lang.Text("LogPage.Title")));
         PanLogCard.Inlines.Add(new Run(" | "));
         labDebug = new Run("0 Debug")
             { Foreground = (Brush)System.Windows.Application.Current.Resources["ColorBrushDebug"] };
@@ -87,7 +87,7 @@ public partial class PageLogRight
                 _ when (int)v <= 5 => ((int)v * 10 + 50).ToString(),
                 _ when (int)v <= 13 => ((int)v * 50 - 150).ToString(),
                 _ when (int)v <= 28 => ((int)v * 100 - 800).ToString(),
-                _ => "无限制"
+                _ => Lang.Text("LogPage.MaxLines.Unlimited")
             };
         });
         // 绑定日志输出
@@ -143,14 +143,13 @@ public partial class PageLogRight
 
     private void BtnOperationExport_Click(object sender, ModBase.RouteEventArgs e)
     {
-        // TODO(i18n): 文本 @ 文件选择弹窗 - 窗口标题 & 类型选择器选项
-        var savePath = SystemDialogs.SelectSaveFile("选择导出位置",
-            $"游戏日志 - {ModMain.frmLogLeft.currentLog.version.Name}.log", "游戏日志(*.log)|*.log");
+        var savePath = SystemDialogs.SelectSaveFile(Lang.Text("LogPage.Export.SelectLocation"),
+            Lang.Text("LogPage.Export.GameLog.FileName", ModMain.frmLogLeft.currentLog.version.Name),
+            Lang.Text("LogPage.Export.GameLog.Filter"));
         if (savePath.Length < 3)
             return;
         File.WriteAllLines(savePath, ModMain.frmLogLeft.currentLog.fullLog);
-        // TODO(i18n): 文本 @ 左下角提示 - 导出成功提示
-        ModMain.Hint("日志已导出！", ModMain.HintType.Finish);
+        ModMain.Hint(Lang.Text("LogPage.Export.Success"), ModMain.HintType.Finish);
         ModBase.OpenExplorer(savePath);
     }
 
@@ -159,20 +158,23 @@ public partial class PageLogRight
         if (ModMain.frmLogLeft.currentLog.State <= ModWatcher.Watcher.MinecraftState.Running)
         {
             ModMain.frmLogLeft.currentLog.Kill();
-            // TODO(i18n): 文本 @ 左下角提示 - 客户端关闭提示
-            ModMain.Hint($"已关闭游戏 {ModMain.frmLogLeft.currentLog.version.Name}！", ModMain.HintType.Finish);
+            ModMain.Hint(Lang.Text("LogPage.Action.GameClosed", ModMain.frmLogLeft.currentLog.version.Name),
+                ModMain.HintType.Finish);
         }
     }
 
     private void BtnOperationExportStackDump_Click(object sender, ModBase.RouteEventArgs e)
     {
-        var savePath = SystemDialogs.SelectSaveFile("选择导出位置",
-            $"游戏运行栈 - {DateTime.Now.ToString("G", CultureInfo.InvariantCulture).Replace("/", "-").Replace(":", ".").Replace(" ", "_")}.log",
-            "游戏运行栈(*.log)|*.log");
+        var formattedDate = DateTime.Now.ToString("G", CultureInfo.InvariantCulture)
+            .Replace("/", "-")
+            .Replace(":", ".")
+            .Replace(" ", "_");
+        var savePath = SystemDialogs.SelectSaveFile(Lang.Text("LogPage.Export.SelectLocation"),
+            Lang.Text("LogPage.ExportStack.FileName", formattedDate),
+            Lang.Text("LogPage.ExportStack.Filter"));
         if (savePath.Length < 3)
             return;
-        // TODO(i18n): 文本 @ 左下角提示 - 导出运行栈提示
-        ModMain.Hint("正在导出运行栈，请稍等（可能需要 15 秒 ~ 1 分钟）");
+        ModMain.Hint(Lang.Text("LogPage.ExportStack.Progress"));
         BtnOperationExportStackDump.IsEnabled = false;
         ModBase.RunInNewThread(() =>
         {
@@ -180,8 +182,7 @@ public partial class PageLogRight
             File.WriteAllLines(savePath, dump);
             ModBase.RunInUi(() =>
             {
-                // TODO(i18n): 文本 @ 左下角提示 - 导出运行栈提示
-                ModMain.Hint("运行栈已导出！", ModMain.HintType.Finish);
+                ModMain.Hint(Lang.Text("LogPage.ExportStack.Success"), ModMain.HintType.Finish);
                 BtnOperationExportStackDump.IsEnabled = true;
             });
             ModBase.OpenExplorer(savePath);

--- a/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLogRight.xaml.cs
@@ -29,11 +29,11 @@ public partial class PageLogRight
         PanLogCard.Inlines.Clear();
         PanLogCard.Inlines.Add(new Run(Lang.Text("LogPage.Title")));
         PanLogCard.Inlines.Add(new Run(" | "));
-        labDebug = new Run("0 Debug")
+        labDebug = new Run($"0 {Lang.Text("LogPage.Level.Debug")}")
             { Foreground = (Brush)System.Windows.Application.Current.Resources["ColorBrushDebug"] };
         PanLogCard.Inlines.Add(labDebug);
         PanLogCard.Inlines.Add(new Run(" | "));
-        labInfo = new Run("0 Info")
+        labInfo = new Run($"0 {Lang.Text("LogPage.Level.Info")}")
         {
             Foreground =
                 (Brush)System.Windows.Application.Current.Resources[
@@ -41,15 +41,15 @@ public partial class PageLogRight
         };
         PanLogCard.Inlines.Add(labInfo);
         PanLogCard.Inlines.Add(new Run(" | "));
-        labWarn = new Run("0 Warn")
+        labWarn = new Run($"0 {Lang.Text("LogPage.Level.Warn")}")
             { Foreground = (Brush)System.Windows.Application.Current.Resources["ColorBrushWarn"] };
         PanLogCard.Inlines.Add(labWarn);
         PanLogCard.Inlines.Add(new Run(" | "));
-        labError = new Run("0 Error")
+        labError = new Run($"0 {Lang.Text("LogPage.Level.Error")}")
             { Foreground = (Brush)System.Windows.Application.Current.Resources["ColorBrushError"] };
         PanLogCard.Inlines.Add(labError);
         PanLogCard.Inlines.Add(new Run(" | "));
-        labFatal = new Run("0 Fatal")
+        labFatal = new Run($"0 {Lang.Text("LogPage.Level.Fatal")}")
             { Foreground = (Brush)System.Windows.Application.Current.Resources["ColorBrushFatal"] };
         PanLogCard.Inlines.Add(labFatal);
     }
@@ -102,11 +102,11 @@ public partial class PageLogRight
     {
         // 刷新计数器
 
-        labFatal.Text = $"{ModMain.frmLogLeft.currentLog.countFatal} Fatal";
-        labError.Text = $"{ModMain.frmLogLeft.currentLog.countError} Error";
-        labWarn.Text = $"{ModMain.frmLogLeft.currentLog.countWarn} Warn";
-        labInfo.Text = $"{ModMain.frmLogLeft.currentLog.countInfo} Info";
-        labDebug.Text = $"{ModMain.frmLogLeft.currentLog.countDebug} Debug";
+        labFatal.Text = $"{ModMain.frmLogLeft.currentLog.countFatal} {Lang.Text("LogPage.Level.Fatal")}";
+        labError.Text = $"{ModMain.frmLogLeft.currentLog.countError} {Lang.Text("LogPage.Level.Error")}";
+        labWarn.Text = $"{ModMain.frmLogLeft.currentLog.countWarn} {Lang.Text("LogPage.Level.Warn")}";
+        labInfo.Text = $"{ModMain.frmLogLeft.currentLog.countInfo} {Lang.Text("LogPage.Level.Info")}";
+        labDebug.Text = $"{ModMain.frmLogLeft.currentLog.countDebug} {Lang.Text("LogPage.Level.Debug")}";
     }
 
     private void OnLogOutput(ModWatcher.Watcher sender, ModWatcher.LogOutputEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml
@@ -45,20 +45,20 @@
         <RowDefinition Height="Auto" />
         <RowDefinition Height="1*" />
     </Grid.RowDefinitions>
-    <TextBlock Text="总进度" Grid.Row="1" HorizontalAlignment="Center" FontSize="14"
+    <TextBlock Text="{DynamicResource Speed.Progress.Total}" Grid.Row="1" HorizontalAlignment="Center" FontSize="14"
                Foreground="{DynamicResource ColorBrush3}" />
     <TextBlock Grid.Row="2" Style="{DynamicResource Split}" />
     <TextBlock Text="00.00 %" Grid.Row="3" Name="LabProgress" HorizontalAlignment="Center" FontSize="20" />
-    <TextBlock Text="下载速度" Grid.Row="5" HorizontalAlignment="Center" FontSize="14"
+    <TextBlock Text="{DynamicResource Speed.Progress.Speed}" Grid.Row="5" HorizontalAlignment="Center" FontSize="14"
                Foreground="{DynamicResource ColorBrush3}" />
     <TextBlock Grid.Row="6" Style="{DynamicResource Split}" />
     <TextBlock Text="0 B/s" Grid.Row="7" Name="LabSpeed" HorizontalAlignment="Center" FontSize="20" />
-    <TextBlock Text="剩余文件" Grid.Row="9" HorizontalAlignment="Center" FontSize="14"
-               Foreground="{DynamicResource ColorBrush3}" />
+    <TextBlock Text="{DynamicResource Speed.Progress.RemainingFiles}" Grid.Row="9" HorizontalAlignment="Center"
+               FontSize="14" Foreground="{DynamicResource ColorBrush3}" />
     <TextBlock Grid.Row="10" Style="{DynamicResource Split}" />
     <TextBlock Text="123456789" Grid.Row="11" Name="LabFile" HorizontalAlignment="Center" FontSize="20" />
-    <TextBlock Text="剩余线程" Grid.Row="13" HorizontalAlignment="Center" FontSize="14"
-               Foreground="{DynamicResource ColorBrush3}" />
+    <TextBlock Text="{DynamicResource Speed.Progress.RemainingThreads}" Grid.Row="13" HorizontalAlignment="Center"
+               FontSize="14" Foreground="{DynamicResource ColorBrush3}" />
     <TextBlock Grid.Row="14" Style="{DynamicResource Split}" />
     <TextBlock Text="123456789" Grid.Row="15" Name="LabThread" HorizontalAlignment="Center" FontSize="20" />
 </local:MyPageLeft>

--- a/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSpeedLeft.xaml.cs
@@ -139,12 +139,12 @@ public partial class PageSpeedLeft
                             card.Children.Add((UIElement)ModBase.GetObjectFromXML(
                                 "<Path xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" Stretch=\"Uniform\" Tag=\"Failed\" Data=\"F1 M2.5,0 L0,2.5 7.5,10 0,17.5 2.5,20 10,12.5 17.5,20 20,17.5 12.5,10 20,2.5 17.5,0 10,7.5 2.5,0Z\" Height=\"15\" Width=\"15\" HorizontalAlignment=\"Center\" Grid.Column=\"0\" Grid.Row=\"0\" Fill=\"{DynamicResource ColorBrush3}\" Margin=\"0,1,0,0\" VerticalAlignment=\"Top\"/>"));
                             var tb = (TextBlock)ModBase.GetObjectFromXML(
-                                "<TextBlock xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" TextWrapping=\"Wrap\" HorizontalAlignment=\"Left\" ToolTip=\"单击复制错误详情\" Grid.Column=\"1\" Grid.Row=\"0\" Margin=\"0,0,0,5\" />");
+                                "<TextBlock xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" TextWrapping=\"Wrap\" HorizontalAlignment=\"Left\" ToolTip=\"" + Lang.Text("Speed.Error.ClickToCopy") + "\" Grid.Column=\"1\" Grid.Row=\"0\" Margin=\"0,0,0,5\" />");
                             tb.Text = loader.Error.ToString();
                             tb.MouseLeftButtonDown += (sender, _) =>
                             {
                                 ModBase.ClipboardSet(((TextBlock)sender).Text, false);
-                                ModMain.Hint("已复制错误详情！", ModMain.HintType.Finish);
+                                ModMain.Hint(Lang.Text("Speed.Error.Copied"), ModMain.HintType.Finish);
                             };
                             card.Children.Add(tb);
                             break;

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml
@@ -80,12 +80,12 @@
                             <TextBlock TextWrapping="Wrap" Margin="0,0,0,10"
                                        Text="{DynamicResource Tools.GameLink.Agreement.Description}" />
                             <local:MyListItem Title="{DynamicResource Tools.GameLink.Agreement.PrivacyPolicy}"
-                                              Info="了解 PCL CE 如何处理您的个人信息"
+                                              Info="{DynamicResource Tools.GameLink.Agreement.PrivacyPolicyInfo}"
                                               Type="Clickable" local:CustomEventService.EventType="打开网页"
                                               local:CustomEventService.EventData="https://www.pclc.cc/privacy/personal-info-brief.html"
                                               Logo="pack://application:,,,/images/Blocks/Grass.png" />
                             <local:MyListItem Title="{DynamicResource Tools.GameLink.Agreement.NatayarkTerms}"
-                                              Info="查看 Natayark OpenID 服务条款"
+                                              Info="{DynamicResource Tools.GameLink.Agreement.NatayarkTermsInfo}"
                                               Type="Clickable" local:CustomEventService.EventType="打开网页"
                                               local:CustomEventService.EventData="https://account.naids.com/policy"
                                               Logo="pack://application:,,,/images/Blocks/Grass.png" />
@@ -230,7 +230,7 @@
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center"
                                 Grid.ColumnSpan="2">
                         <local:MyHint Margin="0,0,0,16" x:Name="HintEasyTierVersion"
-                                      Text="联机双方目前使用的启动器版本不同，这可能会导致一些连接问题&#x0A;强烈建议双方升级到最新版本后再继续联机" Theme="Yellow"
+                                      Text="{DynamicResource Tools.GameLink.EasyTierVersion}" Theme="Yellow"
                                       Visibility="Collapsed" />
                     </StackPanel>
                     <!--大厅信息栏-->

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml
@@ -1,9 +1,10 @@
 <local:MyPageRight
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:PCL" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             mc:Ignorable="d" x:Class="PCL.PageToolsGameLink"
-             d:DesignWidth="800" d:DesignHeight="800">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:PCL" xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d" x:Class="PCL.PageToolsGameLink"
+    d:DesignWidth="800" d:DesignHeight="800">
     <Grid>
         <Grid x:Name="PanLoad" Visibility="Collapsed">
             <local:MyCard HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="CardLoad"
@@ -31,18 +32,21 @@
                                      Text="" TextError="" TextErrorInherit="False" AutoRun="False"
                                      IsHitTestVisible="False" />
                     <TextBlock x:Name="LabLoadTitle" Grid.Column="3" Grid.Row="1" Grid.ColumnSpan="2"
-                               VerticalAlignment="Center" Text="正在创建大厅" FontSize="19"
+                               VerticalAlignment="Center" Text="{DynamicResource Tools.GameLink.Loading.Creating}"
+                               FontSize="19"
                                Margin="0,0,25,1" Foreground="{Binding Foreground, ElementName=Load}"
                                IsHitTestVisible="False" />
                     <TextBlock x:Name="LabLoadDesc" Grid.Column="3" Grid.ColumnSpan="3" Grid.Row="2"
-                               VerticalAlignment="Center" Margin="0,5,10,-5" Text="下载联机模块中……" FontSize="14"
+                               VerticalAlignment="Center" Margin="0,5,10,-5"
+                               Text="{DynamicResource Tools.GameLink.Loading.DownloadingModule}" FontSize="14"
                                LineHeight="19" MaxWidth="400" MaxHeight="220" TextWrapping="Wrap"
                                Foreground="{StaticResource ColorBrushGray3}" IsHitTestVisible="False" />
                     <local:MyIconButton Grid.Column="5" Grid.Row="1" x:Name="BtnLoadCancel" Height="28" Width="28"
                                         Click="CancelLoad"
                                         VerticalAlignment="Top"
                                         Theme="Black" Opacity="0.5"
-                                        ToolTip="{DynamicResource Common.Action.Cancel}" ToolTipService.Placement="Right"
+                                        ToolTip="{DynamicResource Common.Action.Cancel}"
+                                        ToolTipService.Placement="Right"
                                         ToolTipService.InitialShowDelay="100"
                                         LogoScale="0.72"
                                         Logo="F1 M2,0 L0,2 8,10 0,18 2,20 10,12 18,20 20,18 12,10 20,2 18,0 10,8 2,0Z" />
@@ -68,79 +72,106 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <local:MyHint x:Name="HintAnnounce" Margin="10" MinHeight="36" MaxHeight="64" Grid.Row="0"
-                              HorizontalAlignment="Stretch" Text="正在连接到大厅服务器..." Theme="Blue" />
+                              HorizontalAlignment="Stretch"
+                              Text="{DynamicResource Tools.GameLink.Loading.ConnectingServer}" Theme="Blue" />
                 <StackPanel x:Name="PanEula" Grid.Row="1" HorizontalAlignment="Stretch" Orientation="Vertical">
-                    <local:MyCard Title="PCL CE 联机大厅说明与条款" Margin="10">
+                    <local:MyCard Title="{DynamicResource Tools.GameLink.Agreement.Title}" Margin="10">
                         <StackPanel Margin="20,40,18,18">
                             <TextBlock TextWrapping="Wrap" Margin="0,0,0,10"
-                                       Text="此处列出了 PCL CE 大厅使用的相关服务文档及介绍" />
-                            <local:MyListItem Title="PCL CE 大厅相关隐私政策" Info="了解 PCL CE 如何处理您的个人信息"
-                                Type="Clickable" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://www.pclc.cc/privacy/personal-info-brief.html"
-                                Logo="pack://application:,,,/images/Blocks/Grass.png" />
-                            <local:MyListItem Title="Natayark Network 用户协议与隐私政策" Info="查看 Natayark OpenID 服务条款"
-                                Type="Clickable" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://account.naids.com/policy"
-                                Logo="pack://application:,,,/images/Blocks/Grass.png" />
-                            <TextBlock TextWrapping="Wrap" Margin="0,10,0,0" 
-                                Text="使用大厅功能即代表你同意下列条款：&#xa;&#xa;我承诺严格遵守中国大陆相关法律法规，不会将大厅功能用于违法违规用途。&#xa;我承诺使用大厅功能带来的一切风险自行承担。&#xa;我已知晓并同意 PCL CE 收集经处理的本机识别码、Natayark ID 与其他信息并在必要时提供给执法部门。&#xa;为保护未成年人个人信息，使用联机大厅前，我确认我已满十四周岁。&#xa;&#xa;另外，你还需要同意 PCL CE 大厅相关隐私政策及《Natayark OpenID 服务条款》。" />
-                            <local:MyButton x:Name="BtnEulaAgree" Text="我已阅读并同意" ColorType="Highlight" HorizontalAlignment="Center" Padding="13,8" Margin="0,10,0,0" Click="BtnAgreeEula_Click"/>
+                                       Text="{DynamicResource Tools.GameLink.Agreement.Description}" />
+                            <local:MyListItem Title="{DynamicResource Tools.GameLink.Agreement.PrivacyPolicy}"
+                                              Info="了解 PCL CE 如何处理您的个人信息"
+                                              Type="Clickable" local:CustomEventService.EventType="打开网页"
+                                              local:CustomEventService.EventData="https://www.pclc.cc/privacy/personal-info-brief.html"
+                                              Logo="pack://application:,,,/images/Blocks/Grass.png" />
+                            <local:MyListItem Title="{DynamicResource Tools.GameLink.Agreement.NatayarkTerms}"
+                                              Info="查看 Natayark OpenID 服务条款"
+                                              Type="Clickable" local:CustomEventService.EventType="打开网页"
+                                              local:CustomEventService.EventData="https://account.naids.com/policy"
+                                              Logo="pack://application:,,,/images/Blocks/Grass.png" />
+                            <TextBlock TextWrapping="Wrap" Margin="0,10,0,0"
+                                       Text="{DynamicResource Tools.GameLink.Agreement.Body}" />
+                            <local:MyButton x:Name="BtnEulaAgree"
+                                            Text="{DynamicResource Tools.GameLink.Agreement.Accept}"
+                                            ColorType="Highlight" HorizontalAlignment="Center" Padding="13,8"
+                                            Margin="0,10,0,0" Click="BtnAgreeEula_Click" />
                         </StackPanel>
                     </local:MyCard>
                 </StackPanel>
                 <StackPanel x:Name="PanSelect" Grid.Row="1" HorizontalAlignment="Stretch" Orientation="Vertical">
                     <StackPanel Margin="10,4" HorizontalAlignment="Right" Orientation="Horizontal">
                         <local:MyCard Margin="12,0" x:Name="BtnNatTest">
-                            <StackPanel Orientation="Horizontal" Background="{StaticResource ColorBrushSemiTransparent}" MouseLeftButtonUp="BtnNetTest_Click"
-                                    ToolTip="NAT 类型" ToolTipService.Placement="Center" ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
-                                <Path IsHitTestVisible="False" Width="14" Stretch="Uniform" Fill="{DynamicResource ColorBrushGray1}" Margin="12,0,7,0"
-                                        Data="M623.008 879.328c-10.624-20.096-21.888-49.344-15.68-66.816 5.28-14.624 9.568-18.144 18.112-25.12 11.424-9.312 27.04-22.048 39.488-54.304 4.768-12.48 7.936-25.024 10.944-37.12 10.976-43.904 14.88-50.656 46.72-46.976 23.872 2.816 38.72 14.304 55.872 27.648 16.864 13.056 36 26.944 62.368 31.488a384.704 384.704 0 0 1-217.824 171.2M181.76 708.768c27.744-3.328 58.112-13.024 79.776-36.704 23.968-26.112 24.128-60.256 24.256-87.68 0.192-37.344 2.24-47.584 21.12-54.624 25.856-9.568 37.536-0.416 61.76 21.088 14.272 12.64 30.4 26.976 51.84 33.568 25.248 7.776 55.488 4.16 80.832-9.76a107.744 107.744 0 0 0 52.032-64.8l0.128 0.032 0.224-0.96c0.096-0.256 0.224-0.448 0.288-0.704 0.256-0.928 0.288-1.792 0.544-2.72 1.888-6.528 3.2-13.088 4.032-19.616 0.416-2.912 0.544-5.568 0.8-8.384 0.16-2.24 0.448-4.512 0.544-6.72a311.424 311.424 0 0 0-0.832-44.16 337.6 337.6 0 0 1-1.024-19.552c0.32-7.456 1.664-13.44 4.352-17.216 5.216-2.528 19.2-5.024 28.864-6.72 26.688-4.672 59.328-10.656 79.04-33.824l0.288-0.224-0.032-0.032c1.152-1.376 2.464-2.592 3.52-4.096 33.344-46.976 31.296-95.52-5.28-126.752a120.768 120.768 0 0 0-8.992-6.656c-21.536-14.976-30.72-25.536-24.416-44.928 1.856-5.856 3.84-10.912 5.824-15.52 147.904 53.408 253.824 194.592 253.824 360.896 0 46.24-8.64 90.4-23.584 131.456-6.08 1.6-11.424 2.72-14.144 2.72-13.152 0-22.656-6.88-39.68-20.128-20.544-15.936-46.08-35.744-87.616-40.608-89.504-10.656-106.4 55.488-116.288 94.976-2.496 10.048-4.96 20.256-8.64 29.696-6.272 16.384-11.52 20.64-20.16 27.68-11.232 9.184-26.656 21.76-37.888 53.184-12.48 34.816-1.088 73.792 11.36 101.792-15.52 1.92-31.264 3.232-47.36 3.232-140.032 0-262.208-75.232-329.312-187.232M511.04 128c23.264 0 45.92 2.4 68.032 6.368-1.6 4.032-3.136 8.032-4.608 12.608-21.888 67.904 31.36 104.96 48.832 117.088 1.664 1.184 3.072 2.112 3.968 2.816 3.904 3.328 13.824 12.192-3.616 38.336-6.176 5.28-12.512 6.24-28 6.976-20.832 0.992-52.16 2.528-80 33.504l-0.128 0.096-0.064 0.096-0.352 0.32c-0.576 0.64-0.96 1.344-1.472 1.984-14.784 17.312-18.976 36.256-19.424 54.848-0.672 12.288 0.096 24.64 0.832 36.416 0.8 12.896 1.472 25.184 0.416 36.096-0.672 5.12-1.664 10.368-3.136 15.744a43.84 43.84 0 0 1-21.76 27.232c-10.176 5.568-22.528 7.456-31.168 4.736-8.192-2.528-17.952-11.168-28.256-20.32-25.376-22.496-63.68-56.544-126.56-33.152-62.336 23.232-62.592 78.016-62.784 114.272-0.096 18.944-0.192 36.864-7.456 44.8-13.376 14.624-40.8 17.696-62.72 17.184A381.824 381.824 0 0 1 127.104 512c0-212.064 171.936-384 384-384m0-64c-247.04 0-448 200.96-448 448s200.96 448 448 448 448-200.96 448-448-200.96-448-448-448" />
-                                <TextBlock x:Name="LabNatType" IsHitTestVisible="False" Text="点击测试" VerticalAlignment="Center" Foreground="{DynamicResource ColorBrushGray1}"  Margin="0,0,12,0" />
+                            <StackPanel Orientation="Horizontal"
+                                        Background="{StaticResource ColorBrushSemiTransparent}"
+                                        MouseLeftButtonUp="BtnNetTest_Click"
+                                        ToolTip="{DynamicResource Tools.GameLink.Nat.Title}"
+                                        ToolTipService.Placement="Center" ToolTipService.InitialShowDelay="100"
+                                        ToolTipService.VerticalOffset="-35">
+                                <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
+                                      Fill="{DynamicResource ColorBrushGray1}" Margin="12,0,7,0"
+                                      Data="M623.008 879.328c-10.624-20.096-21.888-49.344-15.68-66.816 5.28-14.624 9.568-18.144 18.112-25.12 11.424-9.312 27.04-22.048 39.488-54.304 4.768-12.48 7.936-25.024 10.944-37.12 10.976-43.904 14.88-50.656 46.72-46.976 23.872 2.816 38.72 14.304 55.872 27.648 16.864 13.056 36 26.944 62.368 31.488a384.704 384.704 0 0 1-217.824 171.2M181.76 708.768c27.744-3.328 58.112-13.024 79.776-36.704 23.968-26.112 24.128-60.256 24.256-87.68 0.192-37.344 2.24-47.584 21.12-54.624 25.856-9.568 37.536-0.416 61.76 21.088 14.272 12.64 30.4 26.976 51.84 33.568 25.248 7.776 55.488 4.16 80.832-9.76a107.744 107.744 0 0 0 52.032-64.8l0.128 0.032 0.224-0.96c0.096-0.256 0.224-0.448 0.288-0.704 0.256-0.928 0.288-1.792 0.544-2.72 1.888-6.528 3.2-13.088 4.032-19.616 0.416-2.912 0.544-5.568 0.8-8.384 0.16-2.24 0.448-4.512 0.544-6.72a311.424 311.424 0 0 0-0.832-44.16 337.6 337.6 0 0 1-1.024-19.552c0.32-7.456 1.664-13.44 4.352-17.216 5.216-2.528 19.2-5.024 28.864-6.72 26.688-4.672 59.328-10.656 79.04-33.824l0.288-0.224-0.032-0.032c1.152-1.376 2.464-2.592 3.52-4.096 33.344-46.976 31.296-95.52-5.28-126.752a120.768 120.768 0 0 0-8.992-6.656c-21.536-14.976-30.72-25.536-24.416-44.928 1.856-5.856 3.84-10.912 5.824-15.52 147.904 53.408 253.824 194.592 253.824 360.896 0 46.24-8.64 90.4-23.584 131.456-6.08 1.6-11.424 2.72-14.144 2.72-13.152 0-22.656-6.88-39.68-20.128-20.544-15.936-46.08-35.744-87.616-40.608-89.504-10.656-106.4 55.488-116.288 94.976-2.496 10.048-4.96 20.256-8.64 29.696-6.272 16.384-11.52 20.64-20.16 27.68-11.232 9.184-26.656 21.76-37.888 53.184-12.48 34.816-1.088 73.792 11.36 101.792-15.52 1.92-31.264 3.232-47.36 3.232-140.032 0-262.208-75.232-329.312-187.232M511.04 128c23.264 0 45.92 2.4 68.032 6.368-1.6 4.032-3.136 8.032-4.608 12.608-21.888 67.904 31.36 104.96 48.832 117.088 1.664 1.184 3.072 2.112 3.968 2.816 3.904 3.328 13.824 12.192-3.616 38.336-6.176 5.28-12.512 6.24-28 6.976-20.832 0.992-52.16 2.528-80 33.504l-0.128 0.096-0.064 0.096-0.352 0.32c-0.576 0.64-0.96 1.344-1.472 1.984-14.784 17.312-18.976 36.256-19.424 54.848-0.672 12.288 0.096 24.64 0.832 36.416 0.8 12.896 1.472 25.184 0.416 36.096-0.672 5.12-1.664 10.368-3.136 15.744a43.84 43.84 0 0 1-21.76 27.232c-10.176 5.568-22.528 7.456-31.168 4.736-8.192-2.528-17.952-11.168-28.256-20.32-25.376-22.496-63.68-56.544-126.56-33.152-62.336 23.232-62.592 78.016-62.784 114.272-0.096 18.944-0.192 36.864-7.456 44.8-13.376 14.624-40.8 17.696-62.72 17.184A381.824 381.824 0 0 1 127.104 512c0-212.064 171.936-384 384-384m0-64c-247.04 0-448 200.96-448 448s200.96 448 448 448 448-200.96 448-448-200.96-448-448-448" />
+                                <TextBlock x:Name="LabNatType" IsHitTestVisible="False"
+                                           Text="{DynamicResource Tools.GameLink.Nat.Test}" VerticalAlignment="Center"
+                                           Foreground="{DynamicResource ColorBrushGray1}" Margin="0,0,12,0" />
                             </StackPanel>
                         </local:MyCard>
 
                         <local:MyCard x:Name="BtnNatayarkUserName">
                             <StackPanel Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}"
-                                        ToolTip="Natayark 账户" ToolTipService.Placement="Center"
+                                        ToolTip="{DynamicResource Tools.GameLink.Natayark.Account}"
+                                        ToolTipService.Placement="Center"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{DynamicResource ColorBrushGray1}" Margin="12,0,7,0"
                                       Data="M512 447.223c-88.224 0-160-71.776-160-160s71.776-160 160-160c88.225 0 160 71.776 160 160s-71.775 160-160 160z m0-256c-52.935 0-96 43.065-96 96s43.065 96 96 96 96-43.065 96-96-43.065-96-96-96zM454.901 870.594c-96.594 0-184.933-3.802-231.263-49.955C203.308 800.386 193 774.164 193 742.701c0-31.629 10.247-62.812 30.457-92.686 17.978-26.573 42.908-50.741 74.098-71.833C359.256 536.46 437.418 512.53 512 512.53c74.55 0 152.55 23.943 214.002 65.691 31.05 21.094 55.861 45.273 73.746 71.867C819.822 679.937 830 711.096 830 742.701c0 31.552-10.317 57.827-30.664 78.097-50.714 50.521-151.822 50.128-258.88 49.723a7395.45 7395.45 0 0 0-56.914-0.001c-9.605 0.037-19.163 0.074-28.641 0.074zM512 806.447c9.567 0 19.149 0.037 28.701 0.073 49.52 0.191 96.284 0.37 135.808-4.396 38.418-4.633 64.546-13.604 77.659-26.668 5.079-5.06 11.832-13.96 11.832-32.755 0-38.089-27.688-78.744-75.963-111.54C638.933 596.442 574.04 576.53 512 576.53c-126.309 0-255 83.862-255 166.171 0 18.675 6.738 27.547 11.807 32.596 32.045 31.922 128.975 31.55 214.491 31.224 9.556-0.037 19.139-0.074 28.702-0.074z" />
                                 <TextBlock x:Name="LabNatayarkUserName"
                                            MouseLeftButtonUp="LabNatayarkUserName_MouseLeftButtonUp"
-                                           Text="点击登录 Natayark 账户" VerticalAlignment="Center"
+                                           Text="{DynamicResource Tools.GameLink.Natayark.Login}"
+                                           VerticalAlignment="Center"
                                            Foreground="{DynamicResource ColorBrushGray1}" Margin="0,0,12,0" />
                             </StackPanel>
                         </local:MyCard>
                     </StackPanel>
-                    <local:MyCard x:Name="BtnSelectJoin" Margin="10" Title="加入大厅">
+                    <local:MyCard x:Name="BtnSelectJoin" Margin="10"
+                                  Title="{DynamicResource Tools.GameLink.Join.Title}">
                         <StackPanel Margin="10,30,10,10">
                             <TextBlock LineHeight="23" FontSize="14" TextWrapping="Wrap" Margin="10,10,10,-2"
-                                       Text="1、在下方输入朋友发送给你的大厅编号，单击【加入】&#xa;2、启动游戏，选择【多人游戏】，在局域网游戏中加入大厅" />
+                                       Text="{DynamicResource Tools.GameLink.Join.Description}" />
                             <DockPanel Margin="10" Height="28">
-                                <local:MyButton x:Name="BtnJoin" DockPanel.Dock="Right" Text="加入" ColorType="Highlight"
+                                <local:MyButton x:Name="BtnJoin" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Tools.GameLink.Join.Action}"
+                                                ColorType="Highlight"
                                                 Width="50" Margin="10,0,0,0" Click="BtnJoin_Click" />
-                                <local:MyButton x:Name="BtnPaste" DockPanel.Dock="Right" Text="粘贴" ColorType="Normal"
+                                <local:MyButton x:Name="BtnPaste" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Tools.GameLink.Join.Paste}" ColorType="Normal"
                                                 Width="50" Margin="10,0,0,0" Click="PasteLobbyId" />
-                                <local:MyButton x:Name="BtnClearLobbyId" DockPanel.Dock="Right" Text="清除"
+                                <local:MyButton x:Name="BtnClearLobbyId" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Tools.GameLink.Join.Clear}"
                                                 Click="ClearLobbyId"
                                                 ColorType="Normal" Width="50" Margin="10,0,0,0" />
-                                <local:MyTextBox x:Name="TextJoinLobbyId" HintText="编号应该长得像这样：U/NNNN-AAAA-SSSS-EEEE"
+                                <local:MyTextBox x:Name="TextJoinLobbyId"
+                                                 HintText="{DynamicResource Tools.GameLink.Join.IdHint}"
                                                  MaxLines="1" AcceptsReturn="False" KeyDown="TextJoinLobbyId_KeyDown" />
                             </DockPanel>
                         </StackPanel>
                     </local:MyCard>
                     <!--<local:MyHint IsWarn="True" Text="这是错误文本。" x:Name="HintTypeError" Visibility="Collapsed" Grid.ColumnSpan="5" Grid.RowSpan="5" Margin="15,15,15,0" VerticalAlignment="Top" />-->
-                    <local:MyCard x:Name="BtnSelectCreate" Margin="10" Title="创建大厅" CanSwap="True">
+                    <local:MyCard x:Name="BtnSelectCreate" Margin="10"
+                                  Title="{DynamicResource Tools.GameLink.Create.Title}" CanSwap="True">
                         <StackPanel Margin="10,30,10,10">
                             <TextBlock LineHeight="23" FontSize="14" TextWrapping="Wrap" Margin="10,10,10,0"
-                                       Text="1、进入世界后，在游戏菜单中选择【对局域网开放】&#xa;2、在下方选择此游戏实例，单击【创建】&#xa;3、成功创建大厅后，复制大厅编号并发送给你的朋友" />
+                                       Text="{DynamicResource Tools.GameLink.Create.Description}" />
                             <DockPanel Margin="10" Height="28">
-                                <local:MyButton x:Name="BtnCreate" DockPanel.Dock="Right" Text="创建"
+                                <local:MyButton x:Name="BtnCreate" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Tools.GameLink.Create.Action}"
                                                 ColorType="Highlight" Width="50" Margin="10,0,0,0"
                                                 Click="BtnCreate_Click" />
-                                <local:MyButton x:Name="BtnRefresh" DockPanel.Dock="Right" Text="{DynamicResource Common.Action.Refresh}" ColorType="Normal"
+                                <local:MyButton x:Name="BtnRefresh" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Common.Action.Refresh}" ColorType="Normal"
                                                 Width="50" Margin="10,0,0,0" Click="BtnRefresh_Click" />
-                                <local:MyButton x:Name="BtnInputPort" DockPanel.Dock="Right" Text="手动输入"
+                                <local:MyButton x:Name="BtnInputPort" DockPanel.Dock="Right"
+                                                Text="{DynamicResource Tools.GameLink.Create.ManualInput}"
                                                 ColorType="Normal" Width="80" Margin="10,0,0,0"
                                                 Click="BtnInputPort_Click" />
                                 <local:MyComboBox x:Name="ComboWorldList" DropDownWidthSync="False" />
@@ -150,22 +181,36 @@
                 </StackPanel>
                 <local:MyCard x:Name="PanFooter" Grid.Row="2" Margin="10">
                     <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical" Opacity="0.75" Margin="8">
-                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="15,6" Orientation="Horizontal">
-                            <local:MyTextButton Text="违法违规举报" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://qm.qq.com/q/zfml1KaPWS" />
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="15,6"
+                                    Orientation="Horizontal">
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.Report}"
+                                                local:CustomEventService.EventType="打开网页"
+                                                local:CustomEventService.EventData="https://qm.qq.com/q/zfml1KaPWS" />
                             <TextBlock Text=" | " />
-                            <local:MyTextButton Text="Natayark Network 用户协议与隐私政策" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://account.naids.com/policy" />
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.Terms}"
+                                                local:CustomEventService.EventType="打开网页"
+                                                local:CustomEventService.EventData="https://account.naids.com/policy" />
                             <TextBlock Text=" | " />
-                            <local:MyTextButton Text="大厅隐私协议" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://www.pclc.cc/privacy/personal-info-brief.html" />
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.Privacy}"
+                                                local:CustomEventService.EventType="打开网页"
+                                                local:CustomEventService.EventData="https://www.pclc.cc/privacy/personal-info-brief.html" />
                             <TextBlock Text=" | " />
-                            <local:MyTextButton Text="停用联机功能" x:Name="BtnEulaStop" Click="BtnEulaStop_Click"/>
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.Disable}"
+                                                x:Name="BtnEulaStop" Click="BtnEulaStop_Click" />
                             <TextBlock Text=" | " />
-                            <local:MyTextButton Text="常见问题解答" local:CustomEventService.EventType="打开帮助" local:CustomEventService.EventData="启动器/P2P 联机常见问题.json" />
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.Faq}"
+                                                local:CustomEventService.EventType="打开帮助"
+                                                local:CustomEventService.EventData="启动器/P2P 联机常见问题.json" />
                         </StackPanel>
-                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="15,6" Orientation="Horizontal">
-                            <TextBlock Text="友情链接：" />
-                            <local:MyTextButton Text="EasyTier 工具官网" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://easytier.cn/" />
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="15,6"
+                                    Orientation="Horizontal">
+                            <TextBlock Text="{DynamicResource Tools.GameLink.Link.Friends}" />
+                            <local:MyTextButton Text="{DynamicResource Tools.GameLink.Link.EasyTier}"
+                                                local:CustomEventService.EventType="打开网页"
+                                                local:CustomEventService.EventData="https://easytier.cn/" />
                             <TextBlock Text=" | " />
-                            <local:MyTextButton Text="Pysio's Home" local:CustomEventService.EventType="打开网页" local:CustomEventService.EventData="https://pysio.online/" />
+                            <local:MyTextButton Text="Pysio's Home" local:CustomEventService.EventType="打开网页"
+                                                local:CustomEventService.EventData="https://pysio.online/" />
                         </StackPanel>
                     </StackPanel>
                 </local:MyCard>
@@ -189,22 +234,26 @@
                                       Visibility="Collapsed" />
                     </StackPanel>
                     <!--大厅信息栏-->
-                    <local:MyCard x:Name="PanNetInfo" Title="大厅信息" Margin="10" Grid.Row="2">
+                    <local:MyCard x:Name="PanNetInfo" Title="{DynamicResource Tools.GameLink.Finish.InfoTitle}"
+                                  Margin="10" Grid.Row="2">
                         <StackPanel Orientation="Vertical" Margin="10,35,10,10">
                             <StackPanel x:Name="BtnFinishQuality" Margin="5" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}"
-                                        ToolTip="连接状况" ToolTipService.Placement="MousePoint"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.ConnectionStatus}"
+                                        ToolTipService.Placement="MousePoint"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="0,0,7,0"
                                       Data="M512 128c212.064 0 384 171.936 384 384s-173.632 384-384 384C299.936 896 128 724.064 128 512S299.936 128 512 128z m-126.4 575.968c-1.728 40.8 3.52 76.8 36.32 115.2 28.576 8.32 58.816 12.832 90.08 12.832 81.984 0 156.8-30.848 213.408-81.536-77.12 7.2-161.6-5.952-289.216-61.856-11.616 7.52-18.976 12.608-50.592 15.36z m-193.44-202.368c0 123.744 53.536 214.272 135.744 272.16-6.08-25.6-8.352-48.448-4.96-91.68-21.344-17.6-34.944-39.264-34.624-82.08-50.816-42.88-82.88-75.712-96.16-98.4zM544 448c-14.944 0-29.12-3.424-41.728-9.504-10.976 12.96-21.376 26.432-31.2 40.512-4.832 6.912-15.36 23.776-31.616 50.624a95.872 95.872 0 0 1 36.384 106.432c155.52 68.16 302.56 62.048 325.952 11.904 23.36-50.112-35.968-139.776-189.504-228.48A95.68 95.68 0 0 1 544 448z m-160 128a32 32 0 1 0 0 64 32 32 0 0 0 0-64z m-161.92-199.2c-16.576 35.52 16.96 99.68 94.08 163.2a95.936 95.936 0 0 1 59.616-27.648c19.936-35.008 30.72-52.736 42.88-70.08 10.944-15.648 22.528-30.656 38.432-49.44-5.696-12.128-8.96-25.6-9.088-39.872-118.176-30.4-206.88-16.96-225.92 23.84z m415.136-47.84c1.824 7.36 3.296 19.104 2.336 32.416 88.96 48.704 153.76 105.056 192.32 160.704 0-118.656-34.208-176.064-75.52-210.976-49.792-5.92-69.952-4.064-119.136 17.856zM544 320a32 32 0 1 0 0 64 32 32 0 0 0 0-64z m-32-128c-82.016 0-156.8 30.848-213.44 81.6 47.264-4.384 96-0.544 170.304 18.624A95.84 95.84 0 0 1 544 256c21.568 0 41.472 7.104 57.504 19.104 35.968-17.28 62.016-25.824 87.136-29.984A318.528 318.528 0 0 0 512 192z" />
-                                <TextBlock x:Name="LabFinishQuality" IsHitTestVisible="False" Text="检测中"
+                                <TextBlock x:Name="LabFinishQuality" IsHitTestVisible="False"
+                                           Text="{DynamicResource Tools.GameLink.Finish.Checking}"
                                            VerticalAlignment="Center" Foreground="{StaticResource ColorBrushGray1}"
                                            Margin="0,0,12,0" />
                             </StackPanel>
                             <StackPanel x:Name="BtnFinishPing" Margin="5" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}" Visibility="Collapsed"
-                                        ToolTip="与大厅创建者的延迟" ToolTipService.Placement="MousePoint"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.PingToHost}"
+                                        ToolTipService.Placement="MousePoint"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="0,0,7,0"
@@ -215,7 +264,8 @@
                             </StackPanel>
                             <StackPanel x:Name="BtnFinishId" Margin="5" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}"
-                                        ToolTip="大厅编号" ToolTipService.Placement="MousePoint"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.LobbyId}"
+                                        ToolTipService.Placement="MousePoint"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="0,0,7,0"
@@ -226,12 +276,14 @@
                             </StackPanel>
                             <StackPanel x:Name="BtnConnectType" Margin="5" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}" Visibility="Collapsed"
-                                        ToolTip="连接方式" ToolTipService.Placement="MousePoint"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.ConnectionType}"
+                                        ToolTipService.Placement="MousePoint"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="0,0,7,0"
                                       Data="M215.625 18.75A9.375 9.375 0 0 1 225 28.125V249.24375L283.9875 190.2375A9.375 9.375 0 0 1 297.2625000000001 203.5125L222.2625 278.5125000000001A9.375 9.375 0 0 1 208.9875 278.5125000000001L133.9875 203.5125A9.375 9.375 0 1 1 147.2625 190.2375L206.25 249.24375V28.125A9.375 9.375 0 0 1 215.625 18.75zM84.375 281.25A9.375 9.375 0 0 0 93.75 271.875V50.75625L152.7375 109.7625A9.375 9.375 0 0 0 166.0125 96.4875L91.0125 21.4875A9.375 9.375 0 0 0 77.7375 21.4875L2.7375 96.4875A9.375 9.375 0 0 0 16.0125 109.7625L75 50.75625V271.875A9.375 9.375 0 0 0 84.375 281.25z" />
-                                <TextBlock x:Name="LabConnectType" IsHitTestVisible="False" Text="连接中"
+                                <TextBlock x:Name="LabConnectType" IsHitTestVisible="False"
+                                           Text="{DynamicResource Tools.GameLink.Finish.Connecting}"
                                            VerticalAlignment="Center" Foreground="{StaticResource ColorBrushGray1}"
                                            Margin="0,0,12,0" />
                             </StackPanel>
@@ -242,7 +294,8 @@
                         <StackPanel Orientation="Horizontal">
                             <StackPanel x:Name="BtnConnectUserName" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}"
-                                        ToolTip="用户名" ToolTipService.Placement="Center"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.UserName}"
+                                        ToolTipService.Placement="Center"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Width="14" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="12,0,7,0"
@@ -260,7 +313,8 @@
                             </TextBlock>
                             <StackPanel x:Name="BtnConnectUserType" Orientation="Horizontal"
                                         Background="{StaticResource ColorBrushSemiTransparent}"
-                                        ToolTip="用户类型" ToolTipService.Placement="Center"
+                                        ToolTip="{DynamicResource Tools.GameLink.Finish.UserType}"
+                                        ToolTipService.Placement="Center"
                                         ToolTipService.InitialShowDelay="100" ToolTipService.VerticalOffset="-35">
                                 <Path IsHitTestVisible="False" Height="13" Width="13" Stretch="Uniform"
                                       Fill="{StaticResource ColorBrushGray1}" Margin="12,0,7,0"
@@ -272,21 +326,26 @@
                         </StackPanel>
                     </local:MyCard>
                     <!--操作栏-->
-                    <local:MyCard x:Name="PanOperation" Title="大厅操作" Margin="10" Grid.Row="3">
+                    <local:MyCard x:Name="PanOperation" Title="{DynamicResource Tools.GameLink.Finish.Actions}"
+                                  Margin="10" Grid.Row="3">
                         <StackPanel Orientation="Vertical" Margin="10,35,10,10">
                             <local:MyIconTextButton Margin="-2,1" HorizontalAlignment="Left" x:Name="BtnFinishCopyIp"
-                                                    Text="复制虚拟 IP" Click="BtnFinishCopyIp_Click"
+                                                    Text="{DynamicResource Tools.GameLink.Finish.CopyVirtualIp}"
+                                                    Click="BtnFinishCopyIp_Click"
                                                     Logo="M394.666667 106.666667h448a74.666667 74.666667 0 0 1 74.666666 74.666666v448a74.666667 74.666667 0 0 1-74.666666 74.666667H394.666667a74.666667 74.666667 0 0 1-74.666667-74.666667V181.333333a74.666667 74.666667 0 0 1 74.666667-74.666666z m0 64a10.666667 10.666667 0 0 0-10.666667 10.666666v448a10.666667 10.666667 0 0 0 10.666667 10.666667h448a10.666667 10.666667 0 0 0 10.666666-10.666667V181.333333a10.666667 10.666667 0 0 0-10.666666-10.666666H394.666667z m245.333333 597.333333a32 32 0 0 1 64 0v74.666667a74.666667 74.666667 0 0 1-74.666667 74.666666H181.333333a74.666667 74.666667 0 0 1-74.666666-74.666666V394.666667a74.666667 74.666667 0 0 1 74.666666-74.666667h74.666667a32 32 0 0 1 0 64h-74.666667a10.666667 10.666667 0 0 0-10.666666 10.666667v448a10.666667 10.666667 0 0 0 10.666666 10.666666h448a10.666667 10.666667 0 0 0 10.666667-10.666666v-74.666667z" />
                             <local:MyIconTextButton Margin="-2,1" HorizontalAlignment="Left" x:Name="BtnFinishCopy"
-                                                    Text="复制大厅编号" Click="BtnFinishCopy_Click"
+                                                    Text="{DynamicResource Tools.GameLink.Finish.CopyLobbyId}"
+                                                    Click="BtnFinishCopy_Click"
                                                     Logo="M394.666667 106.666667h448a74.666667 74.666667 0 0 1 74.666666 74.666666v448a74.666667 74.666667 0 0 1-74.666666 74.666667H394.666667a74.666667 74.666667 0 0 1-74.666667-74.666667V181.333333a74.666667 74.666667 0 0 1 74.666667-74.666666z m0 64a10.666667 10.666667 0 0 0-10.666667 10.666666v448a10.666667 10.666667 0 0 0 10.666667 10.666667h448a10.666667 10.666667 0 0 0 10.666666-10.666667V181.333333a10.666667 10.666667 0 0 0-10.666666-10.666666H394.666667z m245.333333 597.333333a32 32 0 0 1 64 0v74.666667a74.666667 74.666667 0 0 1-74.666667 74.666666H181.333333a74.666667 74.666667 0 0 1-74.666666-74.666666V394.666667a74.666667 74.666667 0 0 1 74.666666-74.666667h74.666667a32 32 0 0 1 0 64h-74.666667a10.666667 10.666667 0 0 0-10.666666 10.666667v448a10.666667 10.666667 0 0 0 10.666666 10.666666h448a10.666667 10.666667 0 0 0 10.666667-10.666666v-74.666667z" />
                             <local:MyIconTextButton Margin="-2,1" HorizontalAlignment="Left" x:Name="BtnFinishExit"
-                                                    Text="退出大厅" Click="BtnFinishExit_Click"
+                                                    Text="{DynamicResource Tools.GameLink.Finish.Exit}"
+                                                    Click="BtnFinishExit_Click"
                                                     Logo="M718.9248 239.328c24.1984 17.2096 45.7152 36.704 64.5376 58.4896s34.9568 45.312 48.4032 70.592c13.4464 25.28 23.6608 52.032 30.6496 80.2688 6.9952 28.2368 10.4896 56.8704 10.4896 85.9136 0 50.016-9.5424 96.9408-28.64 140.7744-19.0848 43.8336-44.9088 82.016-77.4464 114.5536s-70.7264 58.3552-114.5536 77.4464C608.5376 886.4576 561.6192 896 511.5968 896c-49.472 0-96.1344-9.5424-139.9616-28.64-43.8336-19.0848-82.1504-44.9088-114.9568-77.4464s-58.6176-70.7264-77.4464-114.5536-28.2368-90.7584-28.2368-140.7744c0-28.4992 3.36-56.4736 10.0864-83.8976 6.72-27.4304 16.2624-53.5104 28.64-78.2464 12.3712-24.7424 27.6928-47.872 45.984-69.376 18.2848-21.5168 38.72-40.8768 61.3056-58.0928 11.84-8.6016 24.608-11.8272 38.3232-9.6768 13.7152 2.1504 24.8704 8.8768 33.472 20.1664 8.608 11.296 11.84 23.936 9.6896 37.92-2.1568 13.984-8.8768 25.28-20.1728 33.8816C324.4352 352 298.4896 382.3872 280.4736 418.4192c-18.016 36.032-27.0336 74.7584-27.0336 116.1664 0 35.5008 6.7264 68.9728 20.1728 100.4352 13.4464 31.4624 31.8656 58.8928 55.2576 82.2848 23.3984 23.392 50.8224 41.952 82.2848 55.6608 31.4624 13.7216 64.9344 20.576 100.4288 20.576 35.5008 0 68.9792-6.8544 100.4352-20.576 31.4624-13.7152 58.8928-32.2688 82.2848-55.6608 23.3984-23.392 41.952-50.8224 55.6608-82.2848 13.7216-31.4624 20.576-64.9344 20.576-100.4352 0-41.952-9.6832-81.6128-29.0432-118.9888s-46.5216-68.1664-81.472-92.3712c-11.84-8.064-18.9632-19.0912-21.3824-33.0688-2.4192-13.9904 0.4032-26.8928 8.4672-38.7264 8.0704-11.296 19.0912-18.1504 33.0752-20.5696C694.1824 228.4352 707.0912 231.264 718.9248 239.328L718.9248 239.328zM511.5968 537.0048c-13.984 0-25.9456-4.9728-35.8912-14.9184-9.952-9.952-14.9248-21.92-14.9248-35.904L460.7808 179.6288c0-13.984 4.9728-26.08 14.9248-36.3008S497.6128 128 511.5968 128c14.528 0 26.7648 5.1072 36.704 15.328 9.9584 10.2208 14.9312 22.3168 14.9312 36.3008l0 306.5536c0 13.984-4.9728 25.952-14.9312 35.904C538.3552 532.032 526.1184 537.0048 511.5968 537.0048L511.5968 537.0048zM511.5968 537.0048" />
                         </StackPanel>
                     </local:MyCard>
                     <!--成员-->
-                    <local:MyCard x:Name="CardPlayerList" Title="大厅成员列表（正在获取信息）" Margin="10" MinWidth="300"
+                    <local:MyCard x:Name="CardPlayerList" Title="{DynamicResource Tools.GameLink.Member.ListLoading}"
+                                  Margin="10" MinWidth="300"
                                   Grid.Row="1" Grid.RowSpan="4" Grid.Column="1">
                         <StackPanel x:Name="StackPlayerList" Margin="5,35,6,8" />
                     </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -173,7 +173,7 @@ public partial class PageToolsGameLink
         ModBase.RunInUi(() =>
         {
             LabFinishQuality.Text = Lang.Text("Tools.GameLink.Finish.Connected");
-            LabFinishPing.Text = latency + "ms";
+            LabFinishPing.Text = Lang.Text("Tools.GameLink.Finish.PingMs", latency);
             LabConnectType.Text = Lang.Text("Tools.GameLink.Finish.Unavailable");
         });
     }
@@ -334,7 +334,8 @@ public partial class PageToolsGameLink
                     prefix = Lang.Text("Tools.GameLink.Announcement.Notice");
                 }
 
-                HintAnnounce.Text = "[" + prefix + "] " + info.Content.Replace("\n", "\r\n");
+                HintAnnounce.Text = Lang.Text("Tools.GameLink.Announcement.Format", prefix,
+                    info.Content.Replace("\n", "\r\n"));
             }
             else
             {
@@ -533,15 +534,10 @@ public partial class PageToolsGameLink
 
     private object PlayerInfoItem(PlayerProfile info, MyListItem.ClickEventHandler onClick)
     {
-        string details = null;
-        if (info.Kind == PlayerKind.HOST)
-            details += Lang.Text("Tools.GameLink.Player.Host") + " ";
-        details += info.Vendor;
-        // If info.Cost = ETConnectionType.Local Then
-        // details += $"[本机] NAT {LobbyTextHandler.GetNatTypeChinese(info.NatType)}"
-        // Else
-        // details += $"{info.Ping}ms / {LobbyTextHandler.GetConnectTypeChinese(info.Cost)}"
-        // End If
+        var details = info.Kind == PlayerKind.HOST
+            ? Lang.Text("Tools.GameLink.Player.Details", Lang.Text("Tools.GameLink.Player.Host"), info.Vendor)
+            : info.Vendor;
+
         var newItem = new MyListItem
         {
             Title = info.Name,
@@ -550,6 +546,7 @@ public partial class PageToolsGameLink
             Tag = info
         };
         newItem.Click += onClick;
+
         return newItem;
     }
 
@@ -942,8 +939,10 @@ public partial class PageToolsGameLink
     // 退出
     private async void BtnFinishExit_Click(object sender, ModBase.RouteEventArgs routeEventArgs)
     {
-        var creatorHint = LobbyService.IsHost ? "\r\n" + Lang.Text("Tools.GameLink.Exit.HostWarning") : "";
-        if (ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Exit.ConfirmMessage") + creatorHint,
+        if (ModMain.MyMsgBox(
+                Lang.Text(LobbyService.IsHost
+                    ? "Tools.GameLink.Exit.ConfirmMessageWithHost"
+                    : "Tools.GameLink.Exit.ConfirmMessage"),
                 Lang.Text("Tools.GameLink.Exit.ConfirmTitle"),
                 Lang.Text("Common.Action.Confirm"),
                 Lang.Text("Common.Action.Cancel"),

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -22,7 +22,7 @@ public partial class PageToolsGameLink
 {
     static PageToolsGameLink()
     {
-        initLoader = new ModLoader.LoaderCombo<int>("大厅初始化",
+        initLoader = new ModLoader.LoaderCombo<int>(Lang.Text("Link.Mod.Task.InitLobby"),
             new[] { new ModLoader.LoaderTask<int, int>(Lang.Text("Common.Action.Initialize"), InitTask) { ProgressWeight = 0.5d } });
     }
 
@@ -55,13 +55,13 @@ public partial class PageToolsGameLink
         if (lobbyAnnouncementLoader is null)
         {
             var loaders = new List<ModLoader.LoaderBase>();
-            loaders.Add(new ModLoader.LoaderTask<int, int>("大厅界面初始化", _ => ModBase.RunInUi(() =>
+            loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Link.Mod.Task.InitLobbyUi"), _ => ModBase.RunInUi(() =>
             {
                 HintAnnounce.Visibility = Visibility.Visible;
                 HintAnnounce.Theme = MyHint.Themes.Blue;
-                HintAnnounce.Text = "正在连接到大厅服务器...";
+                HintAnnounce.Text = Lang.Text("Tools.GameLink.Loading.ConnectingServer");
             })));
-            loaders.Add(new ModLoader.LoaderTask<int, int>("大厅公告获取", _ => GetAnnouncement()) { ProgressWeight = 0.5d });
+            loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Link.Mod.Task.FetchAnnouncement"), _ => GetAnnouncement()) { ProgressWeight = 0.5d });
             lobbyAnnouncementLoader = new ModLoader.LoaderCombo<int>("Lobby Announcement", loaders) { show = false };
         }
     }
@@ -76,7 +76,7 @@ public partial class PageToolsGameLink
 
             ModBase.RunInUi(() =>
             {
-                CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+                CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
                 StackPlayerList.Children.Clear();
                 CurrentSubpage = Subpages.PanSelect;
             });
@@ -84,15 +84,14 @@ public partial class PageToolsGameLink
         catch (Exception secEx)
         {
             ModBase.Log(secEx, "Occurred an exception when exit server.");
-            ModMain.Hint("在服务器退出时发生了错误！", ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Tools.GameLink.Error.ServerExit"), ModMain.HintType.Critical);
         }
     }
-
 
     public async void Reload()
     {
         HintAnnounce.Visibility = Visibility.Visible;
-        HintAnnounce.Text = "正在连接到大厅服务器...";
+        HintAnnounce.Text = Lang.Text("Tools.GameLink.Loading.ConnectingServer");
         HintAnnounce.Theme = MyHint.Themes.Blue;
 
         // 加载公告
@@ -114,11 +113,16 @@ public partial class PageToolsGameLink
 
     private void BtnEulaStop_Click(object sender, EventArgs eventArgs)
     {
-        if (ModMain.MyMsgBox("你确定要撤销联机协议授权吗？", "撤销授权确认", Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel"), isWarn: true) == 1)
+        if (ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Eula.RevokeConfirm"),
+                Lang.Text("Tools.GameLink.Eula.RevokeTitle"),
+                Lang.Text("Common.Action.Confirm"),
+                Lang.Text("Common.Action.Cancel"),
+                isWarn: true
+            ) == 1)
         {
             States.Link.NaidRefreshTokenConfig.Reset();
             States.Link.LinkEulaConfig.Reset();
-            ModMain.Hint("联机功能已停用！");
+            ModMain.Hint(Lang.Text("Tools.GameLink.Eula.Disabled"));
             CurrentSubpage = Subpages.PanEula;
         }
     }
@@ -152,7 +156,7 @@ public partial class PageToolsGameLink
 
             ModBase.RunInUi(() =>
             {
-                CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+                CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
                 StackPlayerList.Children.Clear();
                 CurrentSubpage = Subpages.PanSelect;
             });
@@ -160,7 +164,7 @@ public partial class PageToolsGameLink
         catch (Exception ex)
         {
             ModBase.Log(ex, "Occurred an exception when exit server.");
-            ModMain.Hint("在服务器退出时发生了错误！", ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Tools.GameLink.Error.ServerExit"), ModMain.HintType.Critical);
         }
     }
 
@@ -168,9 +172,9 @@ public partial class PageToolsGameLink
     {
         ModBase.RunInUi(() =>
         {
-            LabFinishQuality.Text = "已连接";
+            LabFinishQuality.Text = Lang.Text("Tools.GameLink.Finish.Connected");
             LabFinishPing.Text = latency + "ms";
-            LabConnectType.Text = "暂不可用";
+            LabConnectType.Text = Lang.Text("Tools.GameLink.Finish.Unavailable");
         });
     }
 
@@ -178,11 +182,11 @@ public partial class PageToolsGameLink
     {
         ModBase.RunInUi(() =>
         {
-            CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+            CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
             StackPlayerList.Children.Clear();
             CurrentSubpage = Subpages.PanSelect;
         });
-        ModMain.MyMsgBox("由于你关闭了联机中的 MC 实例，大厅已自动解散。", "大厅已解散");
+        ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Exit.Disbanded"), Lang.Text("Tools.GameLink.Exit.DisbandedTitle"));
     }
 
 
@@ -215,8 +219,8 @@ public partial class PageToolsGameLink
                     break;
             }
 
-            LabFinishQuality.Text = "已连接";
-            CardPlayerList.Title = $"大厅成员列表（共 {LobbyService.Players.Count} 人）";
+            LabFinishQuality.Text = Lang.Text("Tools.GameLink.Finish.Connected");
+            CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListCount", LobbyService.Players.Count);
         });
     }
 
@@ -317,17 +321,17 @@ public partial class PageToolsGameLink
                 if (info.Type == LinkAnnounceType.Important)
                 {
                     HintAnnounce.Theme = MyHint.Themes.Red;
-                    prefix = "重要";
+                    prefix = Lang.Text("Tools.GameLink.Announcement.Important");
                 }
                 else if (info.Type == LinkAnnounceType.Warning)
                 {
                     HintAnnounce.Theme = MyHint.Themes.Yellow;
-                    prefix = "注意";
+                    prefix = Lang.Text("Tools.GameLink.Announcement.Warning");
                 }
                 else
                 {
                     HintAnnounce.Theme = MyHint.Themes.Blue;
-                    prefix = "提示";
+                    prefix = Lang.Text("Tools.GameLink.Announcement.Notice");
                 }
 
                 HintAnnounce.Text = "[" + prefix + "] " + info.Content.Replace("\n", "\r\n");
@@ -428,7 +432,7 @@ public partial class PageToolsGameLink
                     ModBase.RunInUi(() =>
                     {
                         HintAnnounce.Theme = MyHint.Themes.Red;
-                        HintAnnounce.Text = "Please update to the latest PCL CE to use the lobby";
+                        HintAnnounce.Text = Lang.Text("Tools.GameLink.Error.UpdateRequired");
                         LobbyInfoProvider.IsLobbyAvailable = false;
                     });
                     return;
@@ -483,11 +487,11 @@ public partial class PageToolsGameLink
 
                 if (string.IsNullOrWhiteSpace(States.Link.NaidRefreshToken))
                 {
-                    ModBase.RunInUi(() => LabNatayarkUserName.Text = "Click to login Natayark account");
+                    ModBase.RunInUi(() => LabNatayarkUserName.Text = Lang.Text("Tools.GameLink.Natayark.Login"));
                 }
                 else
                 {
-                    ModBase.RunInUi(() => LabNatayarkUserName.Text = "Loading...");
+                    ModBase.RunInUi(() => LabNatayarkUserName.Text = Lang.Text("Tools.GameLink.Natayark.Loading"));
                     if (string.IsNullOrEmpty(NatayarkProfileManager.NaidProfile.Username))
                         ReloadNaidData();
                     else
@@ -500,7 +504,7 @@ public partial class PageToolsGameLink
                             }
                             else
                             {
-                                LabNatayarkUserName.Text = $"{NatayarkProfileManager.NaidProfile.Username} (Abnormal)";
+                                LabNatayarkUserName.Text = $"{NatayarkProfileManager.NaidProfile.Username} {Lang.Text("Tools.GameLink.Natayark.Abnormal")}";
                                 LabNatayarkUserName.Opacity = 0.6;
                             }
                         });
@@ -514,7 +518,7 @@ public partial class PageToolsGameLink
                 ModBase.RunInUi(() =>
                 {
                     HintAnnounce.Theme = MyHint.Themes.Red;
-                    HintAnnounce.Text = "Failed to connect to lobby server";
+                    HintAnnounce.Text = Lang.Text("Tools.GameLink.Error.ConnectFailed");
                 });
                 LogWrapper.Error(ex, "[Link] Failed to get lobby announcement");
             }
@@ -531,7 +535,7 @@ public partial class PageToolsGameLink
     {
         string details = null;
         if (info.Kind == PlayerKind.HOST)
-            details += "[主机] ";
+            details += Lang.Text("Tools.GameLink.Player.Host") + " ";
         details += info.Vendor;
         // If info.Cost = ETConnectionType.Local Then
         // details += $"[本机] NAT {LobbyTextHandler.GetNatTypeChinese(info.NatType)}"
@@ -552,16 +556,7 @@ public partial class PageToolsGameLink
     private void PlayerInfoClick(object sender, MouseButtonEventArgs e)
     {
         var info = (PlayerProfile)((MyListItem)sender).Tag;
-        string msg = null;
-        msg += $"用户名：{info.Name}";
-        msg += "\r\n";
-        msg += $"联机协议客户端标识：{info.Vendor}";
-        // msg += $"{If(info.Cost = ETConnectionType.Local, "本机 ", $"延迟：{info.Ping}ms，丢包率：{info.Loss}%，连接方式：{LobbyTextHandler.GetConnectTypeChinese(info.Cost)}，")}NAT 类型：{LobbyTextHandler.GetNatTypeChinese(info.NatType)}"
-        msg += "\r\n";
-        msg += "此处数据仅供参考，请以实际游玩体验为准。";
-        msg += "\r\n\r\n";
-        msg += "若想了解 NAT 类型与其如何影响联机体验，请前往界面左侧的常见问题一栏。";
-        ModMain.MyMsgBox(msg, $"玩家 {info.Name} 的详细信息");
+        ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Player.InfoMessage", info.Name, info.Vendor), Lang.Text("Tools.GameLink.Player.InfoTitle", info.Name));
     }
 
     #endregion
@@ -581,7 +576,7 @@ public partial class PageToolsGameLink
                 if (expireTime.CompareTo(DateTime.Now) < 0)
                 {
                     States.Link.NaidRefreshToken = "";
-                    ModMain.Hint("Natayark ID token expired, please login again", ModMain.HintType.Critical);
+                    ModMain.Hint(Lang.Text("Tools.GameLink.Natayark.TokenExpired"), ModMain.HintType.Critical);
                     return;
                 }
 
@@ -619,7 +614,7 @@ public partial class PageToolsGameLink
                     }
                     else
                     {
-                        LabNatayarkUserName.Text = $"{profile.Username} (Abnormal)";
+                        LabNatayarkUserName.Text = $"{profile.Username} {Lang.Text("Tools.GameLink.Natayark.Abnormal")}";
                         LabNatayarkUserName.Opacity = 0.6;
                     }
                 });
@@ -634,7 +629,7 @@ public partial class PageToolsGameLink
 
                 ModBase.RunInUi(() =>
                 {
-                    LabNatayarkUserName.Text = "Failed to fetch info";
+                    LabNatayarkUserName.Text = Lang.Text("Tools.GameLink.Natayark.FetchFailed");
                     LabNatayarkUserName.Opacity = 0.6;
                 });
 
@@ -653,27 +648,27 @@ public partial class PageToolsGameLink
         if (string.IsNullOrWhiteSpace(States.Link.NaidRefreshToken))
         {
             // 当前未登录，显示登录选项
-            if (ModMain.MyMsgBox("PCL 将会打开一个登录页面，请在浏览器中完成登录操作，然后回到启动器继续操作。", "登录至 Natayark Network", "继续", Lang.Text("Common.Action.Cancel")) == 1)
+            if (ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Natayark.LoginPrompt"), Lang.Text("Tools.GameLink.Natayark.LoginTitle"), Lang.Text("Tools.GameLink.Natayark.Continue"), Lang.Text("Common.Action.Cancel")) == 1)
             {
-                LabNatayarkUserName.Text = "请在浏览器中继续...";
+                LabNatayarkUserName.Text = Lang.Text("Tools.GameLink.Natayark.BrowserContinue");
                 LabNatayarkUserName.Opacity = 0.6d;
                 BtnNatayarkUserName.IsEnabled = false;
                 ModWebServer.StartNaidAuthorize(() =>
                 {
                     ModBase.RunInUi(() => BtnNatayarkUserName.IsEnabled = true);
-                    ModMain.Hint("已完成登录操作", ModMain.HintType.Finish);
+                    ModMain.Hint(Lang.Text("Tools.GameLink.Natayark.LoginComplete"), ModMain.HintType.Finish);
                     ReloadNaidData();
                 });
             }
         }
         // 当前已登录，显示登出选项
-        else if (ModMain.MyMsgBox("你确定要退出登录吗？", "退出登录", Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel")) == 1)
+        else if (ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Natayark.LogoutConfirm"), Lang.Text("Tools.GameLink.Natayark.LogoutTitle"), Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel")) == 1)
         {
             States.Link.NaidRefreshTokenConfig.Reset();
             States.Link.NaidRefreshToken = "";
-            LabNatayarkUserName.Text = "点击登录 Natayark 账户";
+            LabNatayarkUserName.Text = Lang.Text("Tools.GameLink.Natayark.Login");
             ModBase.Log("[Link] 已退出登录 Natayark Network");
-            ModMain.Hint("已退出登录！", ModMain.HintType.Finish, false);
+            ModMain.Hint(Lang.Text("Tools.GameLink.Natayark.LogoutComplete"), ModMain.HintType.Finish, false);
         }
     }
 
@@ -685,17 +680,17 @@ public partial class PageToolsGameLink
         try
         {
             BtnNatTest.IsEnabled = false;
-            LabNatType.Text = "正在测试";
+            LabNatType.Text = Lang.Text("Tools.GameLink.Nat.Testing");
             var status = await CliNetTest.GetNetStatusAsync();
-            ModBase.RunInUi(() =>
-                LabNatType.Text =
-                    $"{CliNetTest.GetNatTypeString(status.UdpNatType)} (UDP), {CliNetTest.GetNatTypeString(status.TcpNatType)}(TCP)");
+            ModBase.RunInUi(() => LabNatType.Text = Lang.Text("Tools.GameLink.Nat.Result",
+                CliNetTest.GetNatTypeString(status.UdpNatType),
+                CliNetTest.GetNatTypeString(status.TcpNatType)));
         }
         catch (Exception ex)
         {
             ModBase.Log(ex, "[Link] 获取网络测试结果失败", ModBase.LogLevel.Hint);
             BtnNatTest.IsEnabled = true;
-            LabNatType.Text = "测试失败";
+            LabNatType.Text = Lang.Text("Tools.GameLink.Nat.Failed");
         }
         finally
         {
@@ -719,7 +714,7 @@ public partial class PageToolsGameLink
         if (!string.IsNullOrEmpty(lobbyId))
             TextJoinLobbyId.Text = lobbyId;
         else
-            ModMain.Hint("大厅编号不正确，请检查后重新输入");
+            ModMain.Hint(Lang.Text("Tools.GameLink.Join.InvalidText"));
     }
 
     private void ClearLobbyId(object sender, MouseButtonEventArgs e)
@@ -743,7 +738,7 @@ public partial class PageToolsGameLink
         {
             BtnInputPort.IsEnabled = false;
             if (!ModLink.LobbyPrecheck()) return;
-            var input = ModMain.MyMsgBoxInput("请输入端口",
+            var input = ModMain.MyMsgBoxInput(Lang.Text("Tools.GameLink.Create.EnterPort"),
                 validateRules: [new IntValidator(65535,1024)]);
             int port;
             if (int.TryParse(input, out port))
@@ -753,7 +748,7 @@ public partial class PageToolsGameLink
                     if (res is not null && res.Version.Protocol != 0)
                         await CreateLobby(port);
                     else
-                        ModMain.Hint("这似乎不是个 MC 服务端口...", ModMain.HintType.Critical);
+                        ModMain.Hint(Lang.Text("Tools.GameLink.Create.NotMcPort"), ModMain.HintType.Critical);
                 }
         }
         finally
@@ -767,7 +762,7 @@ public partial class PageToolsGameLink
     {
         if (ComboWorldList.SelectedItem is null)
         {
-            ModMain.Hint("请先选择一个要联机的世界！");
+            ModMain.Hint(Lang.Text("Tools.GameLink.Create.NoWorld"));
             return;
         }
 
@@ -795,15 +790,15 @@ public partial class PageToolsGameLink
             BtnFinishPing.Visibility = Visibility.Collapsed;
             LabFinishPing.Text = "-ms";
             BtnConnectType.Visibility = Visibility.Collapsed;
-            LabConnectType.Text = "连接中";
-            CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+            LabConnectType.Text = Lang.Text("Tools.GameLink.Finish.Connecting");
+            CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
             StackPlayerList.Children.Clear();
             LabConnectUserName.Text = username;
-            LabConnectUserType.Text = "创建者";
+            LabConnectUserType.Text = Lang.Text("Tools.GameLink.Finish.Host");
             LabFinishId.Text = LobbyService.CurrentLobbyCode;
             BtnFinishCopyIp.Visibility = Visibility.Collapsed;
             BtnCreate.IsEnabled = true;
-            BtnFinishExit.Text = "关闭大厅";
+            BtnFinishExit.Text = Lang.Text("Tools.GameLink.Finish.CloseLobby");
             CurrentSubpage = Subpages.PanFinish;
         });
 
@@ -812,7 +807,7 @@ public partial class PageToolsGameLink
         if (!res)
             ModBase.RunInUi(() =>
             {
-                CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+                CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
                 StackPlayerList.Children.Clear();
                 CurrentSubpage = Subpages.PanSelect;
             });
@@ -834,11 +829,11 @@ public partial class PageToolsGameLink
             BtnFinishPing.Visibility = Visibility.Visible;
             LabFinishPing.Text = "-ms";
             BtnConnectType.Visibility = Visibility.Visible;
-            LabConnectType.Text = "连接中";
-            CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+            LabConnectType.Text = Lang.Text("Tools.GameLink.Finish.Connecting");
+            CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
             StackPlayerList.Children.Clear();
             LabConnectUserName.Text = username;
-            LabConnectUserType.Text = "加入者";
+            LabConnectUserType.Text = Lang.Text("Tools.GameLink.Finish.Guest");
             LabFinishId.Text = id;
             BtnFinishCopyIp.Visibility = Visibility.Visible;
             CurrentSubpage = Subpages.PanFinish;
@@ -849,7 +844,7 @@ public partial class PageToolsGameLink
         if (!res)
             ModBase.RunInUi(() =>
             {
-                CardPlayerList.Title = "大厅成员列表（正在获取信息）";
+                CardPlayerList.Title = Lang.Text("Tools.GameLink.Member.ListLoading");
                 StackPlayerList.Children.Clear();
                 CurrentSubpage = Subpages.PanSelect;
             });
@@ -947,11 +942,16 @@ public partial class PageToolsGameLink
     // 退出
     private async void BtnFinishExit_Click(object sender, ModBase.RouteEventArgs routeEventArgs)
     {
-        var creatorHint = LobbyService.IsHost ? "\r\n由于你是大厅创建者，退出后此大厅将会自动解散。" : "";
-        if (ModMain.MyMsgBox($"你确定要退出大厅吗？{creatorHint}", "确认退出", Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel"), isWarn: true) == 1)
+        var creatorHint = LobbyService.IsHost ? "\r\n" + Lang.Text("Tools.GameLink.Exit.HostWarning") : "";
+        if (ModMain.MyMsgBox(Lang.Text("Tools.GameLink.Exit.ConfirmMessage") + creatorHint,
+                Lang.Text("Tools.GameLink.Exit.ConfirmTitle"),
+                Lang.Text("Common.Action.Confirm"),
+                Lang.Text("Common.Action.Cancel"),
+                isWarn: true
+            ) == 1)
         {
             CurrentSubpage = Subpages.PanSelect;
-            BtnFinishExit.Text = "退出大厅";
+            BtnFinishExit.Text = Lang.Text("Tools.GameLink.Finish.Exit");
             await LobbyService.LeaveLobbyAsync().ConfigureAwait(true);
         }
     }
@@ -966,9 +966,11 @@ public partial class PageToolsGameLink
     private void BtnFinishCopyIp_Click(object sender, ModBase.RouteEventArgs routeEventArgs)
     {
         var ip = $"127.0.0.1:{LobbyInfoProvider.McForward.LocalPort}";
-        ModMain.MyMsgBox(
-            $"大厅创建者的游戏地址：{ip}\r\n注意：仅推荐在 MC 多人游戏列表不显示大厅广播时使用 IP 连接！通过 IP 连接将可能要求使用正版档案。", "复制 IP",
-            Lang.Text("Common.Action.Copy"), "返回", button1Action: () => ModBase.ClipboardSet(ip));
+        ModMain.MyMsgBox(Lang.Text("Tools.GameLink.CopyIp.Message", ip),
+            Lang.Text("Tools.GameLink.CopyIp.Title"),
+            Lang.Text("Common.Action.Copy"),
+            Lang.Text("Tools.GameLink.CopyIp.Back"),
+            button1Action: () => ModBase.ClipboardSet(ip));
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml
@@ -9,7 +9,7 @@
         <local:MyScrollViewer Visibility="Collapsed" VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
             <StackPanel x:Name="PanMain" Margin="25,25,25,10" Grid.IsSharedSizeScope="True">
-                <local:MySearchBox Margin="0,0,0,15" HintText="搜索帮助" x:Name="SearchBox" TextChanged="SearchRun" />
+                <local:MySearchBox Margin="0,0,0,15" HintText="{DynamicResource Tools.Help.Search.Hint}" x:Name="SearchBox" TextChanged="SearchRun" />  
                 <Grid>
                     <local:MyCard x:Name="PanSearch" Visibility="Collapsed" VerticalAlignment="Top" Opacity="0"
                                   Margin="0,0,0,15" Title=" " MinHeight="40">
@@ -21,7 +21,7 @@
         </local:MyScrollViewer>
         <local:MyCard Visibility="Collapsed" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="40,0"
                       SnapsToDevicePixels="True" x:Name="PanLoad" UseAnimation="False">
-            <local:MyLoading Text="正在加载帮助列表" Margin="20,20,20,17" x:Name="Load" HorizontalAlignment="Center"
+            <local:MyLoading Text="{DynamicResource Tools.Help.Loading}" Margin="20,20,20,17" x:Name="Load" HorizontalAlignment="Center"  
                              VerticalAlignment="Center" />
         </local:MyCard>
     </Grid>

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsHelp.xaml.cs
@@ -195,18 +195,20 @@ public partial class PageToolsHelp : IRefreshable
             PanSearchList.Children.Clear();
             if (!searchResult.Any())
             {
-                PanSearch.Title = "无搜索结果";
+                PanSearch.Title = Lang.Text("Tools.Help.Search.NoResults");
                 PanSearchList.Visibility = Visibility.Collapsed;
             }
             else
             {
-                PanSearch.Title = "搜索结果";
+                PanSearch.Title = Lang.Text("Tools.Help.Search.Results");
                 foreach (var Result in searchResult)
                 {
                     var item = Result.item.ToListItem();
                     if (ModBase.modeDebug)
-                        item.Info = (Result.absoluteRight ? "完全匹配，" : "") + "相似度：" +
-                                    Lang.Number(Math.Round(Result.similarity, 3), "N3") + "，" + item.Info;
+                        item.Info = Lang.Text(
+                            Result.absoluteRight ? "Tools.Help.Search.ExactMatch" : "Tools.Help.Search.Similarity",
+                            Lang.Number(Math.Round(Result.similarity, 3), "N3"),
+                            item.Info);
                     PanSearchList.Children.Add(item);
                 }
 

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
@@ -7,11 +7,11 @@
       mc:Ignorable="d">
     <StackPanel Orientation="Vertical" x:Name="PanItem" Margin="0,12,0,0">
         
-        <TextBlock Text="联机" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextGameLinkCategory"/>
+        <TextBlock Text="{DynamicResource Tools.Left.Online}" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextGameLinkCategory"/>  
 
         <local:MyListItem x:Name="ItemGameLink" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="1"
                           Check="PageCheck"
-                          MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="大厅"
+                          MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="{DynamicResource Tools.Left.Lobby}"  
                           LogoScale="0.85"
                           Logo="M554.496 170.496c141.312 0 256 114.688 256 256s-114.688 256-256 256H402.432c-22.016-1.536-39.424-19.968-39.424-42.496a42.391 42.391 0 0 1 42.496-42.496h149.504c94.208 0 170.496-76.288 170.496-170.496S648.704 256 554.496 256h-256C204.288 256 128 332.288 128 426.496c0 38.4 12.8 73.728 33.792 102.4 5.632 7.168 8.704 15.872 8.704 25.6A42.391 42.391 0 0 1 128 596.992c-11.264 0-20.992-4.096-28.672-11.264l-0.512 0.512c-35.328-44.032-56.32-99.328-56.32-159.744 0-141.312 114.688-256 256-256h256z m64 192h3.072c22.016 1.536 39.424 19.968 39.424 42.496a42.391 42.391 0 0 1-42.496 42.496H469.504c-94.208 0-170.496 76.288-170.496 170.496S375.296 788.48 469.504 788.48h256C819.712 788.48 896 712.192 896 617.984c0-38.4-12.8-73.728-33.792-102.4-5.632-7.168-8.704-15.872-8.704-25.6A42.391 42.391 0 0 1 896 447.488c11.264 0 20.992 4.096 28.672 11.264l0.512-0.512c35.328 44.032 56.32 99.328 56.32 159.744 0 141.312-114.688 256-256 256h-256c-141.312 0-256-114.688-256-256s114.688-256 256-256h148.992z">
             <local:MyListItem.Buttons>
@@ -24,11 +24,11 @@
             </local:MyListItem.Buttons>
         </local:MyListItem>
         
-        <TextBlock Text="奇妙小工具" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextToolsCategory"/>
-        <local:MyListItem x:Name="ItemTest" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="3" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="百宝箱" Check="PageCheck"
+        <TextBlock Text="{DynamicResource Tools.Left.Utilities}" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextToolsCategory"/>  
+        <local:MyListItem x:Name="ItemTest" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="3" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="{DynamicResource Tools.Left.Utilities.Title}" Check="PageCheck"  
                           LogoScale="0.9" Logo="M511 995a128 128 0 0 1-57-13L70 791a126 126 0 0 1-70-113V311a126 126 0 0 1 15-60V248c1-2 3-5 5-8a127 127 0 0 1 49-42L454 13a128 128 0 0 1 112 0l383 190a126 126 0 0 1 72 113v360a126 126 0 0 1-70 115L568 984c-17 7-37 11-57 11z m42-470v370l360-178c14-7 23-21 23-38v-335L554 524zM85 330v347a42 42 0 0 0 23 38l360 178V523L85 330zM135 260l375 189 137-65L286 188 135 260z m245-118l363 197 150-71-365-180a42 42 0 0 0-37 0l-111 53z" />
 
-        <local:MyListItem x:Name="ItemLauncherHelp" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="2" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="帮助库" Check="PageCheck"
+        <local:MyListItem x:Name="ItemLauncherHelp" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="2" MinPaddingRight="35" Height="36" VerticalAlignment="Top" Title="{DynamicResource Tools.Left.Help}" Check="PageCheck"  
                           LogoScale="0.97" Logo="M520.6 620.3c-11.3-0.6-20.1-4-26.9-10.5-6.6-6.3-8.1-11-10.1-20.8-1.9-9.5-1.5-16.7-1-24.9l0.3-5.3c0.5-9.9 3.5-19.6 8.8-28.1 5.7-9 12.5-17.2 20.8-25.1 8.6-8 17.7-15.7 27-22.9 9.4-7.2 18.7-14.8 27.7-22.7 9-7.9 16.2-15.8 22.1-24.3 6.2-9 9.3-18.8 9.3-29.4 1.2-20.3-6.5-37.7-22.8-51.3-16-13.3-37.4-20-63.5-20-13.7 0-26.3 3.3-37.4 10-10.9 6.5-20.2 14.5-27.7 23.8-7.5 9.2-13.5 19-17.9 29.2-4.5 10.6-6.7 19.4-6.7 26.8 0 9.2-3.3 16-10.1 20.8-6.9 4.8-14.6 7.3-22.8 7.3h-1.3c-9-0.3-17-3.3-24.6-9.2-7.3-5.6-11.1-14.6-11.6-27.5-0.6-11.5 1.9-26.1 7.2-43.5 5.4-17.4 14.8-34.4 28.1-50.5 13.4-16.3 31.2-30.4 52.8-41.8 21.6-11.4 49.2-17.2 81.9-17.2 26.4 0 49.6 3.9 69.1 11.7 19.4 7.7 35.4 18.2 47.5 31.1l1.6 1.7c11.8 12.6 20.3 21.7 29.4 44.4 11.6 28.9 7.1 52.1 5.5 58.5-5.8 22.6-12.6 37.7-22.7 50.4-11.7 14.6-24.9 28.2-39.2 40.4-14 11.7-39.2 33.3-39.2 33.3-13.3 11.4-19.4 22.1-18.6 32.9V587c0.5 8.7-2.4 16.1-8.8 22.8-6.2 6.4-14.8 10-26.2 10.5zM519 766.1c-13 0-23.6-4.2-32.2-12.9-8.7-8.7-13-19-13-31.4 0-12.9 4.2-23.5 12.9-32.2 8.7-8.7 19.2-12.9 32.2-12.9 13 0 23.5 4.2 32.2 12.9s12.9 19.2 12.9 32.2c0 12.4-4.2 22.7-12.9 31.4-8.6 8.6-19.2 12.9-32.1 12.9z M515 928.3c-228.1 0-413.7-185.6-413.7-413.7S286.9 100.9 515 100.9s413.7 185.6 413.7 413.7c0.1 228.1-185.5 413.7-413.7 413.7z m0-747.4c-184 0-333.7 149.7-333.7 333.7S331 848.3 515 848.3s333.7-149.7 333.7-333.7S699 180.9 515 180.9z">
             <local:MyListItem.Buttons>
                 <x:Array Type="{x:Type local:MyIconButton}">

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsLeft.xaml
@@ -7,7 +7,7 @@
       mc:Ignorable="d">
     <StackPanel Orientation="Vertical" x:Name="PanItem" Margin="0,12,0,0">
         
-        <TextBlock Text="{DynamicResource Tools.Left.Online}" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextGameLinkCategory"/>  
+        <TextBlock Text="{DynamicResource Tools.Left.Multiplayer}" Margin="13,5,5,3" Opacity="0.6" FontSize="12" x:Name="TextGameLinkCategory"/>  
 
         <local:MyListItem x:Name="ItemGameLink" IsScaleAnimationEnabled="False" Type="RadioBox" Tag="1"
                           Check="PageCheck"

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
@@ -7,25 +7,29 @@
                    PanScroll="{Binding ElementName=PanBack}">
     <local:MyScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
         <StackPanel x:Name="PanMain" Margin="25,10" Grid.IsSharedSizeScope="True">
-            <local:MyCard Margin="0,15" Title="百宝箱">
+            <local:MyCard Margin="0,15" Title="{DynamicResource Tools.Test.Title}">
                 <WrapPanel Margin="25,40,21,5" ItemHeight="50">
-                    <local:MyButton MinWidth="100" Text="内存优化"
-                                    ToolTip="内存优化为 PCL CE 特供版，效果加强！&#xa;&#xa;将物理内存占用降低约 1/3，不仅限于 MC！&#xa;如果使用机械硬盘，这可能会导致一小段时间的严重卡顿。&#xa;使用 --memory 参数启动 PCL 可以静默执行内存优化。"
+                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Memory.Title}"
+                                    ToolTip="{DynamicResource Tools.Test.Memory.ToolTip}"
                                     Margin="0,0,15,15" Click="BtnMemory_Click" />
-                    <local:MyButton x:Name="BtnClear" MinWidth="120" Text="清理游戏垃圾"
-                                    ToolTip="清理 PCL 的缓存与 MC 的日志、崩溃报告等垃圾文件" Margin="0,0,15,15" Click="BtnClear_Click" />
-                    <local:MyButton MinWidth="100" Text="今日人品" Margin="0,0,15,15" Click="BtnLuck_Click" />
-                    <local:MyButton MinWidth="100" Text="崩溃测试"
-                                    ToolTip="点这个按钮会让启动器直接崩掉，没事别点，造成的一切问题均不受理，相关 issue 会被直接关闭" ColorType="Red"
+                    <local:MyButton x:Name="BtnClear" MinWidth="120" Text="{DynamicResource Tools.Test.Clean.Title}"
+                                    ToolTip="{DynamicResource Tools.Test.Clean.ToolTip}" Margin="0,0,15,15"
+                                    Click="BtnClear_Click" />
+                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Luck.Title}" Margin="0,0,15,15"
+                                    Click="BtnLuck_Click" />
+                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Crash.Title}"
+                                    ToolTip="{DynamicResource Tools.Test.Crash.ToolTip}" ColorType="Red"
                                     Margin="0,0,15,15" Click="BtnCrash_Click" />
-                    <local:MyButton MinWidth="120" Text="创建快捷方式" ToolTip="创建一个指向 PCL 社区版可执行文件的快捷方式" Margin="0,0,15,15"
+                    <local:MyButton MinWidth="120" Text="{DynamicResource Tools.Test.Shortcut.Title}"
+                                    ToolTip="{DynamicResource Tools.Test.Shortcut.ToolTip}" Margin="0,0,15,15"
                                     Click="BtnCreateShortcut_Click" />
-                    <local:MyButton MinWidth="120" Text="查看启动计数" Margin="0,0,15,15" Click="BtnLaunchCount_Click" />
+                    <local:MyButton MinWidth="120" Text="{DynamicResource Tools.Test.LaunchCount.Title}"
+                                    Margin="0,0,15,15" Click="BtnLaunchCount_Click" />
                 </WrapPanel>
             </local:MyCard>
-            <local:MyCard Margin="0,0,0,15" Title="下载自定义文件">
+            <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Tools.Test.CustomDownload.Title}">
                 <StackPanel Orientation="Vertical" Margin="25,40,25,20">
-                    <TextBlock Text="使用 PCL 的高速多线程下载引擎下载任意文件。请注意，部分网站（例如百度网盘）可能会报错 (403) 已禁止，无法正常下载。"
+                    <TextBlock Text="{DynamicResource Tools.Test.CustomDownload.Description}"
                                TextWrapping="Wrap" />
                     <Grid Margin="0,10,0,0">
                         <Grid.Resources>
@@ -46,7 +50,7 @@
                             <RowDefinition />
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Column="0" Grid.Row="0" Text="下载地址" />
+                        <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource Tools.Test.CustomDownload.Url}" />
                         <local:MyTextBox x:Name="TextDownloadUrl" Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="2"
                                          TextChanged="TextDownloadUrl_TextChanged"
                                          ValidatedTextChanged="TextDownloadUrl_ValidateChanged">
@@ -55,12 +59,14 @@
                             </local:MyTextBox.ValidateRules>
                         </local:MyTextBox>
 
-                        <TextBlock Grid.Column="0" Grid.Row="1" Text="User-Agent" />
+                        <TextBlock Grid.Column="0" Grid.Row="1"
+                                   Text="{DynamicResource Tools.Test.CustomDownload.UserAgent}" />
                         <local:MyTextBox x:Name="TextUserAgent" Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
                                          ValidatedTextChanged="TextUserAgent_OnValidatedTextChanged"
                                          Margin="0,10" />
 
-                        <TextBlock Grid.Column="0" Grid.Row="2" Text="保存到" />
+                        <TextBlock Grid.Column="0" Grid.Row="2"
+                                   Text="{DynamicResource Tools.Test.CustomDownload.SaveTo}" />
                         <local:MyTextBox x:Name="TextDownloadFolder" Grid.Column="1" Grid.Row="2" Margin="0,10"
                                          ValidatedTextChanged="TextDownloadFolder_OnValidatedTextChanged">
                             <local:MyTextBox.ValidateRules>
@@ -68,9 +74,11 @@
                             </local:MyTextBox.ValidateRules>
                         </local:MyTextBox>
                         <local:MyTextButton Grid.Column="2" Grid.Row="2" Margin="10,0,5,0" VerticalAlignment="Center"
-                                            Text="选择" Click="MyTextButton_Click" />
+                                            Text="{DynamicResource Tools.Test.CustomDownload.Select}"
+                                            Click="MyTextButton_Click" />
 
-                        <TextBlock Grid.Column="0" Grid.Row="3" Text="文件名" />
+                        <TextBlock Grid.Column="0" Grid.Row="3"
+                                   Text="{DynamicResource Tools.Test.CustomDownload.FileName}" />
                         <local:MyTextBox x:Name="TextDownloadName" Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="2">
                             <local:MyTextBox.ValidateRules>
                                 <val:FileNameValidator />
@@ -85,15 +93,17 @@
                             <ColumnDefinition />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
-                        <local:MyButton x:Name="BtnDownloadStart" Grid.Column="0" Width="140" Text="开始下载"
+                        <local:MyButton x:Name="BtnDownloadStart" Grid.Column="0" Width="140"
+                                        Text="{DynamicResource Tools.Test.CustomDownload.Start}"
                                         ColorType="Highlight" Margin="0,0,15,0" HorizontalAlignment="Right"
                                         Click="BtnDownloadStart_Click" />
-                        <local:MyButton x:Name="BtnDownloadOpen" Grid.Column="1" Width="140" Text="{DynamicResource Common.Action.OpenFolder}"
+                        <local:MyButton x:Name="BtnDownloadOpen" Grid.Column="1" Width="140"
+                                        Text="{DynamicResource Common.Action.OpenFolder}"
                                         Margin="0,0,15,0" HorizontalAlignment="Left" Click="BtnDownloadOpen_Click" />
                     </Grid>
                 </StackPanel>
             </local:MyCard>
-            <local:MyCard x:Name="CardSkin" Margin="0,0,0,15" Title="下载正版玩家的皮肤">
+            <local:MyCard x:Name="CardSkin" Margin="0,0,0,15" Title="{DynamicResource Tools.Test.Skin.Title}">
                 <StackPanel Margin="25,40,25,15">
                     <Grid x:Name="PanSkinID" Margin="0,14,0,2">
                         <Grid.ColumnDefinitions>
@@ -104,23 +114,26 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="正版玩家名" Margin="0,0,25,0" />
+                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left"
+                                   Text="{DynamicResource Tools.Test.Skin.PlayerName}" Margin="0,0,25,0" />
                         <local:MyTextBox x:Name="TextSkinID" Grid.Column="1" MaxLength="50" />
                         <Grid Height="35" Grid.Row="1" Grid.ColumnSpan="2" Margin="0,14,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
                             </Grid.ColumnDefinitions>
-                            <local:MyButton x:Name="BtnSkinSave" Text="保存皮肤" MinWidth="140" Padding="13,0"
+                            <local:MyButton x:Name="BtnSkinSave" Text="{DynamicResource Tools.Test.Skin.Save}"
+                                            MinWidth="140" Padding="13,0"
                                             Margin="0,0,20,0" Grid.Row="1" Click="BtnSkinSave_Click" />
                         </Grid>
                     </Grid>
                 </StackPanel>
             </local:MyCard>
-            <local:MyCard Margin="0,0,0,15" Title="瞅眼服务器">
+            <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Tools.Test.ServerQuery.Title}">
                 <local:MinecraftServerQuery Margin="15,40,15,15" />
             </local:MyCard>
-            <local:MyCard Margin="0,0,0,15" Title="自定义成就图片生成器 (仅支持英文)" CanSwap="True" IsSwapped="True">
+            <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Tools.Test.Achievement.Title}" CanSwap="True"
+                          IsSwapped="True">
                 <StackPanel Margin="25,30,25,15">
                     <Grid Margin="0,4,0,2">
                         <Grid.ColumnDefinitions>
@@ -136,16 +149,17 @@
                             <RowDefinition />
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="物品名（ID）" Margin="0,0,25,0" />
+                                   Text="{DynamicResource Tools.Test.Achievement.ItemId}" Margin="0,0,25,0" />
                         <local:MyTextBox Grid.Column="1" Grid.Row="0" Grid.ColumnSpan="2"
                                          x:Name="AchievementBlockTextBox" MaxLength="50" Margin="0,10">
                             <local:MyTextBox.ValidateRules>
-                                <val:RegexValidator Pattern="^[a-z0-9_]+$" ErrorMessage="请输入正确的物品 ID！" />
+                                <val:RegexValidator Pattern="^[a-z0-9_]+$"
+                                                    ErrorKey="Tools.Test.Achievement.InvalidId" />
                             </local:MyTextBox.ValidateRules>
                         </local:MyTextBox>
 
                         <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="成就名" Margin="0,0,25,0" />
+                                   Text="{DynamicResource Tools.Test.Achievement.Name}" Margin="0,0,25,0" />
                         <local:MyTextBox Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
                                          x:Name="AchievementTitleTextBox" MaxLength="50">
                             <local:MyTextBox.ValidateRules>
@@ -154,7 +168,7 @@
                         </local:MyTextBox>
 
                         <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="第一行" Margin="0,0,25,0" />
+                                   Text="{DynamicResource Tools.Test.Achievement.Line1}" Margin="0,0,25,0" />
                         <local:MyTextBox Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="2"
                                          x:Name="AchievementString1TextBox" MaxLength="50" Margin="0,10">
                             <local:MyTextBox.ValidateRules>
@@ -163,7 +177,7 @@
                         </local:MyTextBox>
 
                         <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="第二行（可选）" Margin="0,0,25,0" />
+                                   Text="{DynamicResource Tools.Test.Achievement.Line2}" Margin="0,0,25,0" />
                         <local:MyTextBox Grid.Column="1" Grid.Row="3" Grid.ColumnSpan="2"
                                          x:Name="AchievementString2TextBox" MaxLength="50" />
                     </Grid>
@@ -175,23 +189,27 @@
                             <ColumnDefinition />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
-                        <local:MyButton x:Name="BtnAchievementPreview" Grid.Column="0" Width="140" Text="预览成就图像"
+                        <local:MyButton x:Name="BtnAchievementPreview" Grid.Column="0" Width="140"
+                                        Text="{DynamicResource Tools.Test.Achievement.Preview}"
                                         ColorType="Highlight" Margin="0,0,15,0" HorizontalAlignment="Right"
                                         Click="BtnAchievementPreview_Click" />
-                        <local:MyButton x:Name="BtnAchievementSave" Grid.Column="1" Width="140" Text="保存图片"
+                        <local:MyButton x:Name="BtnAchievementSave" Grid.Column="1" Width="140"
+                                        Text="{DynamicResource Tools.Test.Achievement.Save}"
                                         Margin="0,0,15,0" HorizontalAlignment="Left" Click="BtnAchievementSave_Click" />
                     </Grid>
                     <Image x:Name="AchievementImage" Width="320" Height="64" Stretch="Uniform" Visibility="Collapsed" />
                 </StackPanel>
             </local:MyCard>
-            <local:MyCard Margin="0,0,0,15" Title="皮肤头像生成器" CanSwap="True" IsSwapped="True">
+            <local:MyCard Margin="0,0,0,15" Title="{DynamicResource Tools.Test.Avatar.Title}" CanSwap="True"
+                          IsSwapped="True">
                 <StackPanel Orientation="Vertical" Margin="25,40,25,20">
                     <Grid Margin="0,0,0,10">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="头像大小：" VerticalAlignment="Center" Margin="0,0,10,0" />
+                        <TextBlock Text="{DynamicResource Tools.Test.Avatar.Size}" VerticalAlignment="Center"
+                                   Margin="0,0,10,0" />
                         <local:MyComboBox x:Name="CmbHeadSize" Grid.Column="1" Height="26" SelectedIndex="0">
                             <sys:String>64x64</sys:String>
                             <sys:String>96x96</sys:String>
@@ -205,9 +223,11 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <local:MyButton x:Name="BtnSelectSkin" Grid.Column="1" Text="选择皮肤" Width="140" Height="35"
+                        <local:MyButton x:Name="BtnSelectSkin" Grid.Column="1"
+                                        Text="{DynamicResource Tools.Test.Avatar.SelectSkin}" Width="140" Height="35"
                                         Margin="0,0,10,0" />
-                        <local:MyButton Grid.Column="2" Text="保存头像" Width="140" Height="35" Click="BtnSaveHead_Click" />
+                        <local:MyButton Grid.Column="2" Text="{DynamicResource Tools.Test.Avatar.Save}" Width="140"
+                                        Height="35" Click="BtnSaveHead_Click" />
                     </Grid>
                     <Border x:Name="SkinPreviewBorder" Margin="0,15,0,0" HorizontalAlignment="Center" Padding="10"
                             Visibility="Collapsed">

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -91,7 +91,7 @@ public partial class PageToolsTest
             {
                 case ModBase.LoadState.Finished:
                 {
-                    ModMain.Hint($"{loader.name}完成！", ModMain.HintType.Finish);
+                    ModMain.Hint(Lang.Text("Tools.Test.CustomDownload.Finished", loader.name), ModMain.HintType.Finish);
                     Console.Beep();
                     break;
                 }
@@ -103,7 +103,7 @@ public partial class PageToolsTest
                 }
                 case ModBase.LoadState.Aborted:
                 {
-                    ModMain.Hint($"{loader.name}已取消！");
+                    ModMain.Hint(Lang.Text("Tools.Test.CustomDownload.Aborted", loader.name));
                     break;
                 }
             }
@@ -119,7 +119,7 @@ public partial class PageToolsTest
         {
             if (string.IsNullOrWhiteSpace(folder))
             {
-                folder = SystemDialogs.SelectSaveFile("选择文件保存位置", fileName);
+                folder = SystemDialogs.SelectSaveFile(Lang.Text("Tools.Test.CustomDownload.SelectLocation"), fileName);
                 if (!folder.Contains(@"\")) return;
                 if (folder.EndsWith(fileName)) folder = folder[..^fileName.Length];
             }
@@ -141,12 +141,12 @@ public partial class PageToolsTest
             var uuid = ModBase.GetUuid();
             ModLoader.LoaderBase loaderdownload;
             if (new HttpValidator().Validate(url).IsValid)
-                loaderdownload = new LoaderDownload($"自定义下载文件：{fileName} ",
+                loaderdownload = new LoaderDownload(Lang.Text("Tools.Test.CustomDownload.LoaderName", fileName),
                     new List<DownloadFile> { new(new[] { url }, folder + fileName, null, true, userAgent) });
             else // UNC 路径
-                loaderdownload = new LoaderDownloadUnc($"自定义下载文件：{fileName} ",
+                loaderdownload = new LoaderDownloadUnc(Lang.Text("Tools.Test.CustomDownload.LoaderName", fileName),
                     new Tuple<string, string>(url, folder + fileName));
-            var loaderCombo = new ModLoader.LoaderCombo<int>($"自定义下载 ({uuid}) ", new[] { loaderdownload })
+            var loaderCombo = new ModLoader.LoaderCombo<int>(Lang.Text("Tools.Test.CustomDownload.LoaderTitle", uuid), new[] { loaderdownload })
                 { OnStateChanged = a => DownloadState((ModLoader.LoaderCombo<int>)a) };
             loaderCombo.Start();
             ModLoader.LoaderTaskbarAdd(loaderCombo);
@@ -165,13 +165,12 @@ public partial class PageToolsTest
         var random = new Random(GenerateDailySeed());
         var luckValue = random.Next(0, 101);
         var rating = GetRating(luckValue);
-        var currentDate = Lang.Date(DateTime.Now, "d");
-        var title = $"今日人品 - {currentDate}";
+        var title = Lang.Text("Tools.Test.Luck.MsgboxTitle", Lang.Date(DateTime.Now, "d"));
 
         if (luckValue >= 60)
-            ModMain.MyMsgBox($"你今天的人品值是：{luckValue}！{rating}", title);
+            ModMain.MyMsgBox(Lang.Text("Tools.Test.Luck.MessageGood", luckValue, rating), title);
         else
-            ModMain.MyMsgBox($"你今天的人品值是：{luckValue}... {rating}", title, isWarn: luckValue <= 30);
+            ModMain.MyMsgBox(Lang.Text("Tools.Test.Luck.MessageBad", luckValue, rating), title, isWarn: luckValue <= 30);
     }
 
     public static void RubbishClear()
@@ -204,7 +203,7 @@ public partial class PageToolsTest
                 {
                     if (ModNet.HasDownloadingTask())
                     {
-                        ModMain.Hint("请在所有下载任务完成后再来清理吧……");
+                        ModMain.Hint(Lang.Text("Tools.Test.Clean.WaitForDownload"));
                         return;
                     }
 
@@ -212,13 +211,11 @@ public partial class PageToolsTest
                     if (States.Hint.CleanJunkFile <= 2)
                     {
                         if (ModMain.MyMsgBox(
-                                """
-                                即将清理游戏日志、错误报告、缓存等文件。
-                                虽然应该没人往这些地方放重要文件，但还是问一下，是否确认继续？
-
-                                在完成清理后，PCL 将自动重启。
-                                """, "清理确认", Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Cancel")) ==
-                            2) return;
+                                Lang.Text("Tools.Test.Clean.ConfirmMessage"),
+                                Lang.Text("Tools.Test.Clean.ConfirmTitle"),
+                                Lang.Text("Common.Action.Confirm"),
+                                Lang.Text("Common.Action.Cancel")
+                            ) == 2) return;
                         States.Hint.CleanJunkFile += 1;
                     }
 
@@ -258,22 +255,19 @@ public partial class PageToolsTest
                     num += ModBase.DeleteDirectory(Path.Combine(SystemPaths.DriveLetter, "ProgramData", "PCL"), true);
                     if (num != 0)
                     {
-                        ModMain.MyMsgBox($"""
-                                           清理了 {num} 个文件！
-                                           PCL 即将自动重启……
-                                           """,
-                            "缓存已清理", Lang.Text("Common.Action.Confirm"), "", "", false, true, true);
+                        ModMain.MyMsgBox(Lang.Text("Tools.Test.Clean.ClearedMessage", num),
+                            Lang.Text("Tools.Test.Clean.Cleared"), Lang.Text("Common.Action.Confirm"), "", "", false, true, true);
                         Process.Start(new ProcessStartInfo(Basics.ExecutablePath));
                         FormMain.EndProgramForce();
                     }
                     else
                     {
-                        ModMain.Hint("没有找到任何可以清理的文件！");
+                        ModMain.Hint(Lang.Text("Tools.Test.Clean.NoFiles"));
                     }
                 }
                 else
                 {
-                    ModMain.Hint("请先关闭所有运行中的游戏……");
+                    ModMain.Hint(Lang.Text("Tools.Test.Clean.CloseGameFirst"));
                 }
             }
             catch (Exception ex)
@@ -300,13 +294,10 @@ public partial class PageToolsTest
         if (memLoad > 90) return true; // 情况不太妙啊，先别问了
 
         var s = ModMain.MyMsgBox(
-            "内存优化功能即将被废弃。" +
-            "\n\n该功能依赖未文档化的 Windows NT 内核函数调用，可能在未来版本中不可用，且存在引发未定义行为的可能。" +
-            "\n\n建议使用 Mem Reduct 替代，这是一个专业的第三方内存管理工具。" +
-            "\n\n是否仍然继续使用内存优化？",
-            "功能即将废弃",
+            Lang.Text("Tools.Test.Memory.Deprecated"),
+            Lang.Text("Tools.Test.Memory.DeprecatedTitle"),
             Lang.Text("Common.Action.Confirm"),
-            "了解 Mem Reduct",
+            Lang.Text("Tools.Test.Memory.LearnMemReduct"),
             Lang.Text("Common.Action.Cancel"),
             isWarn: true,
             button2Action: () => Basics.OpenPath("https://github.com/henrypp/memreduct")
@@ -320,17 +311,17 @@ public partial class PageToolsTest
 
     public static string GetRandomCave()
     {
-        return "为便于维护，社区版中不包含百宝箱功能……";
+        return Lang.Text("Tools.Test.CeNotice");
     }
 
     public static string GetRandomHint()
     {
-        return "为便于维护，社区版中不包含百宝箱功能……";
+        return Lang.Text("Tools.Test.CeNotice");
     }
 
     public static string GetRandomPresetHint()
     {
-        return "为便于维护，社区版中不包含百宝箱功能……";
+        return Lang.Text("Tools.Test.CeNotice");
     }
 
     private void TextDownloadUrl_TextChanged(object sender, TextChangedEventArgs e)
@@ -409,14 +400,14 @@ public partial class PageToolsTest
     private void BtnSkinSave_Click(object sender, MouseButtonEventArgs e)
     {
         var id = TextSkinID.Text;
-        ModMain.Hint("正在获取皮肤...");
+        ModMain.Hint(Lang.Text("Tools.Test.Skin.Fetching"));
         ModBase.RunInNewThread(() =>
         {
             try
             {
                 if (id.Length < 3)
                 {
-                    ModMain.Hint("这不是一个有效的 ID...");
+                    ModMain.Hint(Lang.Text("Tools.Test.Skin.InvalidId"));
                 }
                 else
                 {
@@ -425,9 +416,9 @@ public partial class PageToolsTest
                     result = ModMinecraft.McSkinDownload(result);
                     ModBase.RunInUi(() =>
                     {
-                        var path = SystemDialogs.SelectSaveFile("保存皮肤", $"{id}.png", "皮肤图片文件(*.png)|*.png");
+                        var path = SystemDialogs.SelectSaveFile(Lang.Text("Tools.Test.Skin.Save"), $"{id}.png", Lang.Text("Tools.Test.Skin.FileFilter"));
                         ModBase.CopyFile(result, path);
-                        ModMain.Hint($"玩家 {id} 的皮肤已保存！", ModMain.HintType.Finish);
+                        ModMain.Hint(Lang.Text("Tools.Test.Skin.Saved", id), ModMain.HintType.Finish);
                     });
                 }
             }
@@ -435,7 +426,7 @@ public partial class PageToolsTest
             {
                 if (ex.ToString().Contains("429"))
                 {
-                    ModMain.Hint("获取皮肤太过频繁，请 5 分钟之后再试！", ModMain.HintType.Critical);
+                    ModMain.Hint(Lang.Text("Tools.Test.Skin.TooFrequent"), ModMain.HintType.Critical);
                     ModBase.Log($"获取正版皮肤失败（{id}）：获取皮肤太过频繁，请 5 分钟后再试！");
                 }
                 else
@@ -474,47 +465,44 @@ public partial class PageToolsTest
 
     public static string GetRating(int luckValue)
     {
-        if (luckValue == 100)
-            return """
-                   100！100！
-                   隐藏主题 欧皇…… 不对，社区版应该没有这玩意……
-                   """;
+        var key = luckValue switch
+        {
+            100 => "Tools.Test.Luck.Rating100",
+            >= 95 => "Tools.Test.Luck.Rating95",
+            >= 90 => "Tools.Test.Luck.Rating90",
+            >= 60 => "Tools.Test.Luck.Rating60",
+            >= 40 => "Tools.Test.Luck.Rating40",
+            >= 30 => "Tools.Test.Luck.Rating30",
+            >= 10 => "Tools.Test.Luck.Rating10",
+            _ => "Tools.Test.Luck.Rating0"
+        };
 
-        return luckValue >= 95 ? "差一点就到100了呢..." :
-            luckValue >= 90 ? "好评如潮！" :
-            luckValue >= 60 ? "还行啦，还行啦" :
-            luckValue >= 40 ? "勉强还行吧..." :
-            luckValue >= 30 ? "呜..." :
-            luckValue >= 10 ? "不会吧！" : "（是百分制哦）";
+        return Lang.Text(key);
     }
 
     private void BtnCreateShortcut_Click(object sender, MouseButtonEventArgs e)
     {
-        const string shortcutName = "PCL 社区版.lnk";
-        const string desktopName = "桌面";
-        const string startName = "开始菜单";
+        var shortcutName = Lang.Text("Tools.Test.Shortcut.FileName") + ".lnk";
+        var desktopName = Lang.Text("Tools.Test.Shortcut.Desktop");
+        var startName = Lang.Text("Tools.Test.Shortcut.StartMenu");
         var desktop = Paths.GetSpecialPath(Environment.SpecialFolder.Desktop, shortcutName);
         var start = Paths.GetSpecialPath(Environment.SpecialFolder.StartMenu, @"Programs\" + shortcutName);
         var choice =
             ModMain.MyMsgBox(
-                $"""
-                 这个快捷方式不会自动移除，在删除/移动启动器前请手动移除快捷方式。
-
-                 {desktopName}位置: {desktop}
-                 {startName}位置: {start}
-                 """, "选择快捷方式位置", Lang.Text("Common.Action.Cancel"), desktopName, startName);
+                Lang.Text("Tools.Test.Shortcut.ConfirmMessage", desktopName, desktop, startName, start),
+                Lang.Text("Tools.Test.Shortcut.SelectLocation"), Lang.Text("Common.Action.Cancel"), desktopName, startName);
         if (choice == 1)
             return;
         var shortcutPath = choice == 2 ? desktop : start;
         var locationName = choice == 2 ? desktopName : startName;
         Files.CreateShortcut(shortcutPath, Basics.ExecutablePath);
-        ModMain.Hint($"已在{locationName}创建快捷方式", ModMain.HintType.Finish);
+        ModMain.Hint(Lang.Text("Tools.Test.Shortcut.Created", locationName), ModMain.HintType.Finish);
     }
 
     // 启动计数显示
     private void BtnLaunchCount_Click(object sender, MouseButtonEventArgs e)
     {
-        ModMain.MyMsgBox($"PCL 已经为你启动了 {States.System.LaunchCount} 次游戏了。", "启动次数");
+        ModMain.MyMsgBox(Lang.Text("Tools.Test.LaunchCount.Message", States.System.LaunchCount), Lang.Text("Tools.Test.LaunchCount.Title"));
     }
 
     private async void BtnAchievementPreview_Click(object sender, MouseButtonEventArgs e)
@@ -550,8 +538,9 @@ public partial class PageToolsTest
                 Dispatcher.Invoke(() =>
                 {
                     ModBase.Log("获取成就图片失败（404）");
-                    ModMain.Hint("获取成就图片失败，请检查文字是否包含特殊字符", ModMain.HintType.Critical);
+                    ModMain.Hint(Lang.Text("Tools.Test.Achievement.FetchFailed"), ModMain.HintType.Critical);
                 });
+
             else
                 Dispatcher.Invoke(() => ModBase.Log("获取成就图片失败（" + (int)response.StatusCode + "）"));
         }
@@ -587,7 +576,7 @@ public partial class PageToolsTest
                 File.WriteAllBytes(savePath, imageBytes);
 
                 var path =
-                    SystemDialogs.SelectSaveFile("保存皮肤", AchievementTitleTextBox.Text + ".png", "PNG 图片|*.png");
+                    SystemDialogs.SelectSaveFile(Lang.Text("Tools.Test.Achievement.Save"), AchievementTitleTextBox.Text + ".png", Lang.Text("Tools.Test.Achievement.FileFilter"));
                 if (string.IsNullOrEmpty(path))
                 {
                     ModBase.Log("用户取消了保存操作");
@@ -597,14 +586,14 @@ public partial class PageToolsTest
 
                 ModBase.CopyFile(savePath, path);
                 File.Delete(savePath);
-                ModMain.Hint("自定义成就图片已保存！", ModMain.HintType.Finish);
+                ModMain.Hint(Lang.Text("Tools.Test.Achievement.Saved"), ModMain.HintType.Finish);
             }
             // 下载成功，返回 True
             else if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 // 捕获 404 错误
                 ModBase.Log("获取成就图片失败（404）");
-                ModMain.Hint("获取成就图片失败，请检查文字是否包含特殊字符", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Tools.Test.Achievement.FetchFailed"), ModMain.HintType.Critical);
             }
             else
             {
@@ -633,8 +622,10 @@ public partial class PageToolsTest
 
     private void BtnCrash_Click(object sender, MouseButtonEventArgs e)
     {
-        if (ModMain.MyMsgBoxInput("崩溃确认", "你一定是点错了，如果没错请在下方确认", Lang.Text("Common.Action.Confirm"), hintText: "\"sURe\".ToUpper()", isWarn: true) ==
-            "SURE") throw new Exception("手动崩溃");
+        if (ModMain.MyMsgBoxInput(Lang.Text("Tools.Test.Crash.ConfirmTitle"),
+                Lang.Text("Tools.Test.Crash.ConfirmMessage"), Lang.Text("Common.Action.Confirm"),
+                hintText: "\"sURe\".ToUpper()", isWarn: true) ==
+            "SURE") throw new Exception(Lang.Text("Tools.Test.Crash.ManualCrash"));
     }
 
     private int GetHeadSize() => CmbHeadSize.SelectedIndex switch
@@ -647,7 +638,8 @@ public partial class PageToolsTest
 
     private void BtnSelectSkin_Click(object sender, RoutedEventArgs e)
     {
-        var filePath = SystemDialogs.SelectFile("图像文件(*.png)|*.png", "选择皮肤文件");
+        var filePath = SystemDialogs.SelectFile(Lang.Text("Tools.Test.Avatar.FileFilter"),
+            Lang.Text("Tools.Test.Avatar.SelectSkinFile"));
         if (!string.IsNullOrEmpty(filePath)) LoadAndGenerateHead(filePath);
     }
 
@@ -664,7 +656,7 @@ public partial class PageToolsTest
 
             if (currentSkinBitmap.Width != currentSkinBitmap.Height)
             {
-                ModMain.Hint("图片的大小不正确！请确认你选择了正确的文件！", ModMain.HintType.Critical);
+                ModMain.Hint(Lang.Text("Tools.Test.Avatar.InvalidSize"), ModMain.HintType.Critical);
                 SkinPreviewBorder.Visibility = Visibility.Collapsed;
                 return;
             }
@@ -675,13 +667,13 @@ public partial class PageToolsTest
             ImgHair.Source = null;
 
             SkinPreviewBorder.Visibility = Visibility.Visible;
-            ModMain.Hint("头像生成成功！", ModMain.HintType.Finish);
+            ModMain.Hint(Lang.Text("Tools.Test.Avatar.Generated"), ModMain.HintType.Finish);
         }
 
         catch (Exception ex)
         {
             ModBase.Log(ex, "生成头像失败");
-            ModMain.Hint("生成头像失败：" + ex.Message, ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Tools.Test.Avatar.GenerateFailed", ex.Message), ModMain.HintType.Critical);
             SkinPreviewBorder.Visibility = Visibility.Collapsed;
         }
     }
@@ -745,16 +737,17 @@ public partial class PageToolsTest
     {
         if (generatedHeadBitmap is null)
         {
-            ModMain.Hint("请先选择皮肤！", ModMain.HintType.Critical);
+            ModMain.Hint(Lang.Text("Tools.Test.Avatar.SelectFirst"), ModMain.HintType.Critical);
             return;
         }
 
-        var savePath = SystemDialogs.SelectSaveFile("保存头像", "Head.png");
+        var savePath = SystemDialogs.SelectSaveFile(Lang.Text("Tools.Test.Avatar.Save"), "Head.png");
+
         if (string.IsNullOrEmpty(savePath))
             return;
 
         generatedHeadBitmap.Save(savePath, ImageFormat.Png);
-        ModMain.Hint("头像保存成功！", ModMain.HintType.Finish);
+        ModMain.Hint(Lang.Text("Tools.Test.Avatar.Saved"), ModMain.HintType.Finish);
     }
 
     private void CmbHeadSize_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -482,7 +482,7 @@ public partial class PageToolsTest
 
     private void BtnCreateShortcut_Click(object sender, MouseButtonEventArgs e)
     {
-        var shortcutName = Lang.Text("Tools.Test.Shortcut.FileName") + ".lnk";
+        var shortcutName = Lang.Text("Tools.Test.Shortcut.FileName", ".lnk");
         var desktopName = Lang.Text("Tools.Test.Shortcut.Desktop");
         var startName = Lang.Text("Tools.Test.Shortcut.StartMenu");
         var desktop = Paths.GetSpecialPath(Environment.SpecialFolder.Desktop, shortcutName);


### PR DESCRIPTION
> DeepSeek V4 Pro 辅助迁移并校对

#2833 PR 6：工具、联机与辅助页面迁移

<img width="512" alt="image" src="https://github.com/user-attachments/assets/8104c204-eb95-453d-bde9-e248913188c5" />

<img width="512" alt="image" src="https://github.com/user-attachments/assets/26728bff-a9e3-4658-9bb3-3f9ae9710f8b" />

## Summary by Sourcery

通过将硬编码的 UI 文本替换为本地化键，并集中处理与网络和大厅相关的文本，实现对工具、大厅、日志、更新和辅助流程的国际化。

增强内容：
- 通过 `Lang.Text` 键对游戏链接（大厅）工具页面、Natayark 登录/EULA 流程以及相关错误和状态消息进行本地化。
- 对测试工具（下载、运气、清理、内存、皮肤/头像、成就、快捷方式、崩溃测试）和依赖检查实现国际化，包括消息框、提示和文件对话框。
- 添加支持本地化的辅助工具，用于 NAT 类型、连接类型以及大厅/网络质量描述，并重构 `CliNetTest`、`McPing` 和大厅服务以使用这些辅助工具。
- 本地化监视器日志、实时日志页面标题、计数器、导出流程，以及速度任务错误文案 UI，包括最大行数配置提示。
- 对更新工作流进行国际化，包括版本检查、下载/应用任务、社区公告，以及跨多个更新后端的错误处理。
- 更新其他杂项服务（链接预检查、内存交换、正则验证器、Minecraft 服务器查询控制、Natayark 配置文件管理器），使其使用集中管理的本地化消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Internationalize tools, lobby, logging, update, and helper flows by replacing hardcoded UI strings with localization keys and centralizing network- and lobby-related text handling.

Enhancements:
- Localize the Game Link (lobby) tool page, Natayark login/EULA flows, and related error and status messages via Lang.Text keys.
- Internationalize test tools (downloads, luck, cleanup, memory, skin/avatar, achievements, shortcuts, crash test) and dependency checks, including message boxes, hints, and file dialogs.
- Add localization-aware helpers for NAT type, connection type, and lobby/network quality descriptions, and refactor CliNetTest, McPing, and lobby services to use them.
- Localize watcher logs, real-time log page titles, counters, export flows, and speed task error copy UI, including max-line configuration hints.
- Internationalize update workflows, including version checks, download/apply tasks, community notices, and error handling across multiple update backends.
- Update miscellaneous services (link prechecks, memory swap, regex validator, Minecraft server query control, Natayark profile manager) to use centralized localized messages.

</details>