### PR TITLE
refactor(identity): clarify IdentityModel exceptions

### DIFF
--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Minecraft.IdentityModel;
 using PCL.Core.Minecraft.IdentityModel.Extensions.Pkce;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 using PCL.Core.Utils.Exts;
@@ -16,17 +17,14 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// </summary>
     /// <param name="token"></param>
     /// <param name="checkAddress"></param>
-    /// <exception cref="InvalidOperationException">当要求检查地址并不存在任何授权端点时，将触发此错误</exception>
+    /// <exception cref="IdentityModelConfigurationException">当要求检查地址并不存在任何授权端点时，将触发此错误</exception>
     public async Task InitializeAsync(CancellationToken token,bool checkAddress = false)
     {
         var opt = await options.BuildOAuthOptionsAsync(token);
-        if (!checkAddress || opt.Meta.AuthorizeEndpoint.IsNullOrEmpty() || opt.Meta.DeviceEndpoint.IsNullOrEmpty())
-        {
-            _client = options.EnablePkceSupport ? new PkceClient(opt) : new SimpleOAuthClient(opt);
-            return;
-        }
+        if (checkAddress && opt.Meta.AuthorizeEndpoint.IsNullOrEmpty() && opt.Meta.DeviceEndpoint.IsNullOrEmpty())
+            throw new IdentityModelConfigurationException("OpenID 元数据缺少授权代码流端点和设备代码流端点");
 
-        throw new InvalidOperationException();
+        _client = options.EnablePkceSupport ? new PkceClient(opt) : new SimpleOAuthClient(opt);
     }
     /// <summary>
     /// 获取授权代码流地址
@@ -35,10 +33,10 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <param name="state"></param>
     /// <param name="extData">扩展数据</param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 </exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public string GetAuthorizeUrl(string[] scopes, string state,Dictionary<string,string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 OpenID 客户端");
         return _client.GetAuthorizeUrl(scopes, state, extData);
     }
     /// <summary>
@@ -48,10 +46,10 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithCodeAsync(string code, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 OpenID 客户端");
         return await _client.AuthorizeWithCodeAsync(code, token, extData);
     }
     /// <summary>
@@ -61,10 +59,10 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<DeviceCodeData?> GetCodePairAsync(string[] scopes, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 OpenID 客户端");
         return await _client.GetCodePairAsync(scopes, token, extData);
     }
     /// <summary>
@@ -74,10 +72,10 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithDeviceAsync(DeviceCodeData data, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 OpenID 客户端");
         return await _client.AuthorizeWithDeviceAsync(data, token, extData);
     }
     /// <summary>
@@ -87,10 +85,10 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithSilentAsync(AuthorizeResult data, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 OpenID 客户端");
         return await _client.AuthorizeWithSilentAsync(data, token, extData);
     }
 }

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
 using PCL.Core.Minecraft.IdentityModel.Extensions.JsonWebToken;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
+using PCL.Core.Minecraft.IdentityModel;
 using PCL.Core.IO.Net.Http;
 
 namespace PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
@@ -25,9 +26,9 @@ public record OpenIdOptions
         get;
         set;
     }
-    
+
     // 为了让 YggdrasilConnect Client 复用代码做的逻辑
-    
+
     /// <summary>
     /// 是否只使用设备代码流授权
     /// </summary>
@@ -52,7 +53,7 @@ public record OpenIdOptions
     /// OpenId 元数据，请勿自行设置此属性，而是应该调用 <see cref="InitializeAsync"/>
     /// </summary>
     public OpenIdMetadata? Meta { get; internal set; }
-    
+
     /// <summary>
     /// 从互联网拉取 OpenID 配置信息
     /// </summary>
@@ -75,11 +76,10 @@ public record OpenIdOptions
     /// <param name="kid">密钥 ID</param>
     /// <param name="token"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
-    /// <exception cref="FormatException">找不到 Jwk 或 Jwk 配置无效</exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/>，或找不到匹配的 Jwk</exception>
     public async Task<JsonWebKey> GetSignatureKeyAsync(string kid,CancellationToken token)
     {
-        if (Meta?.JwksUri is null) throw new InvalidOperationException();
+        if (Meta?.JwksUri is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 加载 OpenID 元数据");
         using var response = await HttpRequest.Create(Meta.JwksUri)
             .WithHeaders(Headers ?? [])
             .SendAsync(GetClient.Invoke())
@@ -88,19 +88,22 @@ public record OpenIdOptions
         var result = await response
             .AsJsonAsync<JsonWebKeys>(cancellationToken: token)
             .ConfigureAwait(false);
-        return result?.Keys.Single(k => k.Kid == kid) 
-               ?? throw new FormatException();
+        return result?.Keys.SingleOrDefault(k => k.Kid == kid)
+               ?? throw new IdentityModelConfigurationException($"找不到匹配的 Jwk：{kid}");
     }
     /// <summary>
     /// 构建 OAuth 客户端配置
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/> 或缺少授权所需配置</exception>
     public virtual async Task<OAuthClientOptions> BuildOAuthOptionsAsync(CancellationToken token)
     {
-        if (Meta is null) throw new InvalidOperationException();
-        if(!OnlyDeviceAuthorize) ArgumentException.ThrowIfNullOrEmpty(RedirectUri);
+        if (Meta is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 加载 OpenID 元数据");
+        if (string.IsNullOrEmpty(Meta.TokenEndpoint))
+            throw new IdentityModelConfigurationException("OpenID 元数据缺少 TokenEndpoint");
+        if (!OnlyDeviceAuthorize && string.IsNullOrEmpty(RedirectUri))
+            throw new IdentityModelConfigurationException("授权代码流需要设置 RedirectUri");
         return new OAuthClientOptions
         {
             GetClient = GetClient,

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdOptions.cs
@@ -82,7 +82,7 @@ public record OpenIdOptions
         if (Meta?.JwksUri is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 加载 OpenID 元数据");
         using var response = await HttpRequest.Create(Meta.JwksUri)
             .WithHeaders(Headers ?? [])
-            .SendAsync(GetClient.Invoke())
+            .SendAsync(GetClient.Invoke(), cancellationToken: token)
             .ConfigureAwait(false);
 
         var result = await response

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Minecraft.IdentityModel;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 
@@ -10,7 +11,7 @@ namespace PCL.Core.Minecraft.IdentityModel.Extensions.YggdrasilConnect;
 // Steven Qiu 说这东西完全就是 OpenId + 魔改了一部分，所以可以直接复用 OpenId 的逻辑
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class YggdrasilClient:IOAuthClient
 {
@@ -18,7 +19,7 @@ public class YggdrasilClient:IOAuthClient
     private OpenIdClient? _client;
 
     private YggdrasilOptions _options;
-    
+
     public YggdrasilClient(YggdrasilOptions options)
     {
         _options = options;
@@ -26,7 +27,7 @@ public class YggdrasilClient:IOAuthClient
     /// <summary>
     /// 初始化并拉取网络配置
     /// </summary>
-    /// <exception cref="ArgumentException">当无法获取 ClientId 时抛出，调用方应该设置 ClientId 并重新实例化 Client</exception>
+    /// <exception cref="IdentityModelConfigurationException">无法获取 ClientId 或 OpenID 元数据无效</exception>
     /// <param name="token"></param>
     public async Task InitializeAsync(CancellationToken token)
     {
@@ -40,10 +41,10 @@ public class YggdrasilClient:IOAuthClient
     /// <param name="state"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public string GetAuthorizeUrl(string[] scopes, string state, Dictionary<string, string>? extData)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 Yggdrasil Connect 客户端");
         return _client.GetAuthorizeUrl(scopes, state, extData);
     }
     /// <summary>
@@ -53,10 +54,10 @@ public class YggdrasilClient:IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithCodeAsync(string code, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 Yggdrasil Connect 客户端");
         return await _client.AuthorizeWithCodeAsync(code, token, extData);
 
     }
@@ -67,12 +68,12 @@ public class YggdrasilClient:IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<DeviceCodeData?> GetCodePairAsync(string[] scopes, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 Yggdrasil Connect 客户端");
         return await _client.GetCodePairAsync(scopes, token, extData);
-        
+
     }
     /// <summary>
     /// 发起一次请求验证用户授权状态
@@ -81,10 +82,10 @@ public class YggdrasilClient:IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithDeviceAsync(DeviceCodeData data, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 Yggdrasil Connect 客户端");
         return await _client.AuthorizeWithDeviceAsync(data, token, extData);
 
     }
@@ -95,10 +96,10 @@ public class YggdrasilClient:IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/></exception>
     public async Task<AuthorizeResult?> AuthorizeWithSilentAsync(AuthorizeResult data, CancellationToken token, Dictionary<string, string>? extData = null)
     {
-        if (_client is null) throw new InvalidOperationException();
+        if (_client is null) throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 初始化 Yggdrasil Connect 客户端");
         return await _client.AuthorizeWithSilentAsync(data, token, extData);
     }
 }

--- a/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilOptions.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/YggdrasilConnect/YggdrasilOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using PCL.Core.Minecraft.IdentityModel;
 using PCL.Core.Minecraft.IdentityModel.Extensions.OpenId;
 using PCL.Core.Minecraft.IdentityModel.OAuth;
 using PCL.Core.Utils.Exts;
@@ -12,49 +13,50 @@ namespace PCL.Core.Minecraft.IdentityModel.Extensions.YggdrasilConnect;
 public record YggdrasilOptions:OpenIdOptions
 {
     private string[] _scopesRequired = ["openid", "Yggdrasil.PlayerProfiles.Select", "Yggdrasil.Server.Join"];
-    
+
     // 重写这个鬼方法是因为 Yggdrasil Connect 有要求（
-    
+
     /// <summary>
     /// 拉取 Yggdrasil 配置
     /// </summary>
     /// <param name="token"></param>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">无法加载元数据或缺少必要 scope</exception>
     public override async Task InitializeAsync(CancellationToken token)
     {
         using var response = await HttpRequest
             .Create(OpenIdDiscoveryAddress)
             .WithHeaders(Headers ?? [])
-            .SendAsync(GetClient.Invoke())
+            .SendAsync(GetClient.Invoke(), cancellationToken: token)
             .ConfigureAwait(false);
 
-        Meta = (await response.AsJsonAsync<YggdrasilConnectMetaData>().ConfigureAwait(false))
-            ?? throw new InvalidOperationException();
-        if (_scopesRequired.Except(Meta.ScopesSupported).Any()) throw new InvalidOperationException();
+        Meta = (await response.AsJsonAsync<YggdrasilConnectMetaData>(cancellationToken: token).ConfigureAwait(false))
+            ?? throw new IdentityModelConfigurationException("无法加载 Yggdrasil Connect 元数据");
+
+        var missingScopes = _scopesRequired.Except(Meta.ScopesSupported).ToArray();
+        if (missingScopes.Length > 0)
+            throw new IdentityModelConfigurationException($"Yggdrasil Connect 元数据缺少必要 scope：{string.Join(", ", missingScopes)}");
     }
     /// <summary>
     /// 构建 OAuth 客户端选项
     /// </summary>
     /// <param name="token"></param>
     /// <returns></returns>
-    /// <exception cref="InvalidOperationException">未调用 <see cref="InitializeAsync"/></exception>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="InvalidCastException"></exception>
+    /// <exception cref="IdentityModelConfigurationException">未调用 <see cref="InitializeAsync"/> 或缺少必要的客户端配置</exception>
     public override async Task<OAuthClientOptions> BuildOAuthOptionsAsync(CancellationToken token)
     {
         if (Meta is YggdrasilConnectMetaData meta)
         {
             var options = await base.BuildOAuthOptionsAsync(token);
             if (!options.ClientId.IsNullOrEmpty()) return options;
-            if (meta is null) throw new InvalidOperationException();
             if (!meta.SharedClientId.IsNullOrEmpty())
             {
                 options.ClientId = meta.SharedClientId;
+                return options;
             }
 
-            throw new ArgumentException();
+            throw new IdentityModelConfigurationException("Yggdrasil Connect 需要设置 ClientId，或由元数据提供 sharedClientId");
         }
 
-        throw new InvalidCastException();
+        throw new IdentityModelConfigurationException("请先调用 InitializeAsync() 加载 Yggdrasil Connect 元数据");
     }
 }

--- a/PCL.Core/Minecraft/IdentityModel/IdentityModelException.cs
+++ b/PCL.Core/Minecraft/IdentityModel/IdentityModelException.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace PCL.Core.Minecraft.IdentityModel;
+
+/// <summary>
+/// IdentityModel 模块异常基类。
+/// </summary>
+public class IdentityModelException(string message, Exception? innerException = null) : Exception(message, innerException);
+
+/// <summary>
+/// IdentityModel 配置或元数据不满足当前认证流程要求时抛出的异常。
+/// </summary>
+public class IdentityModelConfigurationException(string message, Exception? innerException = null)
+    : IdentityModelException(message, innerException);
+
+/// <summary>
+/// 认证服务器返回 OAuth/Yggdrasil 协议错误时抛出的异常。
+/// </summary>
+/// <param name="error">协议错误代码。</param>
+/// <param name="errorDescription">协议错误描述。</param>
+/// <param name="innerException">内部异常。</param>
+public class IdentityModelAuthenticationException(
+    string? error,
+    string? errorDescription,
+    Exception? innerException = null)
+    : IdentityModelException(_BuildMessage(error, errorDescription), innerException)
+{
+    /// <summary>
+    /// 协议错误代码。
+    /// </summary>
+    public string? Error { get; } = error;
+
+    /// <summary>
+    /// 协议错误描述。
+    /// </summary>
+    public string? ErrorDescription { get; } = errorDescription;
+
+    private static string _BuildMessage(string? error, string? errorDescription)
+    {
+        if (!string.IsNullOrWhiteSpace(error) && !string.IsNullOrWhiteSpace(errorDescription))
+            return $"认证失败：{error} - {errorDescription}";
+
+        if (!string.IsNullOrWhiteSpace(errorDescription)) return $"认证失败：{errorDescription}";
+        if (!string.IsNullOrWhiteSpace(error)) return $"认证失败：{error}";
+        return "认证失败";
+    }
+}

--- a/PCL.Core/Minecraft/IdentityModel/OAuth/Client.cs
+++ b/PCL.Core/Minecraft/IdentityModel/OAuth/Client.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Threading;
 using PCL.Core.IO.Net.Http;
+using PCL.Core.Minecraft.IdentityModel;
 
 namespace PCL.Core.Minecraft.IdentityModel.OAuth;
 
@@ -30,12 +31,12 @@ public sealed class SimpleOAuthClient(OAuthClientOptions options):IOAuthClient
         sb.Append($"?response_type=code&scope={Uri.EscapeDataString(string.Join(" ", scopes))}");
         sb.Append($"&redirect_uri={Uri.EscapeDataString(options.RedirectUri)}");
         sb.Append($"&client_id={options.ClientId}&state={state}");
-        if (extData is null) return sb.ToString(); 
-        foreach (var kvp in extData) 
+        if (extData is null) return sb.ToString();
+        foreach (var kvp in extData)
             sb.Append($"&{kvp.Key}={Uri.EscapeDataString(kvp.Value)}");
         return sb.ToString();
     }
-    
+
     /// <summary>
     /// 使用授权代码获取令牌
     /// </summary>
@@ -59,7 +60,6 @@ public sealed class SimpleOAuthClient(OAuthClientOptions options):IOAuthClient
             .WithHeaders(options.Headers ?? [])
             .SendAsync(client, cancellationToken: token)
             .ConfigureAwait(false);
-        var result  = await response.Content.ReadAsStringAsync(token);
         return await response
             .AsJsonAsync<AuthorizeResult>(cancellationToken: token)
             .ConfigureAwait(false);
@@ -100,11 +100,11 @@ public sealed class SimpleOAuthClient(OAuthClientOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="IdentityModelAuthenticationException">认证服务器返回设备授权错误</exception>
     public async Task<AuthorizeResult?> AuthorizeWithDeviceAsync
         (DeviceCodeData data,CancellationToken token,Dictionary<string,string>? extData = null)
     {
-        if (data.IsError) throw new OperationCanceledException(data.ErrorDescription); 
+        if (data.IsError) throw new IdentityModelAuthenticationException(data.Error, data.ErrorDescription);
         var client = options.GetClient.Invoke();
         extData ??= new Dictionary<string, string>();
         extData["client_id"] = options.ClientId;
@@ -130,12 +130,12 @@ public sealed class SimpleOAuthClient(OAuthClientOptions options):IOAuthClient
     /// <param name="token"></param>
     /// <param name="extData"></param>
     /// <returns></returns>
-    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="IdentityModelAuthenticationException">认证服务器返回刷新授权错误</exception>
     public async Task<AuthorizeResult?> AuthorizeWithSilentAsync
         (AuthorizeResult data,CancellationToken token,Dictionary<string,string>? extData = null)
     {
         var client = options.GetClient.Invoke();
-        if (data.IsError) throw new OperationCanceledException(data.ErrorDescription);
+        if (data.IsError) throw new IdentityModelAuthenticationException(data.Error, data.ErrorDescription);
         extData ??= [];
         extData["refresh_token"] = data.RefreshToken!;
         extData["grant_type"] = "refresh_token";


### PR DESCRIPTION
完全Codex自主完成，写的中规中矩
---
### Motivation
- 消除 IdentityModel 模块中异常语义模糊的问题，把协议错误和配置错误与本地 cancellation/invalid-operation 区分开。 
- 让上层调用者能根据异常类型做更精确的错误处理（例如区分 OpenID/Yggdrasil 元数据问题与认证服务器返回的协议错误）。

### Description
- 新增模块异常类型 `IdentityModelException`、`IdentityModelConfigurationException` 和 `IdentityModelAuthenticationException`（文件 `PCL.Core/Minecraft/IdentityModel/IdentityModelException.cs`）。
- 将 OAuth 设备/刷新流程中把协议错误当作取消的逻辑替换为 `IdentityModelAuthenticationException`（修改 `PCL.Core/Minecraft/IdentityModel/OAuth/Client.cs`）。
- 用 `IdentityModelConfigurationException` 替换 OpenID/Yggdrasil 初始化与未初始化的通用 `InvalidOperationException`，并在 OpenID 元数据校验、JWK 查找、TokenEndpoint/RedirectUri 缺失等情况抛出更明确的错误（修改 `OpenId/OpenIdClient.cs`、`OpenId/OpenIdOptions.cs`）。
- 修复 Yggdrasil Connect 的元数据加载以传递 cancellation token、改进缺失 scope 的错误信息，并在使用元数据的 shared client id 时正确返回构建后的 `OAuthClientOptions`（修改 `YggdrasilConnect/YggdrasilOptions.cs`），同时更新 `YggdrasilClient` 的初始化/守卫异常为模块异常。 
- 进行了若干调用处的防御性消息与返回值处理调整及格式/空白清理，保持现有行为并提供更可操作的错误消息。 

### Testing
- 运行 `git diff --check`，检查无 diff 余量；结果通过。 
- 尝试运行 `dotnet build PCL.Core/PCL.Core.csproj --configuration CI` 以进行编译验证，但当前环境中 `dotnet` 不可用，构建未在此环境执行。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ec9b27848322b6ea1606956b72df)

## Summary by Sourcery

引入专用的 IdentityModel 异常类型，并在 OAuth、OpenID 和 YggdrasilConnect 流程中使用它们，以区分配置问题和认证协议错误。

增强内容：
- 新增 IdentityModelException、IdentityModelConfigurationException 和 IdentityModelAuthenticationException 作为 IdentityModel 的模块专用异常类型。
- 优化 OpenIdOptions、OpenIdClient、YggdrasilOptions 和 YggdrasilClient，更严格地验证元数据、必需的 scopes，以及客户端配置，并提供更具描述性的错误信息。
- 更新 OAuth 设备授权和静默授权流程，通过 IdentityModelAuthenticationException 暴露认证协议失败，而不是使用泛化的取消或无效操作错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dedicated IdentityModel exception types and adopt them across OAuth, OpenID, and YggdrasilConnect flows to distinguish configuration issues from authentication protocol errors.

Enhancements:
- Add IdentityModelException, IdentityModelConfigurationException, and IdentityModelAuthenticationException as module-specific exception types for IdentityModel.
- Refine OpenIdOptions, OpenIdClient, YggdrasilOptions, and YggdrasilClient to validate metadata, required scopes, and client configuration more strictly with descriptive errors.
- Update OAuth device and silent authorization flows to surface authentication protocol failures via IdentityModelAuthenticationException instead of generic cancellation or invalid-operation errors.

</details>