### PR TITLE
fix: disable log4j lookups in legacy debug config

### DIFF
--- a/Plain Craft Launcher 2/Resources/log4j2-legacy-debug.xml
+++ b/Plain Craft Launcher 2/Resources/log4j2-legacy-debug.xml
@@ -2,13 +2,13 @@
 <Configuration status="WARN">
     <Appenders>
         <Console name="SysOut" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n"/>
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg{nolookups}%n"/>
         </Console>
         <Queue name="ServerGuiConsole">
-            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n"/>
+            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg{nolookups}%n"/>
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %msg%n"/>
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %msg{nolookups}%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>
@@ -16,7 +16,7 @@
         </RollingRandomAccessFile>
         <RollingRandomAccessFile name="DebugFile" fileName="logs/debug.log"
                                  filePattern="logs/debug-%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss}] [%t/%level] [%logger]: %msg%n"/>
+            <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss}] [%t/%level] [%logger]: %msg{nolookups}%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
                 <OnStartupTriggeringPolicy/>


### PR DESCRIPTION
### Motivation
- Remediate a high-severity issue where the legacy debug Log4j2 configuration used raw `%msg` patterns, which can re-enable lookup expansion (and JNDI-style exploits) for older Log4j2 versions selected for pre-2017 Minecraft instances.

### Description
- Updated `Plain Craft Launcher 2/Resources/log4j2-legacy-debug.xml` to replace every `"%msg%n"` pattern with `"%msg{nolookups}%n"` in all `PatternLayout` entries so the legacy debug config matches the non-legacy config's lookup mitigation while preserving existing appenders and formats.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it succeeded.
- Executed a Python static validation script that checks `PatternLayout` patterns and launch-branch occurrences and it reported success (`RESULT=pass`).
- Attempted `dotnet build 'Plain Craft Launcher 2.slnx' --no-restore` but the `dotnet` SDK is not installed in the environment so the build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2358ce46e083229f0ec1cdc1d6ccad)

## Summary by Sourcery

错误修复：
- 在所有旧版调试用的 `PatternLayout` 日志消息模式中禁用 Log4j2 查找功能，以缓解旧版本 Log4j2 中潜在的、类似 JNDI 的利用漏洞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disable Log4j2 lookups in all legacy debug PatternLayout message patterns to mitigate potential JNDI-style exploits in older Log4j2 versions.

</details>