### PR TITLE
fix: sanitize component download filenames

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2944,7 +2944,7 @@ public static class ModComp
         /// <param name="localAddress">目标本地文件夹，或完整的文件路径。会自动判断类型。</param>
         public DownloadFile ToNetFile(string localAddress)
         {
-            return new DownloadFile(DownloadUrls, localAddress + (localAddress.EndsWithF(@"\") ? FileName : ""),
+            return new DownloadFile(DownloadUrls, localAddress + (localAddress.EndsWithF(@"\") ? CompFileNameSanitize(FileName) : ""),
                 new ModBase.FileChecker(hash: Hash), true);
         }
 
@@ -3200,7 +3200,35 @@ public static class ModComp
 
         if (file.Type == CompType.Mod)
             fileName = fileName.Replace("~", "-"); // ~ 会导致 Mixin 加载失败
-        return fileName;
+        return CompFileNameSanitize(fileName);
+    }
+
+    public static string CompFileNameSanitize(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return "download";
+
+        var sanitized = new StringBuilder(fileName.Length);
+        foreach (var c in fileName)
+        {
+            sanitized.Append(c switch
+            {
+                '\\' => '＼',
+                '/' => '／',
+                ':' => '：',
+                '*' => '＊',
+                '?' => '？',
+                '"' => '＂',
+                '<' => '＜',
+                '>' => '＞',
+                '|' => '｜',
+                _ when char.IsControl(c) => '_',
+                _ => c
+            });
+        }
+
+        var result = sanitized.ToString().Trim();
+        return result is "" or "." or ".." ? "download" : result;
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Batch component downloads previously combined the user-selected folder with untrusted component `FileName` values, allowing rooted paths or traversal to escape the chosen folder on Windows.
- Remote metadata (CurseForge/Modrinth) can supply filenames that contain separators, drive markers, or control characters which must not be treated as direct local paths.

### Description
- Added `CompFileNameSanitize(string)` to normalize and sanitize component filenames by replacing path separators and reserved characters and by collapsing control/empty names to a safe default (`"download"`).
- `CompFileNameGet` now returns the sanitized filename via `CompFileNameSanitize(...)` to ensure any generated filename is safe.
- `ToNetFile` now uses the sanitized component filename when appending a filename to a provided folder path to avoid `Path.Combine` being overridden by rooted inputs.
- Change applied in `Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs` with minimal surface area to preserve existing behavior and filename formatting rules.

### Testing
- Ran repository checks including `git diff --check` which reported no whitespace or diff problems.
- Performed local source inspections (`rg`/`sed`) to verify sanitized name is used at call sites; these inspections succeeded.
- Project build/test was not executed because `dotnet` is not available in the environment (`dotnet` not installed), so no compiled or unit-test results are available.

------

## Summary by Sourcery

在用于本地下载之前先清理组件文件名，以防止不安全路径和保留字符影响批量下载。

Bug 修复：
- 通过在将不受信任的文件名与本地目录组合之前进行清理，确保组件下载路径无法逃逸出目标文件夹。

增强：
- 将文件名清理逻辑集中到可复用的辅助方法中，对保留字符和控制字符进行标准化处理，并在元数据提供无效文件名时强制使用安全的默认名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize component filenames before using them for local downloads to prevent unsafe paths and reserved characters from affecting batch downloads.

Bug Fixes:
- Ensure component download paths cannot escape the target folder by sanitizing untrusted filenames before combining them with local directories.

Enhancements:
- Centralize filename sanitization in a reusable helper that normalizes reserved and control characters and enforces safe default names when metadata provides invalid filenames.

</details>