### PR TITLE
fix(homepage): validate news links before opening

### DIFF
--- a/PCL.Core.Test/HomepageNewsViewModelTest.cs
+++ b/PCL.Core.Test/HomepageNewsViewModelTest.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PCL.Core.ViewModel.Homepage;
+
+namespace PCL.Core.Test;
+
+[TestClass]
+public class HomepageNewsViewModelTest
+{
+    [DataTestMethod]
+    [DataRow("https://www.minecraft.net/zh-hans/article/example")]
+    [DataRow("http://minecraft.net/news")]
+    [DataRow("https://net-secondary.web.minecraft-services.net/api/v1.0/zh-cn/search")]
+    [DataRow("https://learn.microsoft.com/gaming/")]
+    public void IsSafeNewsLink_AllowsExpectedWebHosts(string url)
+    {
+        Assert.IsTrue(NewsViewModel.IsSafeNewsLink(url));
+    }
+
+    [DataTestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("calc.exe")]
+    [DataRow("C:\\Windows\\System32\\calc.exe")]
+    [DataRow("file:///C:/Windows/System32/calc.exe")]
+    [DataRow("minecraft://open")]
+    [DataRow("\\\\evil.example\\share\\payload.exe")]
+    [DataRow("https://minecraft.net.evil.example/news")]
+    [DataRow("https://evil.example/news")]
+    public void IsSafeNewsLink_BlocksShellAndUnexpectedTargets(string? url)
+    {
+        Assert.IsFalse(NewsViewModel.IsSafeNewsLink(url));
+    }
+}

--- a/PCL.Core/ViewModel/Homepage/NewsViewModel.cs
+++ b/PCL.Core/ViewModel/Homepage/NewsViewModel.cs
@@ -15,6 +15,12 @@ public partial class NewsViewModel : ObservableObject
 {
     private const string BaseApiUrl = "https://net-secondary.web.minecraft-services.net/api/v1.0/zh-cn/search";
     private const int PageSize = 24;
+    private static readonly string[] AllowedNewsLinkHosts =
+    [
+        "minecraft.net",
+        "minecraft-services.net",
+        "microsoft.com"
+    ];
     private int _currentPage = 1;
 
     public ObservableCollection<NewsItem> NewsItems { get; } = new();
@@ -71,10 +77,38 @@ public partial class NewsViewModel : ObservableObject
 
     [RelayCommand]
 #pragma warning disable IDE1006 // 命名样式
-    private void _OpenRead(string url)
+    private void _OpenRead(string? url)
 #pragma warning restore IDE1006 // 命名样式
     {
-        Basics.OpenPath(url);
+        if (!IsSafeNewsLink(url))
+        {
+            LogWrapper.Warn("Homepage", $"已拦截不安全的 Minecraft 信息流链接：{url ?? "<null>"}");
+            return;
+        }
+
+        Basics.OpenPath(url!);
+    }
+
+    internal static bool IsSafeNewsLink(string? url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (!uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) &&
+            !uri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var host = uri.IdnHost;
+        foreach (var allowedHost in AllowedNewsLinkHosts)
+        {
+            if (host.Equals(allowedHost, StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith($".{allowedHost}", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }


### PR DESCRIPTION
### Motivation

- The homepage previously passed remote `url` values directly to `Basics.OpenPath`, which uses shell execution and can launch local executables or dangerous protocol handlers when a malicious feed item is clicked.
- The change aims to prevent remote data from turning into user-assisted command/protocol execution by validating links before opening them.

### Description

- Added an allowlist `AllowedNewsLinkHosts` and an `IsSafeNewsLink(string?)` helper that requires absolute `http`/`https` URIs and enforces host suffix matching against the allowlist.
- Updated `_OpenRead` to call `IsSafeNewsLink` and to log and block unsafe or non-HTTP(S) targets instead of forwarding them to `Basics.OpenPath`.
- Added unit tests `PCL.Core.Test/HomepageNewsViewModelTest.cs` covering allowed Minecraft/Microsoft web hosts and blocking malicious local/shell/protocol targets and lookalike domains.

### Testing

- Ran a targeted source-flow validation script (`python3` based) which confirmed the new validation runs before `Basics.OpenPath` and enforces scheme and host checks (PASS).
- Added MSTest unit tests under `PCL.Core.Test` but could not run them here because the environment lacks the .NET SDK; the intended command is `dotnet test PCL.Core.Test/PCL.Core.Test.csproj --filter HomepageNewsViewModelTest` (not executed: `dotnet` not available).

------

## Summary by Sourcery

在打开主页新闻链接之前先进行验证，防止从主页信息流中启动不安全的 URL。

Bug 修复：
- 添加安全检查，仅当主页新闻链接是指向已批准的 Minecraft 或 Microsoft 主机的 HTTP(S) URL 时才允许打开，并阻止本地文件及其他危险协议。

增强功能：
- 引入可复用的 `IsSafeNewsLink` 辅助方法和主机允许列表，在使用主页新闻 URL 之前对其进行验证。

测试：
- 添加单元测试，覆盖被允许的 Minecraft/Microsoft 主机，以及对恶意或意外新闻链接目标的拦截。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate homepage news links before opening them to prevent unsafe URLs from being launched from the homepage feed.

Bug Fixes:
- Add safety checks so homepage news links are only opened if they are HTTP(S) URLs to approved Minecraft or Microsoft hosts, blocking local files and other dangerous protocols.

Enhancements:
- Introduce a reusable IsSafeNewsLink helper and host allowlist for validating homepage news URLs before use.

Tests:
- Add unit tests covering allowed Minecraft/Microsoft hosts and blocking of malicious or unexpected news link targets.

</details>