### PR TITLE
fix(java): 避免从攻击者可控制的位置检索 Java 运行时

### DIFF
--- a/PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs
@@ -36,7 +36,6 @@ public class DefaultPathsScanner : IJavaScanner
         {
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             Path.Combine(Basics.ExecutableDirectory, "PCL")
         };
 


### PR DESCRIPTION
### Motivation
- Prevent the launcher from recursively searching `Environment.SpecialFolder.UserProfile` for Java runtimes because scanning broad user-controlled profile paths can allow attacker-controlled `java.exe` layouts to be auto-discovered and treated as enabled runtimes.

### Description
- Removed `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` from the default search roots in `PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs`, leaving `ApplicationData`, `LocalApplicationData`, the launcher's `PCL` directory and the existing Program Files / drive root keyword searches and preserving the BFS scanner behavior.

### Testing
- Verified the change with `git diff --check` and `rg -n "SpecialFolder\.UserProfile" 'PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs'` to confirm the profile root was removed, and with `rg -n "ApplicationData|LocalApplicationData|ExecutableDirectory" 'PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs'` to confirm other roots remain; these checks passed; `dotnet test` could not be run in this environment because `dotnet` is not installed.

------

## Summary by Sourcery

错误修复：
- 通过将用户配置文件目录从 Java 扫描的默认搜索根目录中移除，避免从攻击者可控制的位置检测到 Java 运行时。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid detecting Java runtimes from attacker-controlled locations by removing the user profile directory from default search roots for Java scanning.

</details>