### PR TITLE
fix(json): 兼容 ISO 8601 当日终点时间 24:00

### DIFF
--- a/PCL.Core.Test/JsonCompatDateTimeTest.cs
+++ b/PCL.Core.Test/JsonCompatDateTimeTest.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PCL.Core.Utils;
+
+namespace PCL.Core.Test
+{
+    [TestClass]
+    public class JsonCompatDateTimeTest
+    {
+        [TestMethod]
+        public void ParsesStandardIso()
+        {
+            Assert.IsTrue(JsonCompat.TryParseDateTime("2025-11-25T13:30:42+00:00", out var dt));
+            Assert.AreEqual(new DateTimeOffset(2025, 11, 25, 13, 30, 42, TimeSpan.Zero).LocalDateTime, dt);
+        }
+
+        [TestMethod]
+        public void ParsesNegativeZeroOffset()
+        {
+            // 部分社区清单用 -00:00 表示 UTC，应与 +00:00 等价
+            Assert.IsTrue(JsonCompat.TryParseDateTime("2009-05-20T00:00:00-00:00", out var dt));
+            Assert.AreEqual(new DateTimeOffset(2009, 5, 20, 0, 0, 0, TimeSpan.Zero).LocalDateTime, dt);
+        }
+
+        [TestMethod]
+        public void ParsesEndOfDayHour24AsNextDayMidnight()
+        {
+            // ISO 8601：24:00:00 表示当日终点，等于次日零点。真实数据见 UVMC 清单版本 c0.27_st。
+            Assert.IsTrue(JsonCompat.TryParseDateTime("2009-10-24T24:00:00+00:00", out var dt));
+            Assert.AreEqual(new DateTimeOffset(2009, 10, 25, 0, 0, 0, TimeSpan.Zero).LocalDateTime, dt);
+        }
+
+        [TestMethod]
+        public void RejectsInvalidTimeMasqueradingAsEndOfDay()
+        {
+            // 24:30:00 不是合法的当日终点写法，应解析失败而非被强行归一化
+            Assert.IsFalse(JsonCompat.TryParseDateTime("2009-10-24T24:30:00+00:00", out _));
+        }
+
+        [TestMethod]
+        public void RejectsGarbage()
+        {
+            Assert.IsFalse(JsonCompat.TryParseDateTime("not a date", out _));
+            Assert.IsFalse(JsonCompat.TryParseDateTime("", out _));
+            Assert.IsFalse(JsonCompat.TryParseDateTime(null, out _));
+        }
+    }
+}

--- a/PCL.Core/Utils/JsonCompat.cs
+++ b/PCL.Core/Utils/JsonCompat.cs
@@ -109,9 +109,20 @@ public static class JsonCompat
         dateTime = default;
         if (string.IsNullOrWhiteSpace(value)) return false;
 
+        // ISO 8601 允许用 24:00:00 表示当日终点（语义等于次日零点），但 .NET 的日期解析器不接受小时为 24，
+        // 需先把小时 24 归一化为 00，再在解析成功后补一天。例如社区版本清单中的 2009-10-24T24:00:00+00:00。
+        var addDay = false;
+        var endOfDay = RegexPatterns.Iso8601EndOfDay.Match(value);
+        if (endOfDay.Success)
+        {
+            value = value.Remove(endOfDay.Index + 1, 2).Insert(endOfDay.Index + 1, "00");
+            addDay = true;
+        }
+
         if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
                 out var dateTimeOffset))
         {
+            if (addDay) dateTimeOffset = dateTimeOffset.AddDays(1);
             dateTime = dateTimeOffset.LocalDateTime;
             return true;
         }
@@ -119,7 +130,7 @@ public static class JsonCompat
         if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var parsed))
             return false;
 
-        dateTime = NormalizeDateTime(parsed);
+        dateTime = NormalizeDateTime(addDay ? parsed.AddDays(1) : parsed);
         return true;
     }
 

--- a/PCL.Core/Utils/RegexPatterns.cs
+++ b/PCL.Core/Utils/RegexPatterns.cs
@@ -22,6 +22,13 @@ public static partial class RegexPatterns
     private static partial Regex _NewLine();
 
     /// <summary>
+    /// ISO 8601 当日终点时间写法 24:00(:00)(.0…)，语义等于次日零点。
+    /// </summary>
+    public static readonly Regex Iso8601EndOfDay = _Iso8601EndOfDay();
+    [GeneratedRegex(@"[Tt]24:00(?::00(?:\.0+)?)?(?=[Zz+\-]|$)")]
+    private static partial Regex _Iso8601EndOfDay();
+
+    /// <summary>
     /// Semantic Versioning (SemVer) 规范的版本号，包含可选的 v 前缀。
     /// </summary>
     public static readonly Regex SemVer = _SemVer();

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1310,8 +1310,7 @@ public partial class PageInstanceInstall
 
                                 default:
                                 {
-                                    var releaseDate = Version["releaseTime"].ToObject<DateTime>().ToUniversalTime()
-                                        .AddHours(2d);
+                                    var releaseDate = McVersionClassifier.GetReleaseTime(Version).ToUniversalTime().AddHours(2d);
                                     if (releaseDate.Month == 4 && releaseDate.Day == 1)
                                     {
                                         type = "愚人节版";
@@ -1344,7 +1343,7 @@ public partial class PageInstanceInstall
 
                 // 排序
                 foreach (var Pair in dict.ToList())
-                    dict[Pair.Key] = Pair.Value.OrderByDescending(j => j["releaseTime"].ToObject<DateTime>()).ToList();
+                    dict[Pair.Key] = Pair.Value.OrderByDescending(McVersionClassifier.GetReleaseTime).ToList();
                 // 清空当前
                 PanMinecraft.Children.Clear();
                 // 添加最新版本


### PR DESCRIPTION
Close #3000

修复 #2882 引入的版本列表解析崩溃。

## Summary by Sourcery

处理 ISO 8601 的“日终”（end-of-day）时间戳，并使版本发布时间的处理方式与共享分类器保持一致。

Bug 修复：
- 修复使用小时 `24:00` 的 ISO 8601 时间戳的 JSON 日期解析问题，避免在遇到“日终”时间时版本列表崩溃。
- 确保 JSON 日期解析能够正确将 `-00:00` 偏移视为 UTC，并在遇到格式错误的“日终”时间时拒绝它们，而不是对其进行归一化处理。

增强功能：
- 添加可复用的正则表达式模式，用于检测 ISO 8601 的“日终”时间戳，并在解析之前对其进行归一化。
- 在实例安装页面中重构 Minecraft 版本发布时间的计算与排序逻辑，改为使用 `McVersionClassifier.GetReleaseTime` 以保持一致性。

测试：
- 为 `JsonCompat.TryParseDateTime` 添加单元测试，覆盖标准 ISO 时间戳、负零 UTC 偏移、合法的 `24:00`“日终”时间戳、非法的 `24:30` 情况以及一般的垃圾输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle ISO 8601 end-of-day timestamps and align version release time handling with the shared classifier.

Bug Fixes:
- Fix JSON date parsing for ISO 8601 timestamps using hour 24:00 so version lists no longer crash when encountering end-of-day times.
- Ensure JSON date parsing correctly treats -00:00 offsets as UTC and rejects malformed end-of-day times instead of normalizing them.

Enhancements:
- Add a reusable regex pattern to detect ISO 8601 end-of-day timestamps and normalize them before parsing.
- Refactor Minecraft version release time calculation and sorting in the instance install page to use McVersionClassifier.GetReleaseTime for consistency.

Tests:
- Add unit tests covering standard ISO timestamps, negative zero UTC offsets, valid 24:00 end-of-day timestamps, invalid 24:30 cases, and general garbage input for JsonCompat.TryParseDateTime.

</details>