### PR TITLE
fix(event): 使用了废弃的事件

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModEvent.cs
+++ b/Plain Craft Launcher 2/Modules/ModEvent.cs
@@ -329,7 +329,7 @@ namespace PCL
                         {
                             if (!ConfirmSecuritySensitiveSettingWrite(args[0], args[1]))
                                 return;
-                            item.SetValueNoType(args[1], ModMinecraft.McInstanceSelected?.PathInstance);
+                            item.SetValueNoType(args[1], ModInstanceList.McMcInstanceSelected?.PathInstance);
                         }
                         if (args.Length == 2)
                             ModMain.Hint($"已写入设置：{args[0]} → {args[1]}", ModMain.HintType.Finish);


### PR DESCRIPTION
### Motivation
- The project refactor removed the old `ModMinecraft.McInstanceSelected` accessor and custom-event setting writes still referenced it, causing errors after merging changes.

### Description
- Replace `ModMinecraft.McInstanceSelected?.PathInstance` with `ModInstanceList.McMcInstanceSelected?.PathInstance` in `Plain Craft Launcher 2/Modules/ModEvent.cs` so custom event setting writes use the current global instance accessor.

### Testing
- Ran `rg -n "\bModMinecraft\b" "Plain Craft Launcher 2" PCL.Core --glob '!bin/**' --glob '!obj/**'` and `git diff --check` which showed no remaining occurrences or diff-check issues; attempted `dotnet build "Plain Craft Launcher 2.slnx"` but `dotnet` is not available in the container so the solution build could not be executed; attempted `apt-get update && apt-get install -y dotnet-sdk-10.0` but package repository access failed with HTTP 403 from the environment proxy, preventing SDK installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23bdc1a4808322b4687feff48479bc)

## Summary by Sourcery

错误修复：
- 修复自定义事件设置写入仍引用已废弃的 `ModMinecraft.McInstanceSelected` 访问器的问题，改为使用 `ModInstanceList.McMcInstanceSelected`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix custom event setting writes referencing the obsolete ModMinecraft.McInstanceSelected accessor by switching to ModInstanceList.McMcInstanceSelected.

</details>