### PR TITLE
fix(mod-main): 修复连续触发 Hint 导致位置发生偏移

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -348,11 +348,11 @@ public static class ModMain
                                     ModAnimation.aniSpeed;
                         ModAnimation.AniStart(new[]
                             {
-                                ModAnimation.AaX(doubleStack, slideSign * 12 - doubleStack.Margin.Left, 50,
+                                ModAnimation.AaX(doubleStack, alignRight ? doubleStack.Margin.Right + 12 : -12 - doubleStack.Margin.Left, 50,
                                     ease: new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8d, 50, 100, new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 100, new ModAnimation.AniEaseOutFluent()),
+                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
                                 ModAnimation.AaDouble(i =>
                                 {
                                     percent += (double)i;


### PR DESCRIPTION
>Generated by deepseek-v4-pro
<img width="253" height="82" alt="PixPin_2026-06-06_20-42-57" src="https://github.com/user-attachments/assets/4f803989-0812-4583-9d03-32d6647a283b" />
