### PR TITLE
ci: 改善PR构建工作流

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,4 +35,3 @@ jobs:
     with:
       configuration: ${{ matrix.configuration }}
       architecture: ${{ matrix.architecture }}
-    secrets: inherit

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set Describe
         run: |


### PR DESCRIPTION
### Motivation
- Prevent PR-controlled code from receiving repository/org secrets or a persistent checkout token during reusable build runs, which could enable secret exfiltration via build-time scripts.

### Description
- Remove `secrets: inherit` from `.github/workflows/build-test.yml` so pull-request-triggered jobs no longer forward repository secrets into the called reusable workflow.
- Add `persist-credentials: false` to the `actions/checkout@v4` step in `.github/workflows/reusable-build.yml` to prevent the checkout token from being persisted to the runner environment.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch errors and it passed.
- Verified workflow content with `rg -n "secrets: inherit|persist-credentials: false|pull_request"` and confirmed `secrets: inherit` was removed and `persist-credentials: false` was added.
- Executed a short Python assertion that checks the `pull_request` trigger remains, `secrets: inherit` is absent, and `persist-credentials: false` is present, and the assertion passed.

------

## 由 Sourcery 提供的摘要

通过在可复用构建运行中限制机密信息和令牌的暴露，使 pull-request 构建工作流更加安全可靠。

CI：
- 在可复用构建工作流的 checkout 步骤中禁用凭据持久化，以避免在运行器上遗留 GitHub 令牌。
- 当由 `pull_request` 事件触发时，停止向可复用构建工作流传递仓库机密信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the pull-request build workflow by limiting secret and token exposure during reusable build runs.

CI:
- Disable credential persistence in the reusable build workflow checkout step to avoid leaving the GitHub token on the runner.
- Stop propagating repository secrets to the reusable build workflow when triggered from pull_request events.

</details>