### PR TITLE
fix(instance): 修复重命名实例后 jar/natives/json 未同步重命名

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceOverall.xaml.cs
@@ -341,38 +341,39 @@ public partial class PageInstanceOverall
             ModBase.IniClearCache(Path.Combine(PageInstanceLeft.instance.PathIndie, "options.txt"));
             // 重命名 Jar 文件与 natives 文件夹
             // 不能进行遍历重命名，否则在实例名很短的时候容易误伤其他文件（Meloong-Git/#6443）
-            if (Directory.Exists($"{newPath}{oldName}-natives"))
+            if (Directory.Exists(Path.Combine(newPath, $"{oldName}-natives")))
             {
                 if (isCaseChangedOnly)
                 {
-                    FileSystem.RenameDirectory($"{newPath}{oldName}-natives", $"{oldName}natives_temp");
-                    FileSystem.RenameDirectory($"{newPath}{oldName}-natives_temp", $"{newName}-natives");
+                    FileSystem.RenameDirectory(Path.Combine(newPath, $"{oldName}-natives"), $"{oldName}natives_temp");
+                    FileSystem.RenameDirectory(Path.Combine(newPath, $"{oldName}-natives_temp"), $"{newName}-natives");
                 }
                 else
                 {
-                    ModBase.DeleteDirectory($"{newPath}{newName}-natives");
-                    FileSystem.RenameDirectory($"{newPath}{oldName}-natives", $"{newName}-natives");
+                    ModBase.DeleteDirectory(Path.Combine(newPath, $"{newName}-natives"));
+                    FileSystem.RenameDirectory(Path.Combine(newPath, $"{oldName}-natives"), $"{newName}-natives");
                 }
             }
 
-            if (File.Exists($"{newPath}{oldName}.jar"))
+            if (File.Exists(Path.Combine(newPath, $"{oldName}.jar")))
             {
                 if (isCaseChangedOnly)
                 {
-                    FileSystem.RenameFile($"{newPath}{oldName}.jar", $"{oldName}_temp.jar");
-                    FileSystem.RenameFile($"{newPath}{oldName}_temp.jar", $"{newName}.jar");
+                    FileSystem.RenameFile(Path.Combine(newPath, $"{oldName}.jar"), $"{oldName}_temp.jar");
+                    FileSystem.RenameFile(Path.Combine(newPath, $"{oldName}_temp.jar"), $"{newName}.jar");
                 }
                 else
                 {
-                    File.Delete($"{newPath}{newName}.jar");
-                    FileSystem.RenameFile($"{newPath}{oldName}.jar", $"{newName}.jar");
+                    File.Delete(Path.Combine(newPath, $"{newName}.jar"));
+                    FileSystem.RenameFile(Path.Combine(newPath, $"{oldName}.jar"), $"{newName}.jar");
                 }
             }
 
             // 替换实例设置文件中的路径
-            if (File.Exists(newPath + @"PCL\Setup.ini"))
-                ModBase.WriteFile(newPath + @"PCL\Setup.ini",
-                    ModBase.ReadFile(newPath + @"PCL\Setup.ini").Replace(oldPath, newPath));
+            var setupIniPath = Path.Combine(newPath, "PCL", "Setup.ini");
+            if (File.Exists(setupIniPath))
+                ModBase.WriteFile(setupIniPath,
+                    ModBase.ReadFile(setupIniPath).Replace(oldPath, newPath + @"\"));
             // 更改已选中的实例
             if ((ModBase.ReadIni(ModMinecraft.mcFolderSelected + "PCL.ini", "Version") ?? "") == (oldName ?? ""))
                 ModBase.WriteIni(ModMinecraft.mcFolderSelected + "PCL.ini", "Version", newName);
@@ -380,7 +381,7 @@ public partial class PageInstanceOverall
             try
             {
                 jsonObject["id"] = newName;
-                ModBase.WriteFile(newPath + newName + ".json", jsonObject.ToString());
+                ModBase.WriteFile(Path.Combine(newPath, $"{newName}.json"), jsonObject.ToString());
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Close #3020

#2818 将重命名实例时的 `newPath` 改为 `Path.Combine` 后不再以分隔符结尾，下游按尾随分隔符假设拼接的路径全部失效并被静默跳过，导致改名后夹内文件保留旧名、实例 Json 校验失败。

- jar、natives、实例 Json 与 `Setup.ini` 的路径统一改用 `Path.Combine` 构建，行为恢复至 #2818 之前
- `Setup.ini` 内容替换时为新路径补回尾随 `\`，与 `PathInstance` 的存储格式对齐

## Summary by Sourcery

确保在实例重命名时，通过一致的路径处理方式，使相关文件和配置保持同步。

Bug 修复：
- 修复当实例路径不再以目录分隔符结尾时，jar、natives 目录和实例 JSON 未被重命名的问题。
- 修复 Setup.ini 路径替换问题，通过恢复末尾反斜杠，使其与存储的 PathInstance 格式对齐。

增强功能：
- 在实例重命名过程中，使用 `Path.Combine` 标准化文件和目录路径的构建方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure instance rename keeps associated files and config in sync using consistent path handling.

Bug Fixes:
- Fix jar, natives directory, and instance JSON not being renamed when an instance path no longer ended with a directory separator.
- Fix Setup.ini path replacement to align with the stored PathInstance format by restoring a trailing backslash.

Enhancements:
- Standardize construction of file and directory paths during instance rename using Path.Combine.

</details>