### PR TITLE
fix: block behavior gadgets in loose XAML

### DIFF
--- a/PCL.Core/UI/IconManager.cs
+++ b/PCL.Core/UI/IconManager.cs
@@ -1,8 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xaml;
 using System.Windows;
-using System.Windows.Markup;
+using System.Windows.Controls;
+using System.Windows.Data;
+using WpfXamlReader = System.Windows.Markup.XamlReader;
 
 namespace PCL.Core.UI;
 
@@ -55,7 +61,8 @@ public class IconManager : INotifyPropertyChanged {
         }
         
         try {
-            icon = (UIElement)XamlReader.Parse(xamlString);
+            ValidateSafeLooseXaml(xamlString);
+            icon = (UIElement)WpfXamlReader.Parse(xamlString);
             return true;
         }
         catch (Exception) {
@@ -75,8 +82,80 @@ public class IconManager : INotifyPropertyChanged {
             throw new InvalidOperationException("XAML 解析需要在 UI 线程执行。");
         }
         
-        icon = (UIElement)XamlReader.Parse(xamlString);
+        ValidateSafeLooseXaml(xamlString);
+        icon = (UIElement)WpfXamlReader.Parse(xamlString);
         return true;
+    }
+
+    private static readonly Type[] DisallowedLooseXamlTypes =
+    [
+        typeof(WebBrowser),
+        typeof(Frame),
+        typeof(MediaElement),
+        typeof(ObjectDataProvider),
+        typeof(XmlDataProvider),
+        typeof(WpfXamlReader),
+        typeof(Window),
+        typeof(Process),
+        typeof(ProcessStartInfo)
+    ];
+
+    private static readonly string[] DisallowedLooseXamlMembers =
+    [
+        "Code",
+        "FactoryMethod",
+        "Static"
+    ];
+
+    private static readonly string[] DisallowedLooseXamlAssemblies =
+    [
+        "Microsoft.Xaml.Behaviors"
+    ];
+
+    private static void ValidateSafeLooseXaml(string xamlString) {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(xamlString));
+        using var reader = new XamlXmlReader(stream);
+
+        while (reader.Read()) {
+            if (reader.Type?.UnderlyingType is { } nodeType) {
+                ValidateLooseXamlType(nodeType);
+            }
+
+            if (reader.Member is { } member) {
+                if (DisallowedLooseXamlMembers.Contains(member.Name)) {
+                    throw new UnauthorizedAccessException($"不允许使用 {member.Name} 成员。");
+                }
+
+                if (member.DeclaringType?.UnderlyingType is { } declaringType) {
+                    ValidateLooseXamlType(declaringType);
+                }
+            }
+
+            if (reader.Value is string value) {
+                ValidateLooseXamlValue(value);
+            }
+        }
+    }
+
+    private static void ValidateLooseXamlType(Type type) {
+        if (DisallowedLooseXamlTypes.Any(disallowedType => disallowedType.IsAssignableFrom(type))) {
+            throw new UnauthorizedAccessException($"不允许使用 {type.Name} 类型。");
+        }
+
+        var assemblyName = type.Assembly.GetName().Name;
+        if (assemblyName is not null && DisallowedLooseXamlAssemblies.Any(disallowedAssembly => assemblyName.StartsWith(disallowedAssembly, StringComparison.Ordinal))) {
+            throw new UnauthorizedAccessException($"不允许使用 {assemblyName} 程序集中的类型。");
+        }
+    }
+
+    private static void ValidateLooseXamlValue(string value) {
+        if (DisallowedLooseXamlTypes.Any(disallowedType => string.Equals(value, disallowedType.Name, StringComparison.Ordinal))) {
+            throw new UnauthorizedAccessException($"不允许使用 {value} 值。");
+        }
+
+        if (DisallowedLooseXamlAssemblies.Any(disallowedAssembly => value.Contains(disallowedAssembly, StringComparison.Ordinal))) {
+            throw new UnauthorizedAccessException($"不允许引用 {value}。");
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -3223,13 +3223,24 @@ public static class ModBase
                     foreach (var blackListType in new[]
                              {
                                  typeof(WebBrowser), typeof(Frame), typeof(MediaElement), typeof(ObjectDataProvider),
-                                 typeof(XamlReader), typeof(Window), typeof(XmlDataProvider)
+                                 typeof(XamlReader), typeof(Window), typeof(XmlDataProvider),
+                                 typeof(Process), typeof(ProcessStartInfo)
                              })
                     {
                         if (reader.Type is not null && blackListType.IsAssignableFrom(reader.Type.UnderlyingType))
                             throw new UnauthorizedAccessException($"不允许使用 {blackListType.Name} 类型。");
                         if (reader.Value is not null && Equals(reader.Value, blackListType.Name))
                             throw new UnauthorizedAccessException($"不允许使用 {blackListType.Name} 值。");
+                    }
+
+                    foreach (var blackListAssembly in new[] { "Microsoft.Xaml.Behaviors" })
+                    {
+                        if (reader.Type?.UnderlyingType?.Assembly.GetName().Name?.StartsWith(blackListAssembly, StringComparison.Ordinal) == true)
+                            throw new UnauthorizedAccessException($"不允许使用 {blackListAssembly} 程序集中的类型。");
+                        if (reader.Member?.DeclaringType?.UnderlyingType?.Assembly.GetName().Name?.StartsWith(blackListAssembly, StringComparison.Ordinal) == true)
+                            throw new UnauthorizedAccessException($"不允许使用 {blackListAssembly} 程序集中的成员。");
+                        if (reader.Value is string value && value.Contains(blackListAssembly, StringComparison.Ordinal))
+                            throw new UnauthorizedAccessException($"不允许引用 {blackListAssembly} 程序集。");
                     }
 
                     foreach (var blackListMember in new[] { "Code", "FactoryMethod", "Static" })


### PR DESCRIPTION
### Motivation
- Adding `Microsoft.Xaml.Behaviors.Wpf` and a `TriggerAction`-based animation exposed behavior action types to loose XAML, creating a gadget that can invoke arbitrary methods (e.g. `Process.Start`) when attacker-controlled XAML is parsed. 
- Loose-XAML loading paths (`XamlReader.Parse` / `XamlReader.Load`) had no explicit checks to deny behavior assemblies, process-related types, or dangerous XAML members, so a pre-parse sanitizer is required to prevent remote XAML RCE.

### Description
- Add a pre-parse validator `ValidateSafeLooseXaml` to `PCL.Core/UI/IconManager.cs` and call it before invoking the WPF XAML parser, rejecting disallowed types, members, and assembly references. 
- Denylist in `IconManager` now includes `Process` and `ProcessStartInfo`, existing dangerous XAML types (`WebBrowser`, `Frame`, `ObjectDataProvider`, etc.), and assembly references starting with `Microsoft.Xaml.Behaviors`, and it blocks members like `Code`, `FactoryMethod`, and `Static`. 
- Use a `WpfXamlReader` alias for clarity when invoking the WPF parser and centralize loose-XAML checks into re-usable validation helpers. 
- Extend the existing launcher sanitizer in `Plain Craft Launcher 2/Modules/Base/ModBase.cs` to also reject `Process`/`ProcessStartInfo` and any references to the `Microsoft.Xaml.Behaviors` assembly during the `XamlXmlReader` scan.

### Testing
- Ran `git diff --check` which produced no whitespace or diff-check errors. 
- Attempted `dotnet build PCL.Core/PCL.Core.csproj -c Debug` but the `dotnet` SDK was not available in the execution environment so a full build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234a5bd91083228c17d694003ed183)

## Summary by Sourcery

在图标和启动器的 XML 处理流水线中加强对松散 XAML 的加载校验，以阻止基于行为（behavior）的 gadgets 以及其他危险的类型、成员和程序集。

Bug 修复：
- 在解析由攻击者控制的用于图标的松散 XAML 时，阻止执行不安全的行为 gadgets 和与进程相关的操作。
- 扩展启动器的 XML/XAML 清洗器，以拒绝与进程相关的类型、危险成员以及对 `Microsoft.Xaml.Behaviors` 的引用。

增强内容：
- 引入可复用的松散 XAML 验证辅助方法，并在图标加载路径中调用 WPF XAML 解析器之前应用这些验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden loose XAML loading in the icon and launcher XML pipelines to block behavior-based gadgets and other dangerous types, members, and assemblies.

Bug Fixes:
- Prevent execution of unsafe behavior gadgets and process-related actions when parsing attacker-controlled loose XAML for icons.
- Extend the launcher XML/XAML sanitizer to reject process-related types, dangerous members, and references to Microsoft.Xaml.Behaviors.

Enhancements:
- Introduce reusable loose-XAML validation helpers and apply them before invoking the WPF XAML parser in the icon loading path.

</details>