### PR TITLE
fix(net): 由于未正确处理 `HttpContent` 导致的请求失败

### DIFF
--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -108,9 +108,16 @@ public static class Requester
                     request.Headers.TryAddWithoutValidation(header.Key, header.Value);
             if (SupportBody(request.Method) && param.Content is not null)
             {
-                var content = param.Content is string text ? text : param.Content.ToString() ?? "";
-                request.Content = new StringContent(content, param.Encoding ?? Encoding.UTF8,
-                    param.ContentType ?? "application/json");
+                if (param.Content is HttpContent httpContent)
+                {
+                    request.Content = httpContent;
+                }
+                else
+                {
+                    var content = param.Content is string text ? text : param.Content.ToString() ?? "";
+                    request.Content = new StringContent(content, param.Encoding ?? Encoding.UTF8,
+                        param.ContentType ?? "application/json");
+                }
             }
 
             using var cts = new CancellationTokenSource();

--- a/Plain Craft Launcher 2/Modules/Network/Models/FetchParam.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Models/FetchParam.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Text;
 
 namespace PCL.Network;
@@ -5,6 +6,10 @@ namespace PCL.Network;
 public struct FetchParam
 {
     public string Method { get; set; }
+    
+    /// <summary>
+    /// 请求体内容。支持 <see cref="string"/>（自动包装为 StringContent）和 <see cref="HttpContent"/>（直接使用）。
+    /// </summary>
     public object? Content { get; set; }
     public string? ContentType { get; set; }
     public Dictionary<string, string>? Headers { get; set; }


### PR DESCRIPTION
## Summary by Sourcery

在构建 HTTP 请求时正确处理 `HttpContent`，以防止请求失败。

Bug 修复：
- 确保类型为 `HttpContent` 的 `FetchParam.Content` 能被直接传入 `HttpRequestMessage`，而不是总是被包装为 `StringContent`。

增强：
- 记录 `FetchParam.Content` 支持的类型，澄清对字符串和 `HttpContent` 请求体的处理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HttpContent correctly when building HTTP requests to prevent request failures.

Bug Fixes:
- Ensure FetchParam.Content of type HttpContent is passed directly to HttpRequestMessage instead of always being wrapped as StringContent.

Enhancements:
- Document supported types for FetchParam.Content, clarifying behavior for string and HttpContent bodies.

</details>