### PR TITLE
fix(WPF): deny WPF Behaviors namespaces in untrusted homepage XAML

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -3213,6 +3213,20 @@ public static class ModBase
             Replace("EventData=\"", "local:CustomEventService.EventData=\"").
             Replace("Property=\"EventType\"", "Property=\"local:CustomEventService.EventType\"").
             Replace("Property=\"EventData\"", "Property=\"local:CustomEventService.EventData\"");
+
+        // 自定义主页 XAML 被视为不受信任内容；禁止引用 WPF Behaviors 中可调用方法/改写属性的通用动作。
+        foreach (var blockedXamlNamespace in new[]
+                 {
+                     "Microsoft.Xaml.Behaviors",
+                     "Microsoft.Xaml.Behaviors.Core",
+                     "Microsoft.Xaml.Interactions.Core",
+                     "http://schemas.microsoft.com/xaml/behaviors"
+                 })
+        {
+            if (str.Contains(blockedXamlNamespace, StringComparison.OrdinalIgnoreCase))
+                throw new UnauthorizedAccessException($"不允许使用 {blockedXamlNamespace} 命名空间。");
+        }
+
         using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(str)))
         {
             // 类型检查


### PR DESCRIPTION
### Motivation
- The project added `Microsoft.Xaml.Behaviors.Wpf` and a `TriggerAction`-derived animation action (`RunAnimationAction`), which expands the XAML surface and enables generic behavior actions that can invoke methods from untrusted homepage XAML. 
- Prevent attacker-supplied homepage markup from referencing behavior types (e.g., `CallMethodAction`/`ChangePropertyAction`) that could enable arbitrary method/property invocation.

### Description
- Add a pre-parse namespace denylist in `ModBase.GetObjectFromXML(string)` that scans the XAML string and throws `UnauthorizedAccessException` when it contains any of `Microsoft.Xaml.Behaviors`, `Microsoft.Xaml.Behaviors.Core`, `Microsoft.Xaml.Interactions.Core`, or `http://schemas.microsoft.com/xaml/behaviors`.
- Preserve the existing compatibility rewrites and the `XamlXmlReader`-based type/member blacklist and continue to load via `XamlReader.Load` when checks pass.

### Testing
- Verified the denylist insertion with a local Python presence check that confirms the new namespace checks are present and would trigger the `UnauthorizedAccessException` path. 
- Ran repository checks including `git diff --check` to ensure no style/whitespace issues were introduced. 
- Could not run `dotnet build 'Plain Craft Launcher 2/Plain Craft Launcher 2.csproj' -c Debug -v:minimal` in this environment because `dotnet` is not installed, so compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234cbe6d98832280426b72ae24ec7d)

## Summary by Sourcery

错误修复：
- 当不受信任的主页 XAML 引用 `Microsoft.Xaml.Behaviors` 或相关行为命名空间时，在解析之前抛出 `UnauthorizedAccessException`，以防止加载这些 XAML。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent untrusted homepage XAML from loading when it references Microsoft.Xaml.Behaviors or related behaviors namespaces by throwing an UnauthorizedAccessException before parsing.

</details>