### PR TITLE
fix(network-service): 修复 NetworkService 启动时序

### DIFF
--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -19,12 +19,9 @@ public partial class NetworkService
     private static ServiceProvider? _provider;
     private static IHttpClientFactory? _factory;
 
-    private static ICacheService? _cacheService;
-
     [LifecycleStart]
     private static void _Start()
     {
-        _cacheService = CacheServiceManager.Current;
         // 重新构建服务提供者，添加带缓存的 HTTP 客户端
         var services = new ServiceCollection();
         services.AddHttpClient("default")
@@ -54,7 +51,7 @@ public partial class NetworkService
                 ConnectCallback = Config.Network.EnableDoH
                     ? HostConnectionHandler.Instance.GetConnectionAsync
                     : null
-            }, _cacheService));
+            }, CacheServiceManager.Current));
 
         _provider?.Dispose();
         _provider = services.BuildServiceProvider();


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复 NetworkService 的启动顺序问题：在配置 HTTP 处理程序时，从 `CacheServiceManager` 延迟获取缓存服务，而不是在生命周期开始时就将其缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix NetworkService startup sequence by obtaining the cache service lazily from CacheServiceManager during HTTP handler configuration instead of caching it at lifecycle start.

</details>