### PR TITLE
fix(mod-main): 修复`弹出提示靠右显示`时收回动画的方向不正确

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -348,11 +348,11 @@ public static class ModMain
                                     ModAnimation.aniSpeed;
                         ModAnimation.AniStart(new[]
                             {
-                                ModAnimation.AaX(doubleStack, alignRight ? doubleStack.Margin.Right + 12 : -12 - doubleStack.Margin.Left, 50,
+                                ModAnimation.AaX(doubleStack, slideSign * 12 - doubleStack.Margin.Left, 50,
                                     ease: new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 100, new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, -slideSign * 8d, 50, 100, new ModAnimation.AniEaseOutFluent()),
+                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
                                 ModAnimation.AaDouble(i =>
                                 {
                                     percent += (double)i;

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -348,11 +348,11 @@ public static class ModMain
                                     ModAnimation.aniSpeed;
                         ModAnimation.AniStart(new[]
                             {
-                                ModAnimation.AaX(doubleStack, slideSign * 12 - doubleStack.Margin.Left, 50,
+                                ModAnimation.AaX(doubleStack, alignRight ? doubleStack.Margin.Right + 12 : -12 - doubleStack.Margin.Left, 50,
                                     ease: new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8d, 50, 100, new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
+                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 100, new ModAnimation.AniEaseOutFluent()),
+                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
                                 ModAnimation.AaDouble(i =>
                                 {
                                     percent += (double)i;
@@ -364,7 +364,7 @@ public static class ModMain
                                                                       new ModBase.MyColor(255d, 255d, 255d) *
                                                                       (1d - percent);
                                 }, 0.7d, 250),
-                                ModAnimation.AaX(doubleStack, slideSign * 50, 200, (int)Math.Round(delay),
+                                ModAnimation.AaX(doubleStack, -slideSign * 50, 200, (int)Math.Round(delay),
                                     new ModAnimation.AniEaseInFluent()),
                                 ModAnimation.AaOpacity(doubleStack, -1, 150, (int)Math.Round(delay)),
                                 ModAnimation.AaCode(() => doubleStackTag[0] = false,
@@ -433,7 +433,7 @@ public static class ModMain
                     ModAnimation.AniStart(
                         new[]
                         {
-                            ModAnimation.AaX(newHintControl, slideSign * 50, 200, (int)Math.Round(delay),
+                            ModAnimation.AaX(newHintControl, -slideSign * 50, 200, (int)Math.Round(delay),
                                 new ModAnimation.AniEaseInFluent()),
                             ModAnimation.AaOpacity(newHintControl, -1, 150, (int)Math.Round(delay)),
                             ModAnimation.AaCode(() => newHintTag[0] = false, (int)Math.Round(delay)),
@@ -467,7 +467,7 @@ public static class ModMain
             ModAnimation.AniStart(
                 new[]
                 {
-                    ModAnimation.AaX(control, hideSign * 50, 200, ease: new ModAnimation.AniEaseInFluent()),
+                    ModAnimation.AaX(control, -hideSign * 50, 200, ease: new ModAnimation.AniEaseInFluent()),
                     ModAnimation.AaOpacity(control, -1, 150, ease: new ModAnimation.AniEaseInFluent()),
                     ModAnimation.AaCode(() => controlTag[0] = false),
                     ModAnimation.AaHeight(control, -26, 100, ease: new ModAnimation.AniEaseOutFluent(), after: true),


### PR DESCRIPTION
> Generated by deepseek-v4-pro

## Summary by Sourcery

修正提示弹窗的水平方向动画，包括右对齐显示和全局隐藏行为。

错误修复：
- 修复当提示弹窗被配置为显示在右侧时，其收回动画方向不正确的问题。
- 对齐提示弹窗的抖动与隐藏动画，使其在关闭时始终沿远离显示侧的方向移动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct hint popup horizontal animation directions, including right-aligned display and global hide behavior.

Bug Fixes:
- Fix the hint popup retract animation direction when the popup is configured to appear on the right side.
- Align the shake and hide animations for hint popups so they move away from the display side consistently when dismissing.

</details>