### PR TITLE
refactor(instance-save-info): 重构 `PageInstanceSavesInfo`

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2416,6 +2416,11 @@
     <sys:String x:Key="Instance.Saves.Info.Modify.BeforeSave">Make sure the save is not open in-game before modifying settings</sys:String>
     <sys:String x:Key="Instance.Saves.Info.Modify.CheatSuccess">Cheat settings modified successfully</sys:String>
     <sys:String x:Key="Instance.Saves.Info.Modify.DifficultySuccess">Difficulty modified successfully</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Modify.CheatFailed">Failed to modify cheat settings</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Modify.DifficultyFailed">Failed to modify difficulty settings</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.LoadFailed">Failed to get save info</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.ClipboardFailed">Failed to copy to clipboard</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.ChunkbaseFailed">Failed to open Chunkbase</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_9">Unable to get save version for versions below 1.9</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_8">Unable to get save version and difficulty for versions below 1.8</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_3">Unable to get save version, difficulty, and cheat settings for versions below 1.3</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2416,6 +2416,11 @@
     <sys:String x:Key="Instance.Saves.Info.Modify.BeforeSave">修改设置前请确保该存档未在游戏中打开，否则会导致设置无效</sys:String>
     <sys:String x:Key="Instance.Saves.Info.Modify.CheatSuccess">作弊设置修改成功</sys:String>
     <sys:String x:Key="Instance.Saves.Info.Modify.DifficultySuccess">难度设置修改成功</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Modify.CheatFailed">作弊设置修改失败</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Modify.DifficultyFailed">难度设置修改失败</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.LoadFailed">获取存档信息失败</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.ClipboardFailed">复制到剪贴板失败</sys:String>
+    <sys:String x:Key="Instance.Saves.Info.Error.ChunkbaseFailed">跳转到 Chunkbase 失败</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_9">1.9 以下的版本无法获取存档版本</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_8">1.8 以下的版本无法获取存档版本和游戏难度</sys:String>
     <sys:String x:Key="Instance.Saves.Info.VersionHint.1_3">1.3 以下的版本无法获取存档版本、游戏难度和是否允许作弊</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -768,7 +768,7 @@ public partial class PageInstanceOverall
                                             ".jar");
                     core.AddToCore(userInput);
                     ModMain.Hint(Lang.Text("Instance.Overall.Patch.Success"), ModMain.HintType.Finish);
-                    Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.instance] = true;
+                    Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.instance.PathInstance] = true;
                 });
                 break;
             }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -768,7 +768,7 @@ public partial class PageInstanceOverall
                                             ".jar");
                     core.AddToCore(userInput);
                     ModMain.Hint(Lang.Text("Instance.Overall.Patch.Success"), ModMain.HintType.Finish);
-                    Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.instance.PathInstance] = true;
+                    Config.Instance.DisableAssetVerifyV2[PageInstanceLeft.instance] = true;
                 });
                 break;
             }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -187,15 +187,6 @@ public partial class PageInstanceSavesInfo : IRefreshable
         _ => Lang.Text("Instance.Saves.Info.GameMode.Survival"),
     };
 
-    private static string DifficultyName(Difficulty diff) => diff switch
-    {
-        Difficulty.Peaceful => Lang.Text("Instance.Saves.Info.Difficulty.Peaceful"),
-        Difficulty.Easy => Lang.Text("Instance.Saves.Info.Difficulty.Easy"),
-        Difficulty.Normal => Lang.Text("Instance.Saves.Info.Difficulty.Normal"),
-        Difficulty.Hard => Lang.Text("Instance.Saves.Info.Difficulty.Hard"),
-        _ => Lang.Text("Instance.Saves.Info.GetFailed"),
-    };
-
     private static void ShowHint(MyHint hint, string langKey)
     {
         hint.Text = Lang.Text(langKey);

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -10,6 +10,7 @@ namespace PCL;
 
 public partial class PageInstanceSavesInfo : IRefreshable
 {
+    /// <summary>无状态服务，线程安全，所有实例可共享。</summary>
     private static readonly SaveManager SaveManager = new();
     private CancellationTokenSource? _cts;
 
@@ -29,6 +30,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
     private async Task RefreshInfoAsync()
     {
         _cts?.Cancel();
+        _cts?.Dispose();
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
 
@@ -78,10 +80,10 @@ public partial class PageInstanceSavesInfo : IRefreshable
                 Lang.TimeSpan(save.PlayTime, 3, false, TimeUnit.Day, TimeUnit.Second));
 
             if (save.VersionName is not null || save.Difficulty.HasValue)
-                BuildAllowCommandsSetting(save.AllowCommands, ct);
+                BuildAllowCommandsSetting(save.AllowCommands);
 
             if (save.Difficulty.HasValue)
-                BuildDifficultySetting(save.IsHardcore, save.IsDifficultyLocked, (int)save.Difficulty.Value, ct);
+                BuildDifficultySetting(save.IsHardcore, save.IsDifficultyLocked, (int)save.Difficulty.Value);
 
             PanContent.Visibility = Visibility.Visible;
         }
@@ -91,13 +93,15 @@ public partial class PageInstanceSavesInfo : IRefreshable
             ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Error.LoadFailed"), ModBase.LogLevel.Msgbox);
             PanContent.Visibility = Visibility.Collapsed;
             PanSettings.Visibility = Visibility.Collapsed;
+            PanSettingsList.Children.Clear();
+            PanSettingsList.RowDefinitions.Clear();
             Hintversion1_9.Visibility = Visibility.Collapsed;
             Hintversion1_8.Visibility = Visibility.Collapsed;
             Hintversion1_3.Visibility = Visibility.Collapsed;
         }
     }
 
-    private void BuildAllowCommandsSetting(bool allowCommands, CancellationToken ct)
+    private void BuildAllowCommandsSetting(bool allowCommands)
     {
         PanSettings.Visibility = Visibility.Visible;
         var folder = PageInstanceSavesLeft.currentSave;
@@ -120,7 +124,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
                 await SaveManager.ApplyChangesAsync(folder, new SaveChanges
                 {
                     AllowCommands = new Editable<bool>((int)combo.SelectedValue == 1),
-                }, ct);
+                });
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.CheatSuccess"), ModMain.HintType.Finish);
             }
             catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.CheatFailed"), ModBase.LogLevel.Hint); }
@@ -129,7 +133,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
         AddSettingRow(Lang.Text("Instance.Saves.Info.AllowCommands"), combo);
     }
 
-    private void BuildDifficultySetting(bool isHardcore, bool isLocked, int difficultyValue, CancellationToken ct)
+    private void BuildDifficultySetting(bool isHardcore, bool isLocked, int difficultyValue)
     {
         PanSettings.Visibility = Visibility.Visible;
         var folder = PageInstanceSavesLeft.currentSave;
@@ -168,7 +172,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
                 {
                     Difficulty = new Editable<Difficulty>((Difficulty)(int)combo.SelectedValue),
                     LockDifficulty = new Editable<bool>(!isHardcore && lockCheckBox.Checked == true),
-                }, ct);
+                });
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
             }
             catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.DifficultyFailed"), ModBase.LogLevel.Hint); }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -1,480 +1,205 @@
-using System.Diagnostics.Eventing.Reader;
-using System.IO;
 using System.Windows;
 using System.Windows.Controls;
-using fNbt;
 using Humanizer;
 using PCL.Core.App.Localization;
+using PCL.Core.Minecraft.Saves;
+using PCL.Core.Minecraft.Saves.Editing;
 using PCL.Core.UI;
 
 namespace PCL;
 
 public partial class PageInstanceSavesInfo : IRefreshable
 {
-    private bool _loaded;
+    private static readonly SaveManager SaveManager = new();
+    private CancellationTokenSource? _cts;
 
     public PageInstanceSavesInfo()
     {
         InitializeComponent();
-        Loaded += (_, _) => Init();
+        Loaded += async (_, _) =>
+        {
+            PanBack.ScrollToHome();
+            await RefreshInfoAsync();
+        };
     }
 
-    void IRefreshable.Refresh()
+    void IRefreshable.Refresh() => Refresh();
+    public void Refresh() => _ = RefreshInfoAsync();
+
+    private async Task RefreshInfoAsync()
     {
-        IRefreshable_Refresh();
-    }
+        _cts?.Cancel();
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
 
-    private void IRefreshable_Refresh()
-    {
-        Refresh();
-    }
-
-    public void Refresh()
-    {
-        RefreshInfo();
-    }
-
-    private void Init()
-    {
-        PanBack.ScrollToHome();
-
-        RefreshInfo();
-
-        _loaded = true;
-        if (_loaded)
-            return;
-    }
-
-    private void RefreshInfo()
-    {
         try
         {
-            var saveDatPath = Path.Combine(PageInstanceSavesLeft.currentSave, "level.dat");
-            using (var fs = new FileStream(saveDatPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            ClearInfoTable();
+            PanSettingsList.Children.Clear();
+            PanSettingsList.RowDefinitions.Clear();
+            foreach (var h in new[] { Hintversion1_9, Hintversion1_8, Hintversion1_3 })
+                h.Visibility = Visibility.Collapsed;
+            PanSettings.Visibility = Visibility.Collapsed;
+
+            var save = await SaveManager.LoadSaveAsync(PageInstanceSavesLeft.currentSave, ct);
+
+            ModMain.frmInstanceSavesLeft.ItemDatapack.Visibility =
+                save.VersionId is null or < DataVersionBoundaries._17w47a ? Visibility.Collapsed : Visibility.Visible;
+
+            if (save.VersionName is null)
             {
-                var saveInfo = new NbtFile();
-                saveInfo.LoadFromStream(fs, NbtCompression.AutoDetect);
-                ClearInfoTable();
-                PanSettingsList.Children.Clear();
-                PanSettingsList.RowDefinitions.Clear();
-
-                Hintversion1_9.Visibility = Visibility.Collapsed;
-                Hintversion1_8.Visibility = Visibility.Collapsed;
-                Hintversion1_3.Visibility = Visibility.Collapsed;
-                PanSettings.Visibility = Visibility.Collapsed;
-
-                var gameLevel = saveInfo.RootTag.Get<NbtCompound>("Data");
-                AddInfoTable(Lang.Text("Instance.Saves.Info.LevelName"), gameLevel.Get<NbtString>("LevelName").Value);
-                NbtString versionName = null;
-                NbtInt versionId = null;
-                var gameVersion = gameLevel.Get<NbtCompound>("Version");
-                if (gameVersion is not null)
-                {
-                    gameVersion.TryGet("Name", out versionName);
-                    gameVersion.TryGet("Id", out versionId);
-                }
-
-                var currentVersionId = versionId?.Value ?? default(int?);
-                ModMain.frmInstanceSavesLeft.ItemDatapack.Visibility =
-                    !currentVersionId.HasValue || currentVersionId < 1444 ? Visibility.Collapsed : Visibility.Visible;
-
-                var hasDifficulty = gameLevel.Contains("Difficulty") || gameLevel.Contains("difficulty_settings");
-                var hasAllowCommands = gameLevel.Contains("allowCommands");
-
-                if (versionName is null)
-                {
-                    if (hasDifficulty)
-                    {
-                        Hintversion1_9.Visibility = Visibility.Visible;
-                        Hintversion1_9.Text = Lang.Text("Instance.Saves.Info.VersionHint.1_9");
-                    }
-                    else if (hasAllowCommands)
-                    {
-                        Hintversion1_8.Visibility = Visibility.Visible;
-                        Hintversion1_8.Text = Lang.Text("Instance.Saves.Info.VersionHint.1_8");
-                    }
-                    else
-                    {
-                        Hintversion1_3.Visibility = Visibility.Visible;
-                        Hintversion1_3.Text = Lang.Text("Instance.Saves.Info.VersionHint.1_3");
-                    }
-                }
+                if (save.Difficulty.HasValue)
+                    ShowHint(Hintversion1_9, "Instance.Saves.Info.VersionHint.1_9");
+                else if (save.AllowCommands)
+                    ShowHint(Hintversion1_8, "Instance.Saves.Info.VersionHint.1_8");
                 else
-                {
-                    AddInfoTable(Lang.Text("Instance.Saves.Info.Version"), $"{versionName.Value} ({versionId.Value})");
-                }
-
-                NbtLong seedNbt = null;
-                string seed;
-                if (gameLevel.TryGet("RandomSeed", out seedNbt))
-                    seed = seedNbt.Value.ToString();
-                else
-                {
-                    if (gameLevel.Contains("WorldGenSettings"))
-                    {
-                        seed = gameLevel.Get<NbtCompound>("WorldGenSettings").Get<NbtLong>("seed").Value.ToString();
-                    }
-                    else
-                    {
-                        string worldGenSettingsDatPath = System.IO.Path.Combine(PageInstanceSavesLeft.currentSave, "data", "minecraft", "world_gen_settings.dat");
-                        NbtFile worldGenSettingsNbt = new NbtFile(worldGenSettingsDatPath);
-                        var worldGenSettings = worldGenSettingsNbt.RootTag.Get<NbtCompound>("data");
-                        seed = worldGenSettings.Get<NbtLong>("seed").Value.ToString();
-                    }
-                }
-
-                AddInfoTable(Lang.Text("Instance.Saves.Info.Seed"), seed, true, versionName?.Value, true);
-
-                if (hasAllowCommands)
-                {
-                    PanSettings.Visibility = Visibility.Visible;
-                    var allowCommandValue = int.Parse(gameLevel.Get<NbtByte>("allowCommands").Value.ToString());
-                    var combo = new MyComboBox
-                    {
-                        Width = 100d, HorizontalAlignment = HorizontalAlignment.Left,
-                        ToolTip = Lang.Text("Instance.Saves.Info.Modify.BeforeSave")
-                    };
-                    combo.Items.Add(new { Value = 0, Display = Lang.Text("Instance.Saves.Info.AllowCommands.NotAllowed") });
-                    combo.Items.Add(new { Value = 1, Display = Lang.Text("Instance.Saves.Info.AllowCommands.Allowed") });
-                    combo.SelectedValuePath = "Value";
-                    combo.DisplayMemberPath = "Display";
-                    combo.SelectedValue = allowCommandValue;
-
-                    combo.SelectionChanged += (s, e) =>
-                    {
-                        try
-                        {
-                            var newVal = (byte)combo.SelectedValue;
-                            gameLevel.Get<NbtByte>("allowCommands").Value = (byte)newVal;
-                            using (var fileStream = new FileStream(saveDatPath, FileMode.Create, FileAccess.Write,
-                                       FileShare.None))
-                            {
-                                saveInfo.SaveToStream(fileStream, NbtCompression.GZip);
-                            }
-
-                            ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.CheatSuccess"), ModMain.HintType.Finish);
-                        }
-                        catch (Exception ex)
-                        {
-                            ModBase.Log(ex, "作弊设置修改失败", ModBase.LogLevel.Hint);
-                        }
-                    };
-                    var rowIndex = PanSettingsList.RowDefinitions.Count;
-                    PanSettingsList.RowDefinitions.Add(new RowDefinition
-                        { Height = new GridLength(1d, GridUnitType.Auto) });
-
-                    var headTextBlock = new TextBlock { Text = Lang.Text("Instance.Saves.Info.AllowCommands"), Margin = new Thickness(0d, 3d, 0d, 3d) };
-                    Grid.SetRow(headTextBlock, rowIndex);
-                    Grid.SetColumn(headTextBlock, 0);
-
-                    Grid.SetRow(combo, rowIndex);
-                    Grid.SetColumn(combo, 2);
-
-                    PanSettingsList.Children.Add(headTextBlock);
-                    PanSettingsList.Children.Add(combo);
-                    PanSettingsList.RowDefinitions.Add(new RowDefinition
-                        { Height = new GridLength(8d, GridUnitType.Pixel) });
-                }
-
-                if (hasDifficulty)
-                {
-                    PanSettings.Visibility = Visibility.Visible;
-                    NbtByte difficultyElement;
-
-                    if (gameLevel.Contains("difficulty_settings"))
-                    {
-                        var difficultyElementString = gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtString>("difficulty").Value;
-                        byte value = difficultyElementString switch
-                        {
-                            "peaceful" => 0,
-                            "easy" => 1,
-                            "normal" => 2,
-                            "hard" => 3,
-                            _ => 0
-                        };
-                        difficultyElement = new NbtByte("Difficulty", value);
-                    }
-                    else
-                    {
-                        difficultyElement = gameLevel.Get<NbtByte>("Difficulty");
-                    }
-
-                    var difficultyValue = difficultyElement.Value;
-
-                    var difficultyCombo = new MyComboBox
-                    {
-                        Width = 100d, HorizontalAlignment = HorizontalAlignment.Left,
-                        ToolTip = Lang.Text("Instance.Saves.Info.Modify.BeforeSave")
-                    };
-                    difficultyCombo.Items.Add(new { Value = 0, Display = Lang.Text("Instance.Saves.Info.Difficulty.Peaceful") });
-                    difficultyCombo.Items.Add(new { Value = 1, Display = Lang.Text("Instance.Saves.Info.Difficulty.Easy") });
-                    difficultyCombo.Items.Add(new { Value = 2, Display = Lang.Text("Instance.Saves.Info.Difficulty.Normal") });
-                    difficultyCombo.Items.Add(new { Value = 3, Display = Lang.Text("Instance.Saves.Info.Difficulty.Hard") });
-                    difficultyCombo.SelectedValuePath = "Value";
-                    difficultyCombo.DisplayMemberPath = "Display";
-                    difficultyCombo.SelectedValue = difficultyValue;
-
-                    NbtByte isHardcoreCheck = null;
-
-                    if (gameLevel.Contains("difficulty_settings"))
-                        isHardcoreCheck = gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtByte>("hardcore");
-                    else
-                        isHardcoreCheck = gameLevel.Get<NbtByte>("hardcore");
-                        
-                    var isHardcoreMode = isHardcoreCheck.Value == 1;
-
-                    var lockCheckBox = new MyCheckBox
-                    {
-                        Text = Lang.Text("Instance.Saves.Info.LockDifficulty"), ToolTip = Lang.Text("Instance.Saves.Info.LockDifficulty.ToolTip"),
-                        VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10d, 0d, 0d, 0d)
-                    };
-
-                    if (isHardcoreMode)
-                    {
-                        lockCheckBox.Visibility = Visibility.Collapsed;
-                    }
-                    else
-                    {
-                        NbtByte lockedElement;
-
-                        if (gameLevel.Contains("difficulty_settings"))
-                            lockedElement = gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtByte>("locked");
-                        else
-                            lockedElement = gameLevel.Get<NbtByte>("DifficultyLocked");
-                        
-                        var isLocked = lockedElement is not null && lockedElement.Value == 1;
-                        lockCheckBox.Checked = isLocked;
-                    }
-
-                    var difficultyPanel = new StackPanel
-                    {
-                        Orientation = Orientation.Horizontal,
-                        HorizontalAlignment = HorizontalAlignment.Left
-                    };
-                    difficultyPanel.Children.Add(difficultyCombo);
-                    difficultyPanel.Children.Add(lockCheckBox);
-
-
-                    difficultyCombo.SelectionChanged += (s, e) =>
-                    {
-                        try
-                        {
-                            if (difficultyCombo.SelectedValue is null) return;
-                            var newDifficulty = (byte)difficultyCombo.SelectedValue;
-                            if (gameLevel.Contains("difficulty_settings"))
-                            {
-                                var newDifficultyString = GetDifficultyName(newDifficulty);
-                                gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtString>("difficulty").Value = newDifficultyString;
-                            }
-                            else
-                            {
-                                gameLevel.Get<NbtByte>("Difficulty").Value = (byte)newDifficulty;
-                            }
-                            
-                            if (!isHardcoreMode)
-                            {
-                                var newLocked = lockCheckBox.Checked == true ? 1 : 0;
-                                if (gameLevel.Contains("DifficultyLocked"))
-                                    gameLevel.Get<NbtByte>("DifficultyLocked").Value = (byte)newLocked;
-                                else if (newLocked == 1)
-                                    gameLevel.Add(new NbtByte("DifficultyLocked", (byte)newLocked));
-                            }
-
-                            using (var fileStream = new FileStream(saveDatPath, FileMode.Create, FileAccess.Write,
-                                       FileShare.None))
-                            {
-                                saveInfo.SaveToStream(fileStream, NbtCompression.GZip);
-                            }
-
-                            ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
-                        }
-                        catch (Exception ex)
-                        {
-                            ModBase.Log(ex, "难度设置修改失败", ModBase.LogLevel.Hint);
-                        }
-                    };
-
-
-                    lockCheckBox.Change += (sender, user) =>
-                    {
-                        try
-                        {
-                            if (difficultyCombo.SelectedValue is null) return;
-                            var newDifficulty = (byte)difficultyCombo.SelectedValue;
-                            if (gameLevel.Contains("difficulty_settings"))
-                            {
-                                var newDifficultyString = GetDifficultyName(newDifficulty);
-                                gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtString>("difficulty").Value = newDifficultyString;
-                            }
-                            else
-                            {
-                                gameLevel.Get<NbtByte>("Difficulty").Value = (byte)newDifficulty;
-                            }
-                            
-                            if (!isHardcoreMode)
-                            {
-                                var newLocked = lockCheckBox.Checked == true ? 1 : 0;
-                                if (gameLevel.Contains("difficulty_settings"))
-                                    gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtByte>("locked").Value = (byte)newLocked;
-                                else if (gameLevel.Contains("DifficultyLocked"))
-                                    gameLevel.Get<NbtByte>("DifficultyLocked").Value = (byte)newLocked;
-                                else if (newLocked == 1)
-                                    if (gameLevel.Contains("difficulty_settings"))
-                                        gameLevel.Get<NbtCompound>("difficulty_settings").Add(new NbtByte("locked", (byte)newLocked));
-                                    else
-                                        gameLevel.Add(new NbtByte("DifficultyLocked", (byte)newLocked));
-                            }
-
-                            using (var fileStream = new FileStream(saveDatPath, FileMode.Create, FileAccess.Write,
-                                       FileShare.None))
-                            {
-                                saveInfo.SaveToStream(fileStream, NbtCompression.GZip);
-                            }
-
-                            ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
-                        }
-                        catch (Exception ex)
-                        {
-                            ModBase.Log(ex, "难度设置修改失败", ModBase.LogLevel.Hint);
-                        }
-                    };
-
-                    var rowIndex = PanSettingsList.RowDefinitions.Count;
-                    PanSettingsList.RowDefinitions.Add(new RowDefinition
-                        { Height = new GridLength(1d, GridUnitType.Auto) });
-
-                    var headTextBlock = new TextBlock { Text = Lang.Text("Instance.Saves.Info.GameDifficultyLabel"), Margin = new Thickness(0d, 3d, 0d, 3d) };
-                    Grid.SetRow(headTextBlock, rowIndex);
-                    Grid.SetColumn(headTextBlock, 0);
-
-                    Grid.SetRow(difficultyPanel, rowIndex);
-                    Grid.SetColumn(difficultyPanel, 2);
-
-                    PanSettingsList.Children.Add(headTextBlock);
-                    PanSettingsList.Children.Add(difficultyPanel);
-                }
-
-                var lastPlayed = new DateTime(1970, 1, 1, 0, 0, 0)
-                    .AddMilliseconds(long.Parse(gameLevel.Get<NbtLong>("LastPlayed").Value.ToString()))
-                    .ToLocalTime();
-                AddInfoTable(Lang.Text("Instance.Saves.Info.LastPlayed"), Lang.Date(lastPlayed, "g"));
-
-                NbtInt spawnX = null;
-                if (gameLevel.TryGet("SpawnX", out spawnX))
-                {
-                    var spawnY = gameLevel.Get<NbtInt>("SpawnY");
-                    var spawnZ = gameLevel.Get<NbtInt>("SpawnZ");
-                    AddInfoTable(Lang.Text("Instance.Saves.Info.SpawnPoint"), $"{spawnX.Value} / {spawnY.Value} / {spawnZ.Value}");
-                }
-                else
-                {
-                    var spawnPos = gameLevel.Get<NbtCompound>("spawn").Get<NbtIntArray>("pos");
-                    var spawnXPos = spawnPos[0];
-                    var spawnYPos = spawnPos[1];
-                    var spawnZPos = spawnPos[2];
-                    AddInfoTable(Lang.Text("Instance.Saves.Info.SpawnPoint"), $"{spawnXPos} / {spawnYPos} / {spawnZPos}");
-                }
-
-                var gameTypeName = Lang.Text("Instance.Saves.Info.GetFailed");
-
-                NbtByte isHardcore = null;
-
-                if (gameLevel.Contains("difficulty_settings"))
-                {
-                    isHardcore = gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtByte>("hardcore");
-                }
-                else
-                {
-                    isHardcore = gameLevel.Get<NbtByte>("hardcore");
-                }
-
-                if (isHardcore.Value == 1)
-                {
-                    gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Hardcore");
-                }
-                else
-                {
-                    var gameType = gameLevel.Get<NbtInt>("GameType");
-                    switch (gameType.Value)
-                    {
-                        case 0:
-                        {
-                            gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Survival");
-                            break;
-                        }
-                        case 1:
-                        {
-                            gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Creative");
-                            break;
-                        }
-                        case 2:
-                        {
-                            gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Adventure");
-                            break;
-                        }
-                        case 3:
-                        {
-                            gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Spectator");
-                            break;
-                        }
-
-                        default:
-                        {
-                            gameTypeName = Lang.Text("Instance.Saves.Info.GameMode.Survival");
-                            break;
-                        }
-                    }
-                }
-
-                AddInfoTable(Lang.Text("Instance.Saves.Info.GameMode"), gameTypeName);
-
-                if (hasDifficulty)
-                {
-                    string difficultyRaw = gameLevel.Contains("difficulty_settings")
-                        ? gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtString>("difficulty").Value
-                        : gameLevel.Get<NbtByte>("Difficulty").Value.ToString();
-
-                    string difficultyName = difficultyRaw switch
-                    {
-                        "0" or "peaceful" => Lang.Text("Instance.Saves.Info.Difficulty.Peaceful"),
-                        "1" or "easy" => Lang.Text("Instance.Saves.Info.Difficulty.Easy"),
-                        "2" or "normal" => Lang.Text("Instance.Saves.Info.Difficulty.Normal"),
-                        "3" or "hard" => Lang.Text("Instance.Saves.Info.Difficulty.Hard"),
-                        _ => Lang.Text("Instance.Saves.Info.GetFailed")
-                    };
-
-                    NbtByte lockedElement = gameLevel.Contains("difficulty_settings")
-                        ? gameLevel.Get<NbtCompound>("difficulty_settings").Get<NbtByte>("locked")
-                        : gameLevel.Get<NbtByte>("DifficultyLocked");
-                    var isDifficultyLocked =
-                        (lockedElement is not null && lockedElement.Value == 1) ||
-                        isHardcore.Value == 1 ? Lang.Text("Common.Option.Yes") :
-                        lockedElement is not null ? Lang.Text("Common.Option.No") : Lang.Text("Instance.Saves.Info.GetFailed");
-                    if (Hintversion1_8.Visibility != Visibility.Visible)
-                        AddInfoTable(Lang.Text("Instance.Saves.Info.Hardness"), $"{difficultyName}  |  {Lang.Text("Instance.Saves.Info.DifficultyLocked", isDifficultyLocked)}");
-                }
-
-                var totalTicks = long.Parse(gameLevel.Get<NbtLong>("Time").Value.ToString());
-                var formattedPlayTime = Lang.TimeSpan(
-                    TimeSpan.FromSeconds(totalTicks / 20.0d),
-                    precision: 3,
-                    addAffixes: false,
-                    maxUnit: TimeUnit.Day,
-                    minUnit: TimeUnit.Second);
-
-                AddInfoTable(Lang.Text("Instance.Saves.Info.PlayTime"), formattedPlayTime);
-                PanContent.Visibility = Visibility.Visible;
+                    ShowHint(Hintversion1_3, "Instance.Saves.Info.VersionHint.1_3");
             }
+            else
+                AddInfoRow(Lang.Text("Instance.Saves.Info.Version"), $"{save.VersionName} ({save.VersionId})");
+
+            AddInfoRow(Lang.Text("Instance.Saves.Info.LevelName"), save.LevelName);
+            AddInfoRow(Lang.Text("Instance.Saves.Info.Seed"),
+                save.Seed?.ToString() ?? Lang.Text("Instance.Saves.Info.GetFailed"),
+                isSeed: true, versionName: save.VersionName);
+            AddInfoRow(Lang.Text("Instance.Saves.Info.LastPlayed"),
+                Lang.Date(save.LastPlayedUtc.ToLocalTime(), "g"));
+
+            if (save.Spawn.HasValue)
+            {
+                var s = save.Spawn.Value;
+                AddInfoRow(Lang.Text("Instance.Saves.Info.SpawnPoint"), $"{s.X:F0} / {s.Y:F0} / {s.Z:F0}");
+            }
+
+            AddInfoRow(Lang.Text("Instance.Saves.Info.GameMode"), GameModeName(save.GameMode));
+
+            AddInfoRow(Lang.Text("Instance.Saves.Info.PlayTime"),
+                Lang.TimeSpan(save.PlayTime, 3, false, TimeUnit.Day, TimeUnit.Second));
+
+            if (save.VersionName is not null || save.Difficulty.HasValue)
+                BuildAllowCommandsSetting(save.AllowCommands, ct);
+
+            if (save.Difficulty.HasValue)
+                BuildDifficultySetting(save.IsHardcore, save.IsDifficultyLocked, (int)save.Difficulty.Value, ct);
+
+            PanContent.Visibility = Visibility.Visible;
         }
+        catch (OperationCanceledException) { }
         catch (Exception ex)
         {
             ModBase.Log(ex, "获取存档信息失败", ModBase.LogLevel.Msgbox);
             PanContent.Visibility = Visibility.Collapsed;
             PanSettings.Visibility = Visibility.Collapsed;
-            Hintversion1_9.Visibility = Visibility.Collapsed;
-            Hintversion1_8.Visibility = Visibility.Collapsed;
-            Hintversion1_3.Visibility = Visibility.Collapsed;
+            foreach (var h in new[] { Hintversion1_9, Hintversion1_8, Hintversion1_3 })
+                h.Visibility = Visibility.Collapsed;
         }
+    }
+
+    private void BuildAllowCommandsSetting(bool allowCommands, CancellationToken ct)
+    {
+        PanSettings.Visibility = Visibility.Visible;
+        var folder = PageInstanceSavesLeft.currentSave;
+
+        var combo = new MyComboBox
+        {
+            Width = 100d, HorizontalAlignment = HorizontalAlignment.Left,
+            ToolTip = Lang.Text("Instance.Saves.Info.Modify.BeforeSave"),
+            SelectedValuePath = "Value", DisplayMemberPath = "Display",
+        };
+        combo.Items.Add(new { Value = 0, Display = Lang.Text("Instance.Saves.Info.AllowCommands.NotAllowed") });
+        combo.Items.Add(new { Value = 1, Display = Lang.Text("Instance.Saves.Info.AllowCommands.Allowed") });
+        combo.SelectedValue = allowCommands ? 1 : 0;
+
+        combo.SelectionChanged += async (_, _) =>
+        {
+            try
+            {
+                if (combo.SelectedValue is null) return;
+                await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                {
+                    AllowCommands = new Editable<bool>((int)combo.SelectedValue == 1),
+                }, ct);
+                ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.CheatSuccess"), ModMain.HintType.Finish);
+            }
+            catch (Exception ex) { ModBase.Log(ex, "作弊设置修改失败", ModBase.LogLevel.Hint); }
+        };
+
+        AddSettingRow(Lang.Text("Instance.Saves.Info.AllowCommands"), combo);
+    }
+
+    private void BuildDifficultySetting(bool isHardcore, bool isLocked, int difficultyValue, CancellationToken ct)
+    {
+        PanSettings.Visibility = Visibility.Visible;
+        var folder = PageInstanceSavesLeft.currentSave;
+
+        var combo = new MyComboBox
+        {
+            Width = 100d, HorizontalAlignment = HorizontalAlignment.Left,
+            ToolTip = Lang.Text("Instance.Saves.Info.Modify.BeforeSave"),
+            SelectedValuePath = "Value", DisplayMemberPath = "Display",
+        };
+        combo.Items.Add(new { Value = 0, Display = Lang.Text("Instance.Saves.Info.Difficulty.Peaceful") });
+        combo.Items.Add(new { Value = 1, Display = Lang.Text("Instance.Saves.Info.Difficulty.Easy") });
+        combo.Items.Add(new { Value = 2, Display = Lang.Text("Instance.Saves.Info.Difficulty.Normal") });
+        combo.Items.Add(new { Value = 3, Display = Lang.Text("Instance.Saves.Info.Difficulty.Hard") });
+        combo.SelectedValue = difficultyValue;
+
+        var lockCheckBox = new MyCheckBox
+        {
+            Text = Lang.Text("Instance.Saves.Info.LockDifficulty"),
+            ToolTip = Lang.Text("Instance.Saves.Info.LockDifficulty.ToolTip"),
+            VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10d, 0d, 0d, 0d),
+            Checked = isLocked,
+            Visibility = isHardcore ? Visibility.Collapsed : Visibility.Visible,
+        };
+
+        var panel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Left };
+        panel.Children.Add(combo);
+        panel.Children.Add(lockCheckBox);
+
+        async Task ApplyAsync()
+        {
+            try
+            {
+                if (combo.SelectedValue is null) return;
+                await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                {
+                    Difficulty = new Editable<Difficulty>((Difficulty)(int)combo.SelectedValue),
+                    LockDifficulty = new Editable<bool>(!isHardcore && lockCheckBox.Checked == true),
+                }, ct);
+                ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
+            }
+            catch (Exception ex) { ModBase.Log(ex, "难度设置修改失败", ModBase.LogLevel.Hint); }
+        }
+
+        combo.SelectionChanged += async (_, _) => await ApplyAsync();
+        lockCheckBox.Change += async (_, _) => await ApplyAsync();
+
+        AddSettingRow(Lang.Text("Instance.Saves.Info.GameDifficultyLabel"), panel);
+    }
+
+    private static string GameModeName(GameMode mode) => mode switch
+    {
+        GameMode.Hardcore => Lang.Text("Instance.Saves.Info.GameMode.Hardcore"),
+        GameMode.Creative => Lang.Text("Instance.Saves.Info.GameMode.Creative"),
+        GameMode.Adventure => Lang.Text("Instance.Saves.Info.GameMode.Adventure"),
+        GameMode.Spectator => Lang.Text("Instance.Saves.Info.GameMode.Spectator"),
+        _ => Lang.Text("Instance.Saves.Info.GameMode.Survival"),
+    };
+
+    private static string DifficultyName(Difficulty diff) => diff switch
+    {
+        Difficulty.Peaceful => Lang.Text("Instance.Saves.Info.Difficulty.Peaceful"),
+        Difficulty.Easy => Lang.Text("Instance.Saves.Info.Difficulty.Easy"),
+        Difficulty.Normal => Lang.Text("Instance.Saves.Info.Difficulty.Normal"),
+        Difficulty.Hard => Lang.Text("Instance.Saves.Info.Difficulty.Hard"),
+        _ => Lang.Text("Instance.Saves.Info.GetFailed"),
+    };
+
+    private static void ShowHint(MyHint hint, string langKey)
+    {
+        hint.Text = Lang.Text(langKey);
+        hint.Visibility = Visibility.Visible;
     }
 
     private void ClearInfoTable()
@@ -483,104 +208,88 @@ public partial class PageInstanceSavesInfo : IRefreshable
         PanList.RowDefinitions.Clear();
     }
 
-    private void AddInfoTable(string head, string content, bool isSeed = false, string versionName = null,
-        bool allowCopy = false)
+    private void AddInfoRow(string head, string content, bool isSeed = false, string? versionName = null)
     {
-        var headTextBlock = new TextBlock { Text = head, Margin = new Thickness(0d, 3d, 0d, 3d) };
+        var headBlock = new TextBlock { Text = head, Margin = new Thickness(0d, 3d, 0d, 3d) };
         var contentStack = new StackPanel { Orientation = Orientation.Horizontal };
-        UIElement contentTextBlock;
-        if (allowCopy)
-        {
-            var thisBtn = new MyTextButton { Text = content, Margin = new Thickness(0d, 3d, 0d, 3d) };
-            contentTextBlock = thisBtn;
-            thisBtn.Click += (_, _) =>
-            {
-                try
-                {
-                    ModBase.ClipboardSet(content);
-                }
-                catch (Exception ex)
-                {
-                    ModBase.Log(ex, "复制到剪贴板失败", ModBase.LogLevel.Hint);
-                }
-            };
-        }
-        else
-        {
-            contentTextBlock = new TextBlock { Text = content, Margin = new Thickness(0d, 3d, 0d, 3d) };
-        }
-
-        contentStack.Children.Add(contentTextBlock);
 
         if (isSeed && content != Lang.Text("Instance.Saves.Info.GetFailed"))
         {
-            var btnChunkbase = new MyIconButton
+            var seedBtn = new MyTextButton { Text = content, Margin = new Thickness(0d, 3d, 0d, 3d) };
+            seedBtn.Click += (_, _) =>
             {
-                Logo = Icon.IconButtonlink,
+                try { ModBase.ClipboardSet(content); }
+                catch (Exception ex) { ModBase.Log(ex, "复制到剪贴板失败", ModBase.LogLevel.Hint); }
+            };
+            contentStack.Children.Add(seedBtn);
+
+            var chunkbaseBtn = new MyIconButton
+            {
+                Logo = Icon.IconButtonlink, Width = 22d, Height = 22d,
                 ToolTip = Lang.Text("Instance.Saves.Info.Chunkbase.ToolTip"),
-                Width = 22d,
-                Height = 22d
             };
-            contentStack.Children.Add(btnChunkbase);
-
-
-            btnChunkbase.Click += (_, _) =>
-            {
-                try
-                {
-                    if (versionName is null)
-                    {
-                        ModBase.Log(Lang.Text("Instance.Saves.Info.Chunkbase.UnknownVersion"), ModBase.LogLevel.Hint);
-                        return;
-                    }
-
-                    if (versionName.Any(c => char.IsLetter(c)))
-                    {
-                        ModBase.Log(Lang.Text("Instance.Saves.Info.Chunkbase.PreviewVersion", versionName), ModBase.LogLevel.Hint);
-                        return;
-                    }
-
-                    var versionParts = versionName.Split('.');
-                    string usedVersion;
-                    if (versionName.StartsWith("1.21"))
-                        usedVersion = versionName.Replace(".", "_");
-                    else if (versionName.Contains("."))
-                        usedVersion = string.Join("_", versionName.Split('.').Take(2));
-                    else
-                        usedVersion = versionName.Replace(".", "_");
-                    var cbUri =
-                        $"https://www.chunkbase.com/apps/seed-map#seed={content}&platform=java_{usedVersion}&dimension=overworld";
-                    ModBase.OpenWebsite(cbUri);
-                }
-                catch (Exception ex)
-                {
-                    ModBase.Log(ex, "跳转到 Chunkbase 失败", ModBase.LogLevel.Hint);
-                }
-            };
+            chunkbaseBtn.Click += (_, _) => OpenChunkbase(content, versionName);
+            contentStack.Children.Add(chunkbaseBtn);
+        }
+        else
+        {
+            contentStack.Children.Add(new TextBlock { Text = content, Margin = new Thickness(0d, 3d, 0d, 3d) });
         }
 
-        PanList.Children.Add(headTextBlock);
+        PanList.Children.Add(headBlock);
         PanList.Children.Add(contentStack);
-        var targetRow = new RowDefinition();
-        PanList.RowDefinitions.Add(targetRow);
-        var rowIndex = PanList.RowDefinitions.IndexOf(targetRow);
-        Grid.SetRow(headTextBlock, rowIndex);
-        Grid.SetColumn(headTextBlock, 0);
-        Grid.SetRow(contentTextBlock, rowIndex);
-        Grid.SetColumn(contentTextBlock, 2);
+        var rowDef = new RowDefinition();
+        PanList.RowDefinitions.Add(rowDef);
+        var rowIndex = PanList.RowDefinitions.IndexOf(rowDef);
+        Grid.SetRow(headBlock, rowIndex);
+        Grid.SetColumn(headBlock, 0);
         Grid.SetRow(contentStack, rowIndex);
         Grid.SetColumn(contentStack, 2);
     }
-    
-    public string GetDifficultyName(int newDifficulty)
+
+    private void AddSettingRow(string head, UIElement control)
     {
-        return newDifficulty switch
+        var rowIndex = PanSettingsList.RowDefinitions.Count;
+        PanSettingsList.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1d, GridUnitType.Auto) });
+
+        var headBlock = new TextBlock { Text = head, Margin = new Thickness(0d, 3d, 0d, 3d) };
+        Grid.SetRow(headBlock, rowIndex);
+        Grid.SetColumn(headBlock, 0);
+        Grid.SetRow(control, rowIndex);
+        Grid.SetColumn(control, 2);
+        PanSettingsList.Children.Add(headBlock);
+        PanSettingsList.Children.Add(control);
+        PanSettingsList.RowDefinitions.Add(new RowDefinition { Height = new GridLength(8d, GridUnitType.Pixel) });
+    }
+
+    private static void OpenChunkbase(string seed, string? versionName)
+    {
+        try
         {
-            0 => "peaceful",
-            1 => "easy",
-            2 => "normal",
-            3 => "hard",
-            _ => throw new ArgumentOutOfRangeException(nameof(newDifficulty), "Invalid difficulty value")
-        };
+            if (versionName is null)
+            {
+                ModBase.Log(Lang.Text("Instance.Saves.Info.Chunkbase.UnknownVersion"), ModBase.LogLevel.Hint);
+                return;
+            }
+
+            if (versionName.Any(char.IsLetter))
+            {
+                ModBase.Log(Lang.Text("Instance.Saves.Info.Chunkbase.PreviewVersion", versionName),
+                    ModBase.LogLevel.Hint);
+                return;
+            }
+
+            var usedVersion = versionName.StartsWith("1.21")
+                ? versionName.Replace(".", "_")
+                : versionName.Contains('.')
+                    ? string.Join("_", versionName.Split('.').Take(2))
+                    : versionName.Replace(".", "_");
+            ModBase.OpenWebsite(
+                $"https://www.chunkbase.com/apps/seed-map#seed={seed}&platform=java_{usedVersion}&dimension=overworld");
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "跳转到 Chunkbase 失败", ModBase.LogLevel.Hint);
+        }
     }
 }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -37,8 +37,9 @@ public partial class PageInstanceSavesInfo : IRefreshable
             ClearInfoTable();
             PanSettingsList.Children.Clear();
             PanSettingsList.RowDefinitions.Clear();
-            foreach (var h in new[] { Hintversion1_9, Hintversion1_8, Hintversion1_3 })
-                h.Visibility = Visibility.Collapsed;
+            Hintversion1_9.Visibility = Visibility.Collapsed;
+            Hintversion1_8.Visibility = Visibility.Collapsed;
+            Hintversion1_3.Visibility = Visibility.Collapsed;
             PanSettings.Visibility = Visibility.Collapsed;
 
             var save = await SaveManager.LoadSaveAsync(PageInstanceSavesLeft.currentSave, ct);
@@ -90,8 +91,9 @@ public partial class PageInstanceSavesInfo : IRefreshable
             ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Error.LoadFailed"), ModBase.LogLevel.Msgbox);
             PanContent.Visibility = Visibility.Collapsed;
             PanSettings.Visibility = Visibility.Collapsed;
-            foreach (var h in new[] { Hintversion1_9, Hintversion1_8, Hintversion1_3 })
-                h.Visibility = Visibility.Collapsed;
+            Hintversion1_9.Visibility = Visibility.Collapsed;
+            Hintversion1_8.Visibility = Visibility.Collapsed;
+            Hintversion1_3.Visibility = Visibility.Collapsed;
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -87,7 +87,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
         catch (OperationCanceledException) { }
         catch (Exception ex)
         {
-            ModBase.Log(ex, "获取存档信息失败", ModBase.LogLevel.Msgbox);
+            ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Error.LoadFailed"), ModBase.LogLevel.Msgbox);
             PanContent.Visibility = Visibility.Collapsed;
             PanSettings.Visibility = Visibility.Collapsed;
             foreach (var h in new[] { Hintversion1_9, Hintversion1_8, Hintversion1_3 })
@@ -121,7 +121,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
                 }, ct);
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.CheatSuccess"), ModMain.HintType.Finish);
             }
-            catch (Exception ex) { ModBase.Log(ex, "作弊设置修改失败", ModBase.LogLevel.Hint); }
+            catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.CheatFailed"), ModBase.LogLevel.Hint); }
         };
 
         AddSettingRow(Lang.Text("Instance.Saves.Info.AllowCommands"), combo);
@@ -169,7 +169,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
                 }, ct);
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
             }
-            catch (Exception ex) { ModBase.Log(ex, "难度设置修改失败", ModBase.LogLevel.Hint); }
+            catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.DifficultyFailed"), ModBase.LogLevel.Hint); }
         }
 
         combo.SelectionChanged += async (_, _) => await ApplyAsync();
@@ -219,7 +219,7 @@ public partial class PageInstanceSavesInfo : IRefreshable
             seedBtn.Click += (_, _) =>
             {
                 try { ModBase.ClipboardSet(content); }
-                catch (Exception ex) { ModBase.Log(ex, "复制到剪贴板失败", ModBase.LogLevel.Hint); }
+                catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Error.ClipboardFailed"), ModBase.LogLevel.Hint); }
             };
             contentStack.Children.Add(seedBtn);
 
@@ -287,9 +287,6 @@ public partial class PageInstanceSavesInfo : IRefreshable
             ModBase.OpenWebsite(
                 $"https://www.chunkbase.com/apps/seed-map#seed={seed}&platform=java_{usedVersion}&dimension=overworld");
         }
-        catch (Exception ex)
-        {
-            ModBase.Log(ex, "跳转到 Chunkbase 失败", ModBase.LogLevel.Hint);
-        }
+        catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Error.ChunkbaseFailed"), ModBase.LogLevel.Hint); }
     }
 }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesInfo.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Humanizer;
 using PCL.Core.App.Localization;
+using PCL.Core.Logging;
 using PCL.Core.Minecraft.Saves;
 using PCL.Core.Minecraft.Saves.Editing;
 using PCL.Core.UI;
@@ -12,6 +13,10 @@ public partial class PageInstanceSavesInfo : IRefreshable
 {
     /// <summary>无状态服务，线程安全，所有实例可共享。</summary>
     private static readonly SaveManager SaveManager = new();
+
+    /// <summary>防并发冲突</summary>
+    private static readonly SemaphoreSlim WriteLock = new(1, 1);
+
     private CancellationTokenSource? _cts;
 
     public PageInstanceSavesInfo()
@@ -25,7 +30,9 @@ public partial class PageInstanceSavesInfo : IRefreshable
     }
 
     void IRefreshable.Refresh() => Refresh();
-    public void Refresh() => _ = RefreshInfoAsync();
+    public void Refresh() => RefreshInfoAsync().ContinueWith(
+        t => LogWrapper.Warn(t.Exception, "Saves", "刷新存档信息异常"), //only 兜底
+        CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
 
     private async Task RefreshInfoAsync()
     {
@@ -121,10 +128,15 @@ public partial class PageInstanceSavesInfo : IRefreshable
             try
             {
                 if (combo.SelectedValue is null) return;
-                await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                await WriteLock.WaitAsync();
+                try
                 {
-                    AllowCommands = new Editable<bool>((int)combo.SelectedValue == 1),
-                });
+                    await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                    {
+                        AllowCommands = new Editable<bool>((int)combo.SelectedValue == 1),
+                    });
+                }
+                finally { WriteLock.Release(); }
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.CheatSuccess"), ModMain.HintType.Finish);
             }
             catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.CheatFailed"), ModBase.LogLevel.Hint); }
@@ -168,11 +180,16 @@ public partial class PageInstanceSavesInfo : IRefreshable
             try
             {
                 if (combo.SelectedValue is null) return;
-                await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                await WriteLock.WaitAsync();
+                try
                 {
-                    Difficulty = new Editable<Difficulty>((Difficulty)(int)combo.SelectedValue),
-                    LockDifficulty = new Editable<bool>(!isHardcore && lockCheckBox.Checked == true),
-                });
+                    await SaveManager.ApplyChangesAsync(folder, new SaveChanges
+                    {
+                        Difficulty = new Editable<Difficulty>((Difficulty)(int)combo.SelectedValue),
+                        LockDifficulty = new Editable<bool>(!isHardcore && lockCheckBox.Checked == true),
+                    });
+                }
+                finally { WriteLock.Release(); }
                 ModMain.Hint(Lang.Text("Instance.Saves.Info.Modify.DifficultySuccess"), ModMain.HintType.Finish);
             }
             catch (Exception ex) { ModBase.Log(ex, Lang.Text("Instance.Saves.Info.Modify.DifficultyFailed"), ModBase.LogLevel.Hint); }


### PR DESCRIPTION
改用新的存档信息读取器取代原来那坨屎
> Partially generated by deepseek-v4-pro

## Summary by Sourcery

重构实例存档信息页面，以使用新的 Minecraft 存档管理抽象和异步加载机制，同时保持现有功能不变。

增强内容：
- 将实例存档信息页面中对 NBT 和文件的直接操作，替换为集中化的 `SaveManager` 和 `SaveChanges` API。
- 将存档信息加载和 UI 更新转换为与页面生命周期绑定的、可取消的异步工作流。
- 简化并整合用于构建保存元数据、难度与允许指令设置以及 Chunkbase 种子集成的 UI，将其封装为可复用的辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the instance save info page to use the new Minecraft save management abstractions and asynchronous loading while preserving existing functionality.

Enhancements:
- Replace direct NBT and file handling in the instance save info page with the centralized SaveManager and SaveChanges APIs.
- Convert save info loading and UI updates to an asynchronous, cancelable workflow tied to the page lifecycle.
- Simplify and consolidate UI construction for save metadata, difficulty and allow-commands settings, and Chunkbase seed integration into reusable helper methods.

</details>