### PR TITLE
fix(download): 限制依赖库下载路径

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Microsoft.VisualBasic;
+using PCL.Core.IO;
 using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
@@ -2845,8 +2846,7 @@ public static class ModMinecraft
                             init.Url = (string)(rootUrl ?? library["downloads"]["artifact"]["url"]),
                             init.LocalPath = library["downloads"]["artifact"]["path"] is null
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
-                                : Path.Combine(customMcFolder, "libraries", library["downloads"]["artifact"]["path"].ToString()
-                                    .Replace("/", @"\")),
+                                : McLibGetSafeDownloadPath(customMcFolder, library["downloads"]["artifact"]["path"]),
                             init.size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["artifact"]["size"].ToString())),
                             init.IsNatives = false, init.Sha1 = library["downloads"]["artifact"]["sha1"]?.ToString(),
@@ -2885,9 +2885,8 @@ public static class ModMinecraft
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
                                     .Replace(".jar", "-" + library["natives"]["windows"] + ".jar")
                                     .Replace("${arch}", Environment.Is64BitOperatingSystem ? "64" : "32")
-                                : Path.Combine(customMcFolder, "libraries",
-                                  library["downloads"]["classifiers"]["natives-windows"]["path"].ToString()
-                                      .Replace("/", @"\")),
+                                : McLibGetSafeDownloadPath(customMcFolder,
+                                    library["downloads"]["classifiers"]["natives-windows"]["path"]),
                             size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["classifiers"]["natives-windows"]["size"].ToString())),
                             IsNatives = true,
@@ -3098,6 +3097,31 @@ public static class ModMinecraft
         }
 
         return result;
+    }
+
+    /// <summary>
+    ///     根据下载元数据中的相对路径获取支持库下载地址，并阻止路径逃逸 libraries 文件夹。
+    /// </summary>
+    private static string McLibGetSafeDownloadPath(string customMcFolder, JsonNode pathNode)
+    {
+        var rawPath = pathNode?.ToString();
+        if (string.IsNullOrWhiteSpace(rawPath))
+            throw new IOException("支持库下载路径无效");
+
+        var normalizedPath = rawPath.Replace("/", @"\");
+        if (Path.IsPathRooted(normalizedPath) || normalizedPath.StartsWith(@"\") ||
+            Regex.IsMatch(normalizedPath, @"^[A-Za-z]:"))
+            throw new IOException($"支持库下载路径不能为绝对路径：{rawPath}");
+
+        if (normalizedPath.Split(new[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries).Any(x => x == ".."))
+            throw new IOException($"支持库下载路径不能包含上级目录：{rawPath}");
+
+        var librariesFolder = Path.Combine(customMcFolder, "libraries");
+        var localPath = Path.GetFullPath(Path.Combine(librariesFolder, normalizedPath));
+        if (!Files.IsPathWithinDirectory(localPath, librariesFolder))
+            throw new IOException($"支持库下载路径不在 libraries 文件夹内：{rawPath}");
+
+        return localPath;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled `downloads.*.path` values from escaping the intended `libraries` folder and enabling arbitrary file writes.
- Close a regression where deep-cloned MultiMC/LiteLoader library metadata reached the downloader without canonicalization or containment checks.

### Description

- Added a helper `McLibGetSafeDownloadPath(customMcFolder, JsonNode)` that normalizes the metadata path, rejects absolute/drive/UNC paths and `..` traversal, and verifies the resolved path is inside `customMcFolder\libraries` using `Files.IsPathWithinDirectory`.
- Replaced direct `Path.Combine(customMcFolder, "libraries", ...)` usages for artifact and native-classifier paths with `McLibGetSafeDownloadPath` and added `using PCL.Core.IO` to the file.
- The helper throws `IOException` for invalid or escaping paths to stop processing untrusted metadata.
- Existing behavior for entries without a metadata `path` is preserved by keeping the `McLibGet` fallback.

### Testing

- Ran `git diff --check` and it completed without whitespace/format errors.
- Attempted `dotnet --info` to run build/tests but `dotnet` is not available in the execution environment, so compile-time tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fb64253083229c1e8df17a4ceb97)

## 由 Sourcery 提供的摘要

加强对 Minecraft 库下载的处理，防止不安全的元数据路径逃离预期的 libraries 目录。

错误修复：
- 防止由攻击者控制的库下载路径通过元数据逃离 Minecraft 的 libraries 文件夹，从而实现任意文件写入。

功能改进：
- 引入集中式辅助工具，在解析本地下载位置之前，用于验证和规范库元数据路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Minecraft library download handling to prevent unsafe metadata paths from escaping the intended libraries directory.

Bug Fixes:
- Prevent attacker-controlled library download paths in metadata from escaping the Minecraft libraries folder and enabling arbitrary file writes.

Enhancements:
- Introduce a centralized helper to validate and normalize library metadata paths before resolving their local download location.

</details>