### PR TITLE
fix(promote): verify named pipe server process

### DIFF
--- a/PCL.Core/App/Essentials/PromoteService.cs
+++ b/PCL.Core/App/Essentials/PromoteService.cs
@@ -132,6 +132,13 @@ public sealed partial class PromoteService
         var pipeName = _GetPromotePipeName(process.Id);
         var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
         pipe.Connect(10000);
+        var serverProcessId = (int)KernelInterop.GetNamedPipeServerProcessId(pipe.SafePipeHandle.DangerousGetHandle());
+        if (serverProcessId != process.Id)
+        {
+            Context.Error("管道服务端验证失败，正在退出");
+            pipe.Dispose();
+            return;
+        }
         Context.Info("已连接，开始通信");
         var reader = new StreamReader(pipe);
         var writer = new StreamWriter(pipe);

--- a/PCL.Core/Utils/OS/KernelInterop.cs
+++ b/PCL.Core/Utils/OS/KernelInterop.cs
@@ -21,6 +21,10 @@ public static partial class KernelInterop
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool _GetNamedPipeClientProcessId(IntPtr pipeHandle, out uint clientProcessId);
 
+    [LibraryImport("kernel32.dll", EntryPoint = "GetNamedPipeServerProcessId", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool _GetNamedPipeServerProcessId(IntPtr pipeHandle, out uint serverProcessId);
+
     [LibraryImport("kernel32.dll", EntryPoint = "GetLogicalProcessorInformationEx", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static partial bool _GetLogicalProcessorInformationEx(
@@ -96,6 +100,17 @@ public static partial class KernelInterop
     {
         if (!_GetNamedPipeClientProcessId(pipeHandle, out var clientProcessId)) _ThrowLastWin32Error();
         return clientProcessId;
+    }
+
+    /// <summary>
+    /// 获取指定命名管道当前连接的服务端进程 ID
+    /// </summary>
+    /// <param name="pipeHandle">命名管道句柄</param>
+    /// <returns>获取到的进程 ID</returns>
+    public static uint GetNamedPipeServerProcessId(IntPtr pipeHandle)
+    {
+        if (!_GetNamedPipeServerProcessId(pipeHandle, out var serverProcessId)) _ThrowLastWin32Error();
+        return serverProcessId;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Close a local privileged escalation window where the elevated `promote` helper could connect to a predictable named pipe owned by an attacker because only the main process executable path was checked.
- Ensure the promoted helper verifies the actual named-pipe server process identity before accepting privileged `start`/`start-json` commands.

### Description
- Add a Windows API wrapper `KernelInterop.GetNamedPipeServerProcessId` that calls `GetNamedPipeServerProcessId` in `PCL.Core/Utils/OS/KernelInterop.cs`.
- In `PromoteService._PerformAsPromoteProcess`, after connecting the `NamedPipeClientStream`, obtain the server PID via `KernelInterop.GetNamedPipeServerProcessId(pipe.SafePipeHandle.DangerousGetHandle())` and compare it to the expected `process.Id`, closing the pipe and aborting if they differ.
- Preserve existing promote-mode behavior and command handling while preventing the elevated helper from attaching to a spoofed pipe server.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff sanity (passed).
- Ran `dotnet --info` (failed in this environment because the `dotnet` SDK/runtime is not installed).
- Ran `dotnet build PCL.Core/PCL.Core.csproj -c Debug` (could not run due to missing `dotnet` in the container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2304f97a688322b3a08549f0548884)

## Summary by Sourcery

验证用于特权提升助手（privileged promote helper）的 Windows 命名管道服务器进程，以防止连接到伪造的服务器。

Bug 修复：
- 通过将服务器进程 ID 与预期进程进行校验，确保提升助手只与目标命名管道服务器进程通信。

增强功能：
- 为 `GetNamedPipeServerProcessId` 添加一个 `KernelInterop` 包装器，用于获取命名管道的服务器进程 ID，并通过现有的 Win32 错误处理机制抛出错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Verify the Windows named pipe server process for the privileged promote helper to prevent connecting to spoofed servers.

Bug Fixes:
- Ensure the promote helper only communicates with the intended named-pipe server process by validating the server process ID against the expected process.

Enhancements:
- Add a KernelInterop wrapper for GetNamedPipeServerProcessId to retrieve the server process ID for a named pipe and surface errors via existing Win32 error handling.

</details>