### PR TITLE
fix: verify downloaded files before completion

### DIFF
--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -137,6 +137,9 @@ public class LoaderDownload : ModLoader.LoaderBase
             {
                 await FileDownloader.Download(file.Urls, file.LocalPath, file.UseBrowserUserAgent, file.CustomUserAgent,
                     cancellationToken, enableParallelChunks, file).ConfigureAwait(false);
+                var checkError = file.Check?.Check(file.LocalPath);
+                if (checkError is not null)
+                    throw new IOException($"下载文件校验失败：{checkError}");
                 break;
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
### Motivation

- The loader previously validated only existing files and did not verify freshly downloaded content, which allows a malicious mirror to supply modified artifacts that are accepted as valid.
- Callers supply `ModBase.FileChecker` (expected size/hash) for sensitive artifacts such as Minecraft libraries and assets, so downloads must be re-checked after being written.

### Description

- Re-introduce post-download integrity verification by invoking `file.Check?.Check(file.LocalPath)` immediately after `FileDownloader.Download(...)` in `LoaderDownload.ProcessFileAsync` of `Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs`.
- Treat a non-null check result as a failure by throwing an `IOException` with the checker message, which routes the error through the existing retry/failure handling path.
- Preserve the existing retry loop and file state updates so normal successful downloads continue to be marked `Finished` after verification.

### Testing

- Ran a small Python assertion that checks the post-download call to `file.Check?.Check(file.LocalPath)` is present before the `Finished` state, and the assertion passed.
- Ran `git diff --check` to ensure no whitespace errors and it passed.
- Attempted `dotnet build 'Plain Craft Launcher 2/Plain Craft Launcher 2.csproj' -c Debug --no-restore` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230629c7ac83228763c3fb769384ab)

## Summary by Sourcery

Bug Fixes:
- 确保新下载的文件在被标记为成功下载之前，会根据其配置的文件检查规则重新进行验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure freshly downloaded files are re-validated against their configured file checks before being marked as successfully downloaded.

</details>