### PR TITLE
fix(homepage): 阻止主页实时补丁注入 XAML 子元素

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -720,9 +720,8 @@ public partial class PageLaunchRight : IRefreshable
                 _TrySetElementProperty(element, property.Name, property.Value?.ToString() ?? "");
         }
 
-        var childrenXaml = _TryGetString(patch, "childrenXaml", "ChildrenXaml");
-        if (!string.IsNullOrEmpty(childrenXaml) && element is Panel panel)
-            _ReplacePanelChildren(panel, childrenXaml);
+        if (_TryGetString(patch, "childrenXaml", "ChildrenXaml") is not null)
+            ModBase.Log("[Page] Skipped unsupported live patch field childrenXaml", ModBase.LogLevel.Developer);
     }
 
     private static void _SetPropertyIfPresent(FrameworkElement element, JObject patch, string jsonName, string propertyName)
@@ -777,24 +776,6 @@ public partial class PageLaunchRight : IRefreshable
             ModBase.Log(ex, $"[Page] Failed to set live patch property {propertyName}", ModBase.LogLevel.Developer);
             return false;
         }
-    }
-
-    private static void _ReplacePanelChildren(Panel panel, string childrenXaml)
-    {
-        var content = ModMain.ArgumentReplace(childrenXaml);
-        while (content.Contains("xmlns"))
-            content = content.RegexReplace("xmlns[^\"']*(\"|')[^\"']*(\"|')", "").Replace("xmlns", "");
-
-        var wrapped =
-            $"<StackPanel xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xmlns:sys=\"clr-namespace:System;assembly=System.Runtime\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:local=\"clr-namespace:PCL;assembly=Plain Craft Launcher 2\">{content}</StackPanel>";
-
-        if (ModBase.GetObjectFromXML(wrapped) is not Panel parsedPanel) return;
-
-        var children = parsedPanel.Children.OfType<UIElement>().ToList();
-        parsedPanel.Children.Clear();
-        panel.Children.Clear();
-        foreach (var child in children)
-            panel.Children.Add(child);
     }
 
     private static IEnumerable<FrameworkElement> _FindElementsByTag(DependencyObject root, string tag)


### PR DESCRIPTION
### Motivation
- The live-patch feature accepted a `childrenXaml` field from `PCL/CustomLive.json` and parsed it into full WPF/PCL XAML, which allowed untrusted patches to inject active controls and custom events that can write launcher settings and lead to command execution. 
- The intent of this change is to restrict the live-patch channel to inert, property-only updates and remove the ability to inject active XAML.

### Description
- Removed the runtime path that parsed `childrenXaml` into runtime XAML and replaced panel children (the `_ReplacePanelChildren` call and its implementation were removed). 
- Live patch handling now detects `childrenXaml`/`ChildrenXaml`, logs `"[Page] Skipped unsupported live patch field childrenXaml"`, and ignores the field instead of loading XAML. 
- The explicit allowlist-based property update surface (`_homepageLiveAllowedProperties` and `_TrySetElementProperty`) is preserved so live patches can only mutate the intended simple properties.

### Testing
- Ran `git diff --check` and a Python assertion that verifies `_ReplacePanelChildren` and `ModBase.GetObjectFromXML(wrapped)` are no longer present and the `Skipped unsupported live patch field childrenXaml` log message exists. 
- Attempted `dotnet build 'Plain Craft Launcher 2.slnx' -c Debug --no-restore`, but the build could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f8a9daf48322a60c87401025308f)

## 由 Sourcery 生成的摘要

阻止主页实时补丁注入 XAML 子元素，并将其限制为仅更新属性。

错误修复：
- 防止实时补丁将 `childrenXaml/ChildrenXaml` 加载并应用到面板子元素中，以避免不受信任的 XAML 注入。

改进：
- 在实时补丁中记录并忽略不受支持的 `childrenXaml/ChildrenXaml` 字段，而不是对其进行处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Block homepage live patches from injecting XAML children and restrict them to property-only updates.

Bug Fixes:
- Prevent live patches from loading and applying childrenXaml/ChildrenXaml into panel children to avoid untrusted XAML injection.

Enhancements:
- Log and ignore unsupported childrenXaml/ChildrenXaml fields in live patches instead of processing them.

</details>