### PR TITLE
refactor: 使用 `field` 语法

### DIFF
--- a/Plain Craft Launcher 2/Controls/AnimatedBackgroundGrid.cs
+++ b/Plain Craft Launcher 2/Controls/AnimatedBackgroundGrid.cs
@@ -14,8 +14,6 @@ public class AnimatedBackgroundGrid : Grid
 
     public readonly int uuid = ModBase.GetUuid();
 
-    private bool _isAnimating;
-
     public AnimatedBackgroundGrid(DependencyProperty brushDp)
     {
         _animatableBrushProperty = brushDp;
@@ -36,8 +34,8 @@ public class AnimatedBackgroundGrid : Grid
 
     protected bool IsAnimating
     {
-        get => _isAnimating;
-        private set => _isAnimating = value;
+        get => field;
+        private set => field = value;
     }
 
     public SolidColorBrush BackgroundBrush

--- a/Plain Craft Launcher 2/Controls/MyCard.cs
+++ b/Plain Craft Launcher 2/Controls/MyCard.cs
@@ -22,7 +22,6 @@ public class MyCard : AnimatedBackgroundGrid
 
     // 控件
     private readonly Grid mainGrid;
-    private Path _MainSwap;
     private TextBlock _MainTextBlock;
     private bool isLoad;
 
@@ -74,9 +73,9 @@ public class MyCard : AnimatedBackgroundGrid
         get
         {
             Init();
-            return _MainSwap;
+            return field;
         }
-        set => _MainSwap = value;
+        set => field = value;
     }
 
     // 属性
@@ -346,12 +345,12 @@ public class MyCard : AnimatedBackgroundGrid
     /// </summary>
     public bool IsSwapped
     {
-        get => _IsSwapped;
+        get => field;
         set
         {
-            if (_IsSwapped == value)
+            if (field == value)
                 return;
-            _IsSwapped = value;
+            field = value;
             if (SwapControl is null)
                 return;
 
@@ -376,13 +375,11 @@ public class MyCard : AnimatedBackgroundGrid
             // 折叠时箭头指向右侧或向上（根据SwapLogoRight设置），展开时指向下方
             ModAnimation.AniStart(
                 ModAnimation.AaRotateTransform(MainSwap,
-                    (_IsSwapped ? SwapLogoRight ? 270 : 0 : 180) - ((RotateTransform)MainSwap.RenderTransform).Angle,
+                    (field ? SwapLogoRight ? 270 : 0 : 180) - ((RotateTransform)MainSwap.RenderTransform).Angle,
                     250, ease: new ModAnimation.AniEaseOutFluent(ModAnimation.AniEasePower.ExtraStrong)),
                 "MyCard Swap " + uuid, true);
         }
     }
-
-    private bool _IsSwapped;
 
     /// <summary>
     ///     是否已被折叠。(已过时，请使用 IsSwapped)

--- a/Plain Craft Launcher 2/Controls/MyExtraButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyExtraButton.xaml.cs
@@ -17,13 +17,8 @@ public partial class MyExtraButton
     // 务必放在 IsMouseDown 更新之后
     private const int animationColorIn = 120;
     private const int animationColorOut = 150;
-    private string _Logo = "";
-    private double _LogoScale = 1d;
 
     // 进度条
-    private double _Progress;
-    private bool _Show;
-
     // 鼠标点击判定（务必放在点击事件之后，以使得 Button_MouseUp 先于 Button_MouseLeave 执行）
     private bool isLeftMouseHeld;
     private bool isRightMouseHeld;
@@ -42,12 +37,12 @@ public partial class MyExtraButton
 
     public double Progress
     {
-        get => _Progress;
+        get => field;
         set
         {
-            if (_Progress == value)
+            if (field == value)
                 return;
-            _Progress = value;
+            field = value;
             if (value < 0.0001d)
             {
                 PanProgress.Visibility = Visibility.Collapsed;
@@ -62,35 +57,35 @@ public partial class MyExtraButton
 
     public string Logo
     {
-        get => _Logo;
+        get => field;
         set
         {
-            if ((value ?? "") == (_Logo ?? ""))
+            if ((value ?? "") == (field ?? ""))
                 return;
-            _Logo = value;
+            field = value;
             Path.Data = (Geometry)new GeometryConverter().ConvertFromString(value);
         }
-    }
+    } = "";
 
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
             if (Path is not null)
                 Path.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     public bool Show
     {
-        get => _Show;
+        get => field;
         set
         {
-            if (_Show == value)
+            if (field == value)
                 return;
-            _Show = value;
+            field = value;
             ModBase.RunInUi(() =>
             {
                 if (value)

--- a/Plain Craft Launcher 2/Controls/MyExtraTextButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyExtraTextButton.xaml.cs
@@ -22,12 +22,6 @@ public partial class MyExtraTextButton
             if (sender is not null) ((MyExtraTextButton)sender).LabText.Text = (string)e.NewValue;
         }));
 
-    private string _Logo = "";
-    private double _LogoScale = 1d;
-
-    // 动画
-    private bool _Show;
-
     // 鼠标点击判定（务必放在点击事件之后，以使得 Button_MouseUp 先于 Button_MouseLeave 执行）
     private bool isLeftMouseHeld;
 
@@ -49,26 +43,26 @@ public partial class MyExtraTextButton
 
     public string Logo
     {
-        get => _Logo;
+        get => field;
         set
         {
-            if ((value ?? "") == (_Logo ?? ""))
+            if ((value ?? "") == (field ?? ""))
                 return;
-            _Logo = value;
+            field = value;
             Path.Data = (Geometry)new GeometryConverter().ConvertFromString(value);
         }
-    }
+    } = "";
 
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
             if (Path is not null)
                 Path.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     // 显示文本
     public InlineCollection Inlines => LabText.Inlines;
@@ -85,12 +79,12 @@ public partial class MyExtraTextButton
 
     public bool Show
     {
-        get => _Show;
+        get => field;
         set
         {
-            if (_Show == value)
+            if (field == value)
                 return;
-            _Show = value;
+            field = value;
             ModBase.RunInUi(() =>
             {
                 if (value)

--- a/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
@@ -36,8 +36,6 @@ public partial class MyHint
             f.LabText.Text = (string)e.NewValue;
         }));
 
-    private Themes _ColorType = Themes.Red;
-
     // 触发点击事件
     private bool isMouseDown;
     public int Uuid = ModBase.GetUuid();
@@ -70,13 +68,13 @@ public partial class MyHint
 
     public Themes Theme
     {
-        get => _ColorType;
+        get => field;
         set
         {
-            _ColorType = value;
+            field = value;
             UpdateUI();
         }
-    }
+    } = Themes.Red;
 
     [Obsolete("IsWarn 已过时。请换用 Theme 属性。")]
     public bool IsWarn

--- a/Plain Craft Launcher 2/Controls/MyIconButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyIconButton.xaml.cs
@@ -23,10 +23,6 @@ public partial class MyIconButton
     private const int animationColorIn = 120;
     private const int animationColorOut = 150;
 
-    private SolidColorBrush _Foreground = new(Color.FromRgb(128, 128, 128));
-
-    private double _LogoScale = 1d;
-
     // 自定义属性
 
     public int Uuid = ModBase.GetUuid();
@@ -56,28 +52,28 @@ public partial class MyIconButton
 
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
             if (Path is not null)
                 Path.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     public Themes Theme { get; set; } = Themes.Color;
 
     public SolidColorBrush Foreground
     {
-        get => _Foreground;
+        get => field;
         set
         {
-            _Foreground = value;
+            field = value;
             ModAnimation.AniControlEnabled += 1;
             RefreshAnim();
             ModAnimation.AniControlEnabled -= 1;
         }
-    }
+    } = new(Color.FromRgb(128, 128, 128));
 
     // 自定义事件
     public event ClickEventHandler? Click;

--- a/Plain Craft Launcher 2/Controls/MyIconTextButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyIconTextButton.xaml.cs
@@ -36,7 +36,6 @@ public partial class MyIconTextButton
     public static readonly DependencyProperty ColorTypeProperty = DependencyProperty.Register("ColorType",
         typeof(ColorState), typeof(MyIconTextButton), new PropertyMetadata(ColorState.Black));
 
-    private double _LogoScale = 1d;
     private bool isMouseDown;
 
     // 基础
@@ -69,14 +68,14 @@ public partial class MyIconTextButton
 
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
             if (ShapeLogo is not null)
                 ShapeLogo.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     public InlineCollection Inlines => LabText.Inlines;
 

--- a/Plain Craft Launcher 2/Controls/MyImage.cs
+++ b/Plain Craft Launcher 2/Controls/MyImage.cs
@@ -12,8 +12,6 @@ namespace PCL;
 
 public class MyImage : Image
 {
-    private string _ActualSource;
-
     public MyImage()
     {
         Initialized += (_, _) => Load();
@@ -25,14 +23,14 @@ public class MyImage : Image
     /// </summary>
     public string ActualSource
     {
-        get => _ActualSource;
+        get => field;
         set
         {
             if (string.IsNullOrEmpty(value))
                 value = null;
-            if ((_ActualSource ?? "") == (value ?? ""))
+            if ((field ?? "") == (value ?? ""))
                 return;
-            _ActualSource = value;
+            field = value;
             Dispatcher.BeginInvoke(new Func<Task>(async () =>
             {
                 try
@@ -192,21 +190,19 @@ public class MyImage : Image
     /// </summary>
     public new string Source // 覆写 Image 的 Source 属性
     {
-        get => _Source;
+        get => field;
         set
         {
             if (string.IsNullOrEmpty(value))
                 value = null;
-            if ((_Source ?? "") == (value ?? ""))
+            if ((field ?? "") == (value ?? ""))
                 return;
-            _Source = value;
+            field = value;
             if (!IsInitialized)
                 return; // 属性读取顺序修正：在完成 XAML 属性读取后再触发图片加载（#4868）
             Load();
         }
-    }
-
-    private string _Source = "";
+    } = "";
 
     public new static readonly DependencyProperty SourceProperty = DependencyProperty.Register("Source", typeof(string),
         typeof(MyImage), new PropertyMetadata((sender, e) =>

--- a/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyListItem.xaml.cs
@@ -242,14 +242,12 @@ public partial class MyListItem : IMyRadio
     /// <summary>
     ///     Tags 的存放 StackPanel
     /// </summary>
-    public StackPanel _PanTags;
-
     public StackPanel PanTags
     {
         get
         {
-            if (_PanTags is not null)
-                return _PanTags;
+            if (field is not null)
+                return field;
             var newStack = new StackPanel
             {
                 IsHitTestVisible = false,
@@ -260,8 +258,8 @@ public partial class MyListItem : IMyRadio
             SetColumn(newStack, 3);
             SetRow(newStack, 2);
             PanBack.Children.Add(newStack);
-            _PanTags = newStack;
-            return _PanTags;
+            field = newStack;
+            return field;
         }
     }
 
@@ -301,13 +299,12 @@ public partial class MyListItem : IMyRadio
     }
 
     // 副文本
-    private TextBlock _LabInfo;
 
     public TextBlock LabInfo
     {
         get
         {
-            if (_LabInfo is null)
+            if (field is null)
             {
                 var lab = new TextBlock
                 {
@@ -325,12 +322,12 @@ public partial class MyListItem : IMyRadio
                 SetColumn(lab, 4);
                 SetRow(lab, 2);
                 PanBack.Children.Add(lab);
-                _LabInfo = lab;
+                field = lab;
                 // <TextBlock Grid.Row="2" SnapsToDevicePixels="False" UseLayoutRounding="False" HorizontalAlignment="Left" x:Name = "LabInfo" IsHitTestVisible="False" Grid.Column="2" 
                 // TextTrimming = "CharacterEllipsis" Visibility="Collapsed" FontSize="12" Foreground="{StaticResource ColorBrushGray2}" Margin="4,0,0,0" />
             }
 
-            return _LabInfo;
+            return field;
         }
     }
 
@@ -346,16 +343,14 @@ public partial class MyListItem : IMyRadio
     /// </summary>
     public bool IsScaleAnimationEnabled
     {
-        get => _IsScaleAnimationEnabled;
+        get => field;
         set
         {
-            _IsScaleAnimationEnabled = value;
+            field = value;
             if (_RectBack is not null)
                 RectBack.CornerRadius = new CornerRadius(value ? 6 : 0);
         }
-    }
-
-    private bool _IsScaleAnimationEnabled = true;
+    } = true;
 
     // 边距
     public int PaddingLeft
@@ -371,14 +366,13 @@ public partial class MyListItem : IMyRadio
     public int MinPaddingRight { get; set; } = 4;
 
     // 按钮
-    private IEnumerable<MyIconButton> _Buttons;
 
     public IEnumerable<MyIconButton> Buttons
     {
-        get => _Buttons;
+        get => field;
         set
         {
-            _Buttons = value;
+            field = value;
             // 没有特殊按钮，移除原 Stack
             if (buttonStack is not null)
             {
@@ -617,18 +611,16 @@ public partial class MyListItem : IMyRadio
         ColumnLogo.Width = new GridLength((string.IsNullOrEmpty(_Logo) ? 0 : 34) + (Height < 40d ? 0 : 4));
     }
 
-    private double _LogoScale = 1d;
-
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
         if (pathLogo is not null)
                 pathLogo.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     // 图标的点击
     /// <summary>

--- a/Plain Craft Launcher 2/Controls/MyLoading.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyLoading.xaml.cs
@@ -145,27 +145,25 @@ public partial class MyLoading
     }
 
     // 用于外部改变的公开状态
-    private ILoadingTrigger __State;
-
     private ILoadingTrigger _State
     {
         [MethodImpl(MethodImplOptions.Synchronized)]
-        get => __State;
+        get => field;
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         set
         {
-            if (__State is not null)
+            if (field is not null)
             {
-                __State.ProgressChanged -= (_, _) => RefreshText();
-                __State.LoadingStateChanged -= (_, _) => RefreshState();
+                field.ProgressChanged -= (_, _) => RefreshText();
+                field.LoadingStateChanged -= (_, _) => RefreshState();
             }
 
-            __State = value;
-            if (__State is not null)
+            field = value;
+            if (field is not null)
             {
-                __State.ProgressChanged += (_, _) => RefreshText();
-                __State.LoadingStateChanged += (_, _) => RefreshState();
+                field.ProgressChanged += (_, _) => RefreshText();
+                field.LoadingStateChanged += (_, _) => RefreshState();
             }
         }
     }

--- a/Plain Craft Launcher 2/Controls/MyPageRight.cs
+++ b/Plain Craft Launcher 2/Controls/MyPageRight.cs
@@ -26,8 +26,6 @@ public class MyPageRight : AdornerDecorator
     private static readonly DependencyProperty PanScrollProperty =
     DependencyProperty.Register("PanScroll", typeof(MyScrollViewer), typeof(MyPageRight));
 
-    private PageStates _PageState = PageStates.Empty;
-
     private bool _panScrollNullWarned;
 
     public int pageUuid = ModBase.GetUuid();
@@ -51,16 +49,16 @@ public class MyPageRight : AdornerDecorator
 
     public PageStates PageState
     {
-        get => _PageState;
+        get => field;
         set
         {
-            if (_PageState == value)
+            if (field == value)
                 return;
-            _PageState = value;
+            field = value;
             if (ModBase.modeDebug)
                 ModBase.Log("[UI] 页面状态切换为 " + ModBase.GetStringFromEnum(value));
         }
-    }
+    } = PageStates.Empty;
 
     #region 加载器
 

--- a/Plain Craft Launcher 2/Controls/MyRadioButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyRadioButton.xaml.cs
@@ -38,8 +38,6 @@ public partial class MyRadioButton
         }));
 
     private bool _Checked; // 是否选中
-    private ColorState _ColorType = ColorState.White;
-    private double _LogoScale = 1d;
     private bool isMouseDown;
 
     // 基础
@@ -96,14 +94,14 @@ public partial class MyRadioButton
 
     public double LogoScale
     {
-        get => _LogoScale;
+        get => field;
         set
         {
-            _LogoScale = value;
+            field = value;
             if (ShapeLogo is not null)
                 ShapeLogo.RenderTransform = new ScaleTransform { ScaleX = LogoScale, ScaleY = LogoScale };
         }
-    }
+    } = 1d;
 
     public bool Checked
     {
@@ -121,13 +119,13 @@ public partial class MyRadioButton
 
     public ColorState ColorType
     {
-        get => _ColorType;
+        get => field;
         set
         {
-            _ColorType = value;
+            field = value;
             RefreshColor();
         }
-    } // 颜色类别
+    } = ColorState.White; // 颜色类别
 
     public event CheckEventHandler? Check;
 

--- a/Plain Craft Launcher 2/Controls/MySlider.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MySlider.xaml.cs
@@ -13,7 +13,6 @@ public partial class MySlider
 
     // 自定义属性
 
-    private int _MaxValue = 100;
     private int _Value;
     private bool changeByKey;
 
@@ -39,15 +38,15 @@ public partial class MySlider
 
     public int MaxValue
     {
-        get => _MaxValue;
+        get => field;
         set
         {
-            if (value == _MaxValue)
+            if (value == field)
                 return;
-            _MaxValue = value;
+            field = value;
             RefreshWidth(null, null);
         }
-    }
+    } = 100;
 
     public int Value
     {

--- a/Plain Craft Launcher 2/Controls/MyTextBox.cs
+++ b/Plain Craft Launcher 2/Controls/MyTextBox.cs
@@ -34,7 +34,6 @@ public class MyTextBox : TextBox
 
     // 额外控件初始化
 
-    private Collection<IValidator<string>> _ValidateRules = new();
     public List<RoutedEventHandler> changedEventList = new();
 
     // 提示文本
@@ -114,13 +113,13 @@ public class MyTextBox : TextBox
     /// </summary>
     public Collection<IValidator<string>> ValidateRules
     {
-        get => _ValidateRules;
+        get => field;
         set
         {
-            _ValidateRules = value;
+            field = value;
             Validate();
         }
-    }
+    } = new();
 
     public string HintText
     {

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -1296,16 +1296,14 @@ public partial class FormMain
     }
 
     // 窗口隐藏与置顶
-    private bool _Hidden;
-
     public bool Hidden
     {
-        get => _Hidden;
+        get => field;
         set
         {
-            if (_Hidden == value)
+            if (field == value)
                 return;
-            _Hidden = value;
+            field = value;
             if (value)
             {
                 // 隐藏

--- a/Plain Craft Launcher 2/Modules/Base/ModAnimation.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModAnimation.cs
@@ -447,7 +447,6 @@ public static partial class ModAnimation
     /// </summary>
     public static bool aniRunning;
 
-    private static int _AniControlEnabled;
     private static readonly object aniControlEnabledLock = new();
 
     /// <summary>
@@ -455,12 +454,12 @@ public static partial class ModAnimation
     /// </summary>
     public static int AniControlEnabled
     {
-        get => _AniControlEnabled;
+        get => field;
         set
         {
             lock (aniControlEnabledLock)
             {
-                _AniControlEnabled = value;
+                field = value;
             }
         }
     }

--- a/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
@@ -188,9 +188,7 @@ public static class ModLoader
         /// </summary>
         public readonly object lockState = new();
 
-        private MyLoading.MyLoadingState _LoadingState = MyLoading.MyLoadingState.Stop;
-        private double _Progress = -1;
-        private ModBase.LoadState _State = ModBase.LoadState.Waiting;
+
 
         /// <summary>
         ///     使用 LoaderCombo 加载时，该任务是否会阻碍后续任务的进行。
@@ -269,15 +267,15 @@ public static class ModLoader
         /// </summary>
         public ModBase.LoadState State
         {
-            get => _State;
+            get => field;
             set
             {
-                if (_State == value)
+                if (field == value)
                     return;
-                var oldState = _State;
+                var oldState = field;
                 if (value == ModBase.LoadState.Finished && Config.Debug.AddRandomDelay)
                     Thread.Sleep(RandomUtils.NextInt(100, 2000));
-                _State = value;
+                field = value;
                 ModBase.Log("[Loader] 加载器 " + name + " 状态改变：" + ModBase.GetStringFromEnum(value));
                 // 实现 ILoadingTrigger 接口与 OnStateChanged 回调
                 ModBase.RunInUi(() =>
@@ -307,7 +305,7 @@ public static class ModLoader
                 if (hasOnStateChangedThread)
                     ModBase.RunInThread(() => OnStateChangedThread?.Invoke(this, value, oldState));
             }
-        }
+        } = ModBase.LoadState.Waiting;
 
         /// <summary>
         ///     若加载器出错，可提供给外部参考的异常。
@@ -330,7 +328,7 @@ public static class ModLoader
                     }
                     case ModBase.LoadState.Loading:
                     {
-                        return _Progress == -1 ? 0.02d : _Progress;
+                        return field == -1 ? 0.02d : field;
                     }
 
                     default:
@@ -341,13 +339,13 @@ public static class ModLoader
             }
             set
             {
-                if (_Progress == value)
+                if (field == value)
                     return;
-                var oldValue = _Progress;
-                _Progress = value;
+                var oldValue = field;
+                field = value;
                 ProgressChanged?.Invoke(value, oldValue);
             }
-        }
+        } = -1;
 
         /// <summary>
         ///     计算总进度时的权重。它应该为预计时间（秒）。
@@ -358,16 +356,16 @@ public static class ModLoader
 
         public MyLoading.MyLoadingState LoadingState
         {
-            get => _LoadingState;
+            get => field;
             set
             {
-                if (_LoadingState == value)
+                if (field == value)
                     return;
-                var oldState = _LoadingState;
-                _LoadingState = value;
+                var oldState = field;
+                field = value;
                 LoadingStateChanged?.Invoke(value, oldState);
             }
-        }
+        } = MyLoading.MyLoadingState.Stop;
 
         public event ILoadingTrigger.LoadingStateChangedEventHandler? LoadingStateChanged;
         public event ILoadingTrigger.ProgressChangedEventHandler? ProgressChanged;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -227,30 +227,29 @@ public static class ModDownload
         {
             lock (_allDropsLock)
             {
-                if (_allDrops is null)
+                if (field is null)
                 {
                     var rawData = States.Game.Drops;
                     if (string.IsNullOrEmpty(rawData))
-                        _allDrops = new List<int>();
+                        field = new List<int>();
                     else
-                        _allDrops = rawData.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+                        field = rawData.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
                             .Select(d => (int)Math.Round(ModBase.Val(d))).ToList();
                 }
 
-                return _allDrops.Count != 0 ? _allDrops : null;
+                return field.Count != 0 ? field : null;
             }
         }
         set
         {
             lock (_allDropsLock)
             {
-                _allDrops = value;
+                field = value;
                 States.Game.Drops = value.Join(",");
             }
         }
     }
 
-    private static List<int> _allDrops;
     private static readonly object _allDropsLock = new();
 
     // 主加载器
@@ -546,8 +545,6 @@ public static class ModDownload
 
     public class DlOptiFineListEntry
     {
-        private string _inherit;
-
         /// <summary>
         ///     显示名称，已去除 HD_U 字样，如“1.12.2 C8”。
         /// </summary>
@@ -583,12 +580,12 @@ public static class ModDownload
         /// </summary>
         public string Inherit
         {
-            get => _inherit;
+            get => field;
             set
             {
                 if (value.EndsWithF(".0"))
                     value = value.Substring(0, value.Length - 2);
-                _inherit = value;
+                field = value;
             }
         }
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -496,12 +496,12 @@ public static class ModLocalComp
         {
             get
             {
-                if (_tags is null)
+                if (field is null)
                 {
-                    _tags = new List<string>();
+                    field = new List<string>();
                     if (IsFolder)
                     {
-                        _tags.Add("文件夹");
+                        field.Add("文件夹");
                     }
                     else
                     {
@@ -510,29 +510,27 @@ public static class ModLocalComp
                         {
                             case ".litematic":
                             {
-                                _tags.Add("原理图");
+                                field.Add("原理图");
                                 break;
                             }
                             case ".schem":
                             case ".schematic":
                             {
-                                _tags.Add("Schematic结构");
+                                field.Add("Schematic结构");
                                 break;
                             }
                             case ".nbt":
                             {
-                                _tags.Add("原版结构");
+                                field.Add("原版结构");
                                 break;
                             }
                         }
                     }
                 }
 
-                return _tags;
+                return field;
             }
         }
-
-        private List<string> _tags;
 
         /// <summary>
         ///     Mod 的版本，不保证符合版本格式规范。
@@ -598,17 +596,15 @@ public static class ModLocalComp
         {
             get
             {
-                if (_Url is null)
+                if (field is null)
                     Load();
-                return _Url;
+                return field;
             }
             set
             {
-                if (_Url is null && value is not null && value.StartsWithF("http")) _Url = value;
+                if (field is null && value is not null && value.StartsWithF("http")) field = value;
             }
         }
-
-        private string _Url;
 
         /// <summary>
         ///     Mod 的作者列表。
@@ -1682,15 +1678,13 @@ public static class ModLocalComp
         /// </summary>
         public CompProject Comp
         {
-            get => _Comp;
+            get => field;
             set
             {
-                _Comp = value;
+                field = value;
                 OnCompUpdate?.Invoke(this);
             }
         }
-
-        private CompProject _Comp;
 
         /// <summary>
         ///     本地文件对应的联网文件信息。
@@ -1702,15 +1696,13 @@ public static class ModLocalComp
         /// </summary>
         public CompFile UpdateFile
         {
-            get => _UpdateFile;
+            get => field;
             set
             {
-                _UpdateFile = value;
+                field = value;
                 OnCompUpdate?.Invoke(this);
             }
         }
-
-        private CompFile _UpdateFile;
 
         /// <summary>
         ///     该 Mod 的更新日志网址。
@@ -1849,7 +1841,7 @@ public static class ModLocalComp
         {
             get
             {
-                if (_ModrinthHash is null)
+                if (field is null)
                 {
                     // 读取缓存
                     var info = new FileInfo(path);
@@ -1858,21 +1850,19 @@ public static class ModLocalComp
                     var cached = ModBase.ReadIni(ModBase.pathTemp + @"Cache\CompHash.ini", cacheKey);
                     if (!string.IsNullOrEmpty(cached))
                     {
-                        _ModrinthHash = cached;
-                        return _ModrinthHash;
+                        field = cached;
+                        return field;
                     }
 
                     // 计算 SHA1
-                    _ModrinthHash = ModBase.GetFileSHA1(path);
+                    field = ModBase.GetFileSHA1(path);
                     // 写入缓存
-                    ModBase.WriteIni(ModBase.pathTemp + @"Cache\CompHash.ini", cacheKey, _ModrinthHash);
+                    ModBase.WriteIni(ModBase.pathTemp + @"Cache\CompHash.ini", cacheKey, field);
                 }
 
-                return _ModrinthHash;
+                return field;
             }
         }
-
-        private string _ModrinthHash;
 
         #endregion
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -414,7 +414,6 @@ public static class ModMinecraft
 
     public const int mcInstanceCacheVersion = 30;
 
-    private static Instance _mcInstanceSelected;
     private static object _McInstanceSelected_mcInstanceSelectedLast = 0; // 为 0 以保证与 Nothing 不相同，使得 UI 显示可以正常初始化
 
     /// <summary>
@@ -422,12 +421,12 @@ public static class ModMinecraft
     /// </summary>
     public static Instance McInstanceSelected
     {
-        get => _mcInstanceSelected;
+        get => field;
         set
         {
             if (ReferenceEquals(_McInstanceSelected_mcInstanceSelectedLast, value))
                 return;
-            _mcInstanceSelected = value; // 由于有可能是 Nothing，导致无法初始化，才得这样弄一圈
+            field = value; // 由于有可能是 Nothing，导致无法初始化，才得这样弄一圈
             _McInstanceSelected_mcInstanceSelectedLast = value;
             if (value is null)
                 return;
@@ -440,13 +439,6 @@ public static class ModMinecraft
 
     public class Instance
     {
-        private McInstanceInfo _info;
-        private string _inheritInstanceName;
-        private JsonObject _jsonObject;
-        private string _jsonText;
-        private JsonObject _jsonVersion;
-        private string _name;
-
         /// <summary>
         ///     显示的描述文本。
         /// </summary>
@@ -553,9 +545,9 @@ public static class ModMinecraft
         {
             get
             {
-                if (_name is null && !string.IsNullOrEmpty(PathInstance))
-                    _name = ModBase.GetFolderNameFromPath(PathInstance);
-                return _name;
+                if (field is null && !string.IsNullOrEmpty(PathInstance))
+                    field = ModBase.GetFolderNameFromPath(PathInstance);
+                return field;
             }
         }
 
@@ -580,9 +572,9 @@ public static class ModMinecraft
         {
             get
             {
-                if (_info is not null)
-                    return _info;
-                _info = new McInstanceInfo();
+                if (field is not null)
+                    return field;
+                field = new McInstanceInfo();
 
                 #region 获取游戏版本
 
@@ -597,7 +589,7 @@ public static class ModMinecraft
                             releaseTime = JsonObject["releaseTime"].ToObject<DateTime>();
                         if (releaseTime.Year > 2000 && releaseTime.Year < 2013)
                         {
-                            _info.VanillaName = "Old";
+                            field.VanillaName = "Old";
                             goto VersionSearchFinish;
                         }
                     }
@@ -609,14 +601,14 @@ public static class ModMinecraft
                     // 实验性快照
                     if ((string)(JsonObject["type"] ?? "") == "pending")
                     {
-                        _info.VanillaName = "pending";
+                        field.VanillaName = "pending";
                         goto VersionSearchFinish;
                     }
 
                     // 从 PCL 下载的版本信息中获取版本号
                     if (JsonObject["clientVersion"] is not null)
                     {
-                        _info.VanillaName = (string)JsonObject["clientVersion"];
+                        field.VanillaName = (string)JsonObject["clientVersion"];
                         goto VersionSearchFinish;
                     }
 
@@ -625,7 +617,7 @@ public static class ModMinecraft
                         foreach (var patchNode in JsonObject["patches"].AsArray()) { var patch = patchNode.AsObject();
                             if ((patch["id"] ?? "").ToString() == "game" && patch["version"] is not null)
                             {
-                                _info.VanillaName = patch["version"].ToString();
+                                field.VanillaName = patch["version"].ToString();
                                 goto VersionSearchFinish;
                             } }
 
@@ -639,7 +631,7 @@ public static class ModMinecraft
                             {
                                 if (mark)
                                 {
-                                    _info.VanillaName = Argument.ToString();
+                                    field.VanillaName = Argument.ToString();
                                     goto VersionSearchFinish;
                                 }
 
@@ -654,7 +646,7 @@ public static class ModMinecraft
                                 var regexArgument = Argument.ToString().RegexSeek(RegexPatterns.LabyModVersion);
                                 if (regexArgument is not null)
                                 {
-                                    _info.VanillaName = regexArgument;
+                                    field.VanillaName = regexArgument;
                                     goto VersionSearchFinish;
                                 }
                             }
@@ -663,9 +655,9 @@ public static class ModMinecraft
                     // 从继承实例中获取版本号
                     if (!string.IsNullOrEmpty(InheritInstanceName))
                     {
-                        _info.VanillaName = (JsonObject["jar"] ?? "").ToString(); // LiteLoader 优先使用 Jar
-                        if (string.IsNullOrEmpty(_info.VanillaName))
-                            _info.VanillaName = InheritInstanceName;
+                        field.VanillaName = (JsonObject["jar"] ?? "").ToString(); // LiteLoader 优先使用 Jar
+                        if (string.IsNullOrEmpty(field.VanillaName))
+                            field.VanillaName = InheritInstanceName;
                         goto VersionSearchFinish;
                     }
 
@@ -674,7 +666,7 @@ public static class ModMinecraft
                         .RegexSeek(RegexPatterns.MinecraftDownloadUrlVersion);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
@@ -683,7 +675,7 @@ public static class ModMinecraft
                     regex = librariesString.RegexSeek(RegexPatterns.ForgeLibVersion);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
@@ -691,7 +683,7 @@ public static class ModMinecraft
                     regex = librariesString.RegexSeek(RegexPatterns.OptiFineLibVersion);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
@@ -699,14 +691,14 @@ public static class ModMinecraft
                     regex = librariesString.RegexSeek(RegexPatterns.FabricLikeLibVersion);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
                     // 从 jar 项中获取版本号
                     if (JsonObject["jar"] is not null)
                     {
-                        _info.VanillaName = JsonObject["jar"].ToString();
+                        field.VanillaName = JsonObject["jar"].ToString();
                         goto VersionSearchFinish;
                     }
 
@@ -716,7 +708,7 @@ public static class ModMinecraft
                         var jsonVerName = JsonVersion["name"].ToString();
                         if (jsonVerName.Length < 32) // 因为 wiki 说这玩意儿可能是个 hash，虽然我没发现
                         {
-                            _info.VanillaName = jsonVerName;
+                            field.VanillaName = jsonVerName;
                             ModBase.Log("[Minecraft] 从版本 jar 中的 version.json 获取到版本号：" + jsonVerName);
                             goto VersionSearchFinish;
                         }
@@ -727,18 +719,18 @@ public static class ModMinecraft
                         RegexOptions.IgnoreCase);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
                     // 非准确的版本判断警告
                     ModBase.Log("[Minecraft] 无法完全确认 MC 版本号的版本：" + Name);
-                    _info.Reliable = false;
+                    field.Reliable = false;
                     // 从文件夹名中获取
                     regex = Name.RegexSeek(RegexPatterns.MinecraftJsonVersion, RegexOptions.IgnoreCase);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
@@ -749,18 +741,18 @@ public static class ModMinecraft
                     regex = jsonRawText.RegexSeek(RegexPatterns.MinecraftJsonVersion, RegexOptions.IgnoreCase);
                     if (regex is not null)
                     {
-                        _info.VanillaName = regex;
+                        field.VanillaName = regex;
                         goto VersionSearchFinish;
                     }
 
                     // 无法获取
-                    _info.VanillaName = "Unknown";
+                    field.VanillaName = "Unknown";
                     Desc = Lang.Text("Select.Instance.Description.UnknownMcVersion");
                 }
                 catch (Exception ex)
                 {
                     ModBase.Log(ex, "识别 Minecraft 版本时出错");
-                    _info.VanillaName = "Unknown";
+                    field.VanillaName = "Unknown";
                     Desc = Lang.Text("Minecraft.Error.Unrecognizable", ex.Message);
                 }
 
@@ -768,34 +760,34 @@ public static class ModMinecraft
 
                 VersionSearchFinish: ;
 
-                if (_info.VanillaName.StartsWithF("20.") || _info.VanillaName.StartsWithF("21."))
+                if (field.VanillaName.StartsWithF("20.") || field.VanillaName.StartsWithF("21."))
                 {
-                    _info.VanillaName = "1." + _info.VanillaName;
+                    field.VanillaName = "1." + field.VanillaName;
                 }
                 
-                _info.VanillaName = _info.VanillaName.Replace("_unobfuscated", "").Replace(" Unobfuscated", "");
+                field.VanillaName = field.VanillaName.Replace("_unobfuscated", "").Replace(" Unobfuscated", "");
                 // 获取版本号
-                if (_info.VanillaName.StartsWithF("1."))
+                if (field.VanillaName.StartsWithF("1."))
                 {
-                    var segments = _info.VanillaName.Split(" _-.".ToCharArray());
-                    _info.vanilla = new Version((int)Math.Round(ModBase.Val(segments.Count() >= 2 ? segments[1] : "0")),
+                    var segments = field.VanillaName.Split(" _-.".ToCharArray());
+                    field.vanilla = new Version((int)Math.Round(ModBase.Val(segments.Count() >= 2 ? segments[1] : "0")),
                         0, (int)Math.Round(ModBase.Val(segments.Count() >= 3 ? segments[2] : "0")));
                 }
-                else if (_info.VanillaName.RegexCheck(@"^[2-9][0-9]\."))
+                else if (field.VanillaName.RegexCheck(@"^[2-9][0-9]\."))
                 {
-                    var segments = _info.VanillaName.Split(" _-.".ToCharArray());
-                    _info.vanilla = new Version((int)Math.Round(ModBase.Val(segments[0])),
+                    var segments = field.VanillaName.Split(" _-.".ToCharArray());
+                    field.vanilla = new Version((int)Math.Round(ModBase.Val(segments[0])),
                         (int)Math.Round(ModBase.Val(segments.Count() >= 2 ? segments[1] : "0")),
                         (int)Math.Round(ModBase.Val(segments.Count() >= 3 ? segments[2] : "0")));
                 }
                 else
                 {
-                    _info.vanilla = new Version(9999, 0, 0);
+                    field.vanilla = new Version(9999, 0, 0);
                 }
 
-                return _info;
+                return field;
             }
-            set { _info = value; }
+            set { field = value; }
         }
 
         /// <summary>
@@ -813,7 +805,7 @@ public static class ModMinecraft
                 }
 
                 ;
-                if (_jsonText is null)
+                if (field is null)
                 {
                     var jsonPath = PathInstance + Name + ".json";
                     if (!File.Exists(jsonPath))
@@ -832,30 +824,30 @@ public static class ModMinecraft
                         }
                     }
 
-                    _jsonText = ModBase.ReadFile(jsonPath);
+                    field = ModBase.ReadFile(jsonPath);
                     // 如果 ReadFile 失败会返回空字符串；这可能是由于文件被临时占用，故延时后重试
-                    if (!FastJsonCheck(_jsonText))
+                    if (!FastJsonCheck(field))
                     {
                         if (ModBase.RunInUi())
                         {
                             ModBase.Log($"[Minecraft] 实例 JSON 文件为空或有误，将进行短暂重试（{jsonPath}）", ModBase.LogLevel.Debug);
                             Thread.Sleep(200);
-                            _jsonText = ModBase.ReadFile(jsonPath);
+                            field = ModBase.ReadFile(jsonPath);
                         }
                         else
                         {
                             ModBase.Log($"[Minecraft] 实例 JSON 文件为空或有误，将在 2s 后重试读取（{jsonPath}）", ModBase.LogLevel.Debug);
                             Thread.Sleep(2000);
-                            _jsonText = ModBase.ReadFile(jsonPath);
+                            field = ModBase.ReadFile(jsonPath);
                         }
-                        if (!FastJsonCheck(_jsonText))
-                            ModBase.GetJson(_jsonText);
+                        if (!FastJsonCheck(field))
+                            ModBase.GetJson(field);
                     }
                 }
 
-                return _jsonText;
+                return field;
             }
-            set => _jsonText = value;
+            set => field = value;
         }
 
         /// <summary>
@@ -866,21 +858,21 @@ public static class ModMinecraft
         {
             get
             {
-                if (_jsonObject is null)
+                if (field is null)
                 {
                     var text = JsonText; // 触发 JsonText 的 Get 事件
                     try
                     {
-                        _jsonObject = (JsonObject)ModBase.GetJson(text);
+                        field = (JsonObject)ModBase.GetJson(text);
                         // 转换 HMCL 关键项
-                        if (_jsonObject.ContainsKey("patches") && !_jsonObject.ContainsKey("time"))
+                        if (field.ContainsKey("patches") && !field.ContainsKey("time"))
                         {
                             IsHmclFormatJson = true;
                             // 合并 JSON
                             // Dim HasOptiFine As Boolean = False, HasForge As Boolean = False
                             JsonObject currentObject = null;
                             var subjsonList = new List<JsonObject>();
-                            foreach (var SubjsonNode in _jsonObject["patches"].AsArray()) { var subjson = SubjsonNode.AsObject();
+                            foreach (var SubjsonNode in field["patches"].AsArray()) { var subjson = SubjsonNode.AsObject();
                                 subjsonList.Add(subjson); }
                             subjsonList.Sort((left, right) =>
                                 ModBase.Val((left["priority"] ?? "0").ToString()) <
@@ -903,11 +895,11 @@ public static class ModMinecraft
                                 }
                             }
 
-                            _jsonObject = currentObject;
+                            field = currentObject;
                             // 修改附加项
-                            _jsonObject["id"] = Name;
-                            if (_jsonObject.ContainsKey("inheritsFrom"))
-                                _jsonObject.Remove("inheritsFrom");
+                            field["id"] = Name;
+                            if (field.ContainsKey("inheritsFrom"))
+                                field.Remove("inheritsFrom");
                         }
 
                         // 与继承实例合并
@@ -916,9 +908,9 @@ public static class ModMinecraft
                         {
                             try
                             {
-                                inheritInstanceName = _jsonObject["inheritsFrom"] is null
+                                inheritInstanceName = field["inheritsFrom"] is null
                                     ? ""
-                                    : _jsonObject["inheritsFrom"].ToString();
+                                    : field["inheritsFrom"].ToString();
                                 if (Equals(inheritInstanceName, Name))
                                 {
                                     ModBase.Log("[Minecraft] 自引用的继承实例：" + Name, ModBase.LogLevel.Debug);
@@ -938,8 +930,8 @@ public static class ModMinecraft
                                             inheritInstanceName));
                                     inheritInstanceName = inheritInstance.InheritInstanceName;
                                     // 合并
-                                    inheritInstance.JsonObject.Merge(_jsonObject);
-                                    _jsonObject = inheritInstance.JsonObject;
+                                    inheritInstance.JsonObject.Merge(field);
+                                    field = inheritInstance.JsonObject;
                                     goto Recheck;
                                 }
                             }
@@ -955,9 +947,9 @@ public static class ModMinecraft
                     }
                 }
 
-                return _jsonObject;
+                return field;
             }
-            set => _jsonObject = value;
+            set => field = value;
         }
 
         /// <summary>
@@ -995,7 +987,7 @@ public static class ModMinecraft
                                 if (versionJson is not null)
                                     using (var versionJsonStream = new StreamReader(versionJson.Open()))
                                     {
-                                        _jsonVersion = (JsonObject)ModBase.GetJson(versionJsonStream.ReadToEnd());
+                                        field = (JsonObject)ModBase.GetJson(versionJsonStream.ReadToEnd());
                                     }
                             }
                         }
@@ -1006,7 +998,7 @@ public static class ModMinecraft
                     } while (false);
                 }
 
-                return _jsonVersion;
+                return field;
             }
         }
 
@@ -1017,22 +1009,22 @@ public static class ModMinecraft
         {
             get
             {
-                if (_inheritInstanceName is null)
+                if (field is null)
                 {
-                    _inheritInstanceName = (JsonObject["inheritsFrom"] ?? "").ToString();
+                    field = (JsonObject["inheritsFrom"] ?? "").ToString();
                     // 由于过老的 LiteLoader 中没有 Inherits（例如 1.5.2），需要手动判断以获取真实继承实例
                     // 此外，由于这里的加载早于实例种类判断，所以需要手动判断是否为 LiteLoader
                     // 如果实例提供了不同的 JAR，代表所需的 JAR 可能已被更改，则跳过 Inherit 替换
                     if (JsonText.Contains("liteloader") && (Info.VanillaName ?? "") != (Name ?? "") &&
                         !JsonText.Contains("logging"))
                         if (((JsonObject["jar"] ?? Info.VanillaName).ToString() ?? "") == (Info.VanillaName ?? ""))
-                            _inheritInstanceName = Info.VanillaName;
+                            field = Info.VanillaName;
                     // HMCL 实例无 JSON
                     if (IsHmclFormatJson)
-                        _inheritInstanceName = "";
+                        field = "";
                 }
 
-                return _inheritInstanceName;
+                return field;
             }
         }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
@@ -187,7 +187,6 @@ public static class ModWatcher
         private readonly bool realTime;
 
         private readonly object waitingLogLock = new();
-        private MinecraftState _State = MinecraftState.Loading;
         public uint countDebug;
         public uint countError;
         public uint countFatal;
@@ -304,15 +303,15 @@ public static class ModWatcher
 
         public MinecraftState State
         {
-            get => _State;
+            get => field;
             set
             {
-                if (_State == value)
+                if (field == value)
                     return;
-                _State = value;
+                field = value;
                 WatcherStateChanged();
             }
-        }
+        } = MinecraftState.Loading;
 
         /// <summary>
         ///     是否处理实时日志。

--- a/Plain Craft Launcher 2/Modules/ModVideoBack.cs
+++ b/Plain Craft Launcher 2/Modules/ModVideoBack.cs
@@ -2,18 +2,16 @@ namespace PCL;
 
 public static class ModVideoBack
 {
-    private static bool _isGaming;
-    private static bool _forcePlay;
     public static bool isMinimized = false; // 窗口是否被最小化
 
     public static bool IsGaming // 判断用户是否在游戏中
     {
-        get => _isGaming;
+        get => field;
         set
         {
-            if (_isGaming != value)
+            if (field != value)
             {
-                _isGaming = value;
+                field = value;
                 GamingStateChanged?.Invoke(null, new BooleanEventArgs(value));
             }
         }
@@ -21,12 +19,12 @@ public static class ModVideoBack
 
     public static bool ForcePlay // 判断是否强行播放
     {
-        get => _forcePlay;
+        get => field;
         set
         {
-            if (_forcePlay != value)
+            if (field != value)
             {
-                _forcePlay = value;
+                field = value;
                 ForcePlayChanged?.Invoke(null, new BooleanEventArgs(value));
             }
         }

--- a/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Management/NetManager.cs
@@ -17,19 +17,18 @@ public sealed class NetManager
                 return Files.Values.Count(file => file.State != NetState.Finished);
         }
     }
-    private long _downloadDone;
     public object LockDone { get; } = new();
     public long DownloadDone
     {
         get
         {
             lock (LockDone)
-                return _downloadDone;
+                return field;
         }
         set
         {
             lock (LockDone)
-                _downloadDone = value;
+                field = value;
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
@@ -182,21 +182,19 @@ public partial class PageComp
     /// </summary>
     public ModComp.CompType PageType
     {
-        get => _Type;
+        get => field;
         set
         {
-            if (_Type == value)
+            if (field == value)
                 return;
-            _Type = value;
+            field = value;
             BtnSearchInstallModPack.Visibility =
                 value == ModComp.CompType.ModPack ? Visibility.Visible : Visibility.Collapsed;
             loader.name = Lang.Text("Download.Comp.List.Source.ResourceFetch", TypeName);
             PanSearchBox.HintText = ModComp.GetCompSearchName(value);
             Load.Text = ModComp.GetCompLoadingName(value);
         }
-    }
-
-    private ModComp.CompType _Type = (ModComp.CompType)(-1);
+    } = (ModComp.CompType)(-1);
 
     #endregion
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/MyLocalModItem.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/MyLocalModItem.xaml.cs
@@ -430,11 +430,9 @@ public partial class MyLocalCompItem
     }
 
     // 标题
-    private string _Title;
-
     public string Title
     {
-        get => _Title;
+        get => field;
         set
         {
             var rawValue = value;
@@ -461,7 +459,7 @@ public partial class MyLocalCompItem
             if ((LabTitle.Text ?? "") == (value ?? ""))
                 return;
             LabTitle.Text = value;
-            _Title = rawValue;
+            field = rawValue;
         }
     }
 
@@ -594,16 +592,15 @@ public partial class MyLocalCompItem
     // 滑动选中
     public class SwipeSelect
     {
-        private bool _Swiping;
         public int Start { get; set; }
         public int End { get; set; }
 
         public bool Swiping
         {
-            get => _Swiping;
+            get => field;
             set
             {
-                _Swiping = value;
+                field = value;
                 if (TargetFrm is not null)
                     try
                     {
@@ -672,27 +669,25 @@ public partial class MyLocalCompItem
 
     public delegate void ChangedEventHandler(object sender, ModBase.RouteEventArgs e);
 
-    private bool _Checked;
-
     public bool Checked
     {
-        get => _Checked;
+        get => field;
         set
         {
             try
             {
                 // 触发属性值修改
-                var rawValue = _Checked;
-                if (value == _Checked)
+                var rawValue = field;
+                if (value == field)
                     return;
-                _Checked = value;
+                field = value;
                 var ChangedEventArgs = new ModBase.RouteEventArgs();
                 if (IsInitialized)
                 {
                     Changed?.Invoke(this, ChangedEventArgs);
                     if (ChangedEventArgs.handled)
                     {
-                        _Checked = rawValue;
+                        field = rawValue;
                         return;
                     }
                 }
@@ -780,13 +775,11 @@ public partial class MyLocalCompItem
     private Image imgState;
 
     // 指向背景
-    private Border _RectBack;
-
     public Border RectBack
     {
         get
         {
-            if (_RectBack is null)
+            if (field is null)
             {
                 var rect = new Border
                 {
@@ -804,27 +797,25 @@ public partial class MyLocalCompItem
                 SetColumnSpan(rect, 999);
                 SetRowSpan(rect, 999);
                 Children.Insert(0, rect);
-                _RectBack = rect;
+                field = rect;
                 // <!--<corelocal:BlurBorder x:Name = "RectBack" CornerRadius="3" RenderTransformOrigin="0.5,0.5" SnapsToDevicePixels="True" 
                 // IsHitTestVisible = "False" Opacity="0" BorderThickness="1" 
                 // Grid.ColumnSpan = "4" Background="{DynamicResource ColorBrush7}" BorderBrush="{DynamicResource ColorBrush6}"/>-->
             }
 
-            return _RectBack;
+            return field;
         }
     }
 
     // 按钮
     public Action<MyLocalCompItem, EventArgs> buttonHandler;
     public FrameworkElement buttonStack;
-    private IEnumerable<MyIconButton> _Buttons;
-
     public IEnumerable<MyIconButton> Buttons
     {
-        get => _Buttons;
+        get => field;
         set
         {
-            _Buttons = value;
+            field = value;
             // 移除原 Stack
             if (buttonStack is not null)
             {
@@ -862,15 +853,13 @@ public partial class MyLocalCompItem
     }
 
     // 勾选条
-    private Border _RectCheck;
-
     public Border RectCheck
     {
         get
         {
-            if (_RectCheck is null)
+            if (field is null)
             {
-                _RectCheck = new Border
+                field = new Border
                 {
                     Width = 5d,
                     Height = Checked ? double.NaN : 0d,
@@ -881,12 +870,12 @@ public partial class MyLocalCompItem
                     SnapsToDevicePixels = false,
                     Margin = Checked ? new Thickness(-3, 6d, 0d, 6d) : new Thickness(-3, 0d, 0d, 0d)
                 };
-                _RectCheck.SetResourceReference(Border.BackgroundProperty, "ColorBrush3");
-                SetRowSpan(_RectCheck, 10);
-                Children.Add(_RectCheck);
+                field.SetResourceReference(Border.BackgroundProperty, "ColorBrush3");
+                SetRowSpan(field, 10);
+                Children.Add(field);
             }
 
-            return _RectCheck;
+            return field;
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -1480,16 +1480,14 @@ public partial class PageInstanceCompResource : IRefreshable
 
     #region 筛选
 
-    private FilterType _Filter = FilterType.All;
-
     public FilterType Filter
     {
-        get => _Filter;
+        get => field;
         set
         {
-            if (_Filter == value)
+            if (field == value)
                 return;
-            _Filter = value;
+            field = value;
             switch (value)
             {
                 case FilterType.All:
@@ -1527,7 +1525,7 @@ public partial class PageInstanceCompResource : IRefreshable
 
             RefreshUI();
         }
-    }
+    } = FilterType.All;
 
     public enum FilterType
     {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -386,10 +386,10 @@ public partial class PageInstanceExport : IRefreshable
     /// </summary>
     private List<string> RulesOverrides
     {
-        get => _RulesOverrides;
+        get => field;
         set
         {
-            _RulesOverrides = value;
+            field = value;
             if (value is null)
             {
                 BtnOverrideCancel.Visibility = Visibility.Collapsed;
@@ -407,8 +407,6 @@ public partial class PageInstanceExport : IRefreshable
             }
         }
     }
-
-    private List<string> _RulesOverrides;
 
     /// <summary>
     ///     获取当前实际生效的所有规则。

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -776,16 +776,14 @@ public partial class PageInstanceSavesDatapack : IRefreshable
 
     #region 筛选
 
-    private FilterType _Filter = FilterType.All;
-
     public FilterType Filter
     {
-        get => _Filter;
+        get => field;
         set
         {
-            if (_Filter == value)
+            if (field == value)
                 return;
-            _Filter = value;
+            field = value;
             switch (value)
             {
                 case FilterType.All:
@@ -818,7 +816,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
 
             RefreshUI();
         }
-    }
+    } = FilterType.All;
 
     public enum FilterType
     {

--- a/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
@@ -16,7 +16,6 @@ public partial class MySkin
     public delegate void ClickEventHandler(object sender, MouseButtonEventArgs e);
 
     // 皮肤储存
-    private string _Address;
     private bool isChanging;
 
     // 点击
@@ -39,11 +38,11 @@ public partial class MySkin
 
     public string Address
     {
-        get => _Address;
+        get => field;
         set
         {
-            _Address = value;
-            ToolTip = string.IsNullOrEmpty(_Address)
+            field = value;
+            ToolTip = string.IsNullOrEmpty(field)
                 ? Lang.Text("Common.State.Loading")
                 : Lang.Text("Launch.Skin.Change.ToolTip");
         }

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
@@ -729,17 +729,15 @@ public partial class PageSetupUI
 
     #region 功能隐藏
 
-    private static bool _HiddenForceShow;
-
     /// <summary>
     ///     是否强制显示被禁用的功能。
     /// </summary>
     public static bool HiddenForceShow
     {
-        get => _HiddenForceShow;
+        get => field;
         set
         {
-            _HiddenForceShow = value;
+            field = value;
             HiddenRefresh();
         }
     }

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsGameLink.xaml.cs
@@ -982,20 +982,18 @@ public partial class PageToolsGameLink
         PanFinish
     }
 
-    private Subpages _CurrentSubpage = States.Link.LinkEula ? Subpages.PanSelect : Subpages.PanEula;
-
     public Subpages CurrentSubpage
     {
-        get => _CurrentSubpage;
+        get => field;
         set
         {
-            if (_CurrentSubpage == value)
+            if (field == value)
                 return;
-            _CurrentSubpage = value;
+            field = value;
             ModBase.Log("[Link] 子页面更改为 " + ModBase.GetStringFromEnum(value));
             PageOnContentExit();
         }
-    }
+    } = States.Link.LinkEula ? Subpages.PanSelect : Subpages.PanEula;
 
     private void PageLinkLobby_OnPageEnter()
     {


### PR DESCRIPTION
> *依旧 XX……哦不对这次是 XL*

本 PR 使用最新的 `field` 的语法替代了一些 backing field

## Summary by Sourcery

在多个属性中用较新的 `field` 语法替换显式的后备字段，以简化属性定义，并与更新后的语言特性保持一致。

增强内容：
- 重构 Minecraft 模块、UI 控件和页面中的大量属性，将手动声明的字段替换为使用隐式 `field` 后备字段语法。
- 使用新语法，直接在自动属性上为某些属性设置默认值（例如状态、缩放值、枚举、集合等）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace explicit backing fields with the newer `field` syntax across multiple properties to simplify property definitions and align with updated language features.

Enhancements:
- Refactor numerous properties in Minecraft modules, UI controls, and pages to use the implicit `field` backing syntax instead of manually declared fields.
- Initialize certain properties with default values directly on the auto-property using the new syntax (e.g., states, scales, enums, collections).

</details>