### PR TITLE
fix: 将用户可控的 Minecraft 内容目录从自动 Java 发现中排除

### DIFF
--- a/PCL.Core.Test/JavaTest.cs
+++ b/PCL.Core.Test/JavaTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PCL.Core.Minecraft;
+using PCL.Core.Minecraft.Java;
 using PCL.Core.Minecraft.Java.Parser;
 using PCL.Core.Minecraft.Java.Scanner;
 using System;
@@ -39,6 +40,15 @@ namespace PCL.Core.Test
             Assert.IsTrue(secondScaned.Count == 0 || (secondScaned.Count > 0 && (await jas.SelectSuitableJavaAsync(new Version(1, 8, 0), new Version(30, 0, 0))).Length > 0));
             // Java 是否有重复
             Assert.IsFalse(secondScaned.GroupBy(x => x.Installation.JavaExePath).Any(x => x.Count() > 1));
+        }
+
+        [TestMethod]
+        public void TestDefaultJavaSearchKeywordsDoNotIncludeMinecraft()
+        {
+            // Minecraft folders under AppData are user-controlled game content and must not
+            // be automatic Java discovery roots. Java-specific child folder names are still
+            // covered by the other keywords.
+            Assert.IsFalse(JavaConsts.AllKeyworkds.Contains("minecraft", StringComparer.OrdinalIgnoreCase));
         }
     }
 }

--- a/PCL.Core/Minecraft/Java/JavaConsts.cs
+++ b/PCL.Core/Minecraft/Java/JavaConsts.cs
@@ -13,7 +13,7 @@ public class JavaConsts
     public static readonly string[] PossibleKeywords =
     [
         "environment", "env", "runtime", "x86_64", "amd64", "arm64",
-        "pcl", "hmcl", "baka", "minecraft"
+        "pcl", "hmcl", "baka"
     ];
 
     public static readonly string[] AllKeyworkds = [.. PossibleKeywords, .. MostPossibleKeywords];


### PR DESCRIPTION
### Motivation
- The Java scanner previously included the keyword `minecraft` among discovery keywords, which caused user-writable `.minecraft` and modpack folders under AppData to be treated as Java search roots and allowed attacker-controlled `java.exe` to be discovered and selected.

### Description
- Remove `"minecraft"` from the default Java discovery keyword set in `PCL.Core/Minecraft/Java/JavaConsts.cs` so `.minecraft` directories are no longer matched as scan roots.
- Add a regression unit test `TestDefaultJavaSearchKeywordsDoNotIncludeMinecraft` in `PCL.Core.Test/JavaTest.cs` that asserts `JavaConsts.AllKeyworkds` does not contain `"minecraft"`.
- Update test file imports so the new test references `JavaConsts` correctly.

### Testing
- Added a unit test `TestDefaultJavaSearchKeywordsDoNotIncludeMinecraft` intended to be run with `dotnet test`, but `dotnet` is not available in the execution environment so the test could not be executed here (test present in the tree).

------

## Summary by Sourcery

将用户可控的 Minecraft 内容目录从自动 Java 发现中排除，并添加回归测试以强制执行更新后的关键字集合。

Bug 修复：
- 防止自动 Java 发现机制将用户可写的 `.minecraft` 及相关 Minecraft 文件夹视为 Java 搜索根目录。

测试：
- 添加一个回归单元测试，确保默认的 Java 搜索关键字不再包含 `minecraft`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exclude user-controlled Minecraft content directories from automatic Java discovery and add a regression test to enforce the updated keyword set.

Bug Fixes:
- Prevent automatic Java discovery from treating user-writable `.minecraft` and related Minecraft folders as Java search roots.

Tests:
- Add a regression unit test ensuring the default Java search keywords no longer include `minecraft`.

</details>