### PR TITLE
fix(instance-setup): 修复部分配置未正常保存

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -182,14 +182,13 @@ public partial class PageInstanceSetup
     {
         if (ModAnimation.AniControlEnabled != 0)
             return;
-        if (o is not MyRadioBox radioBox) return;
+        if (o is not MyRadioBox { Tag: string tag }) return;
 
-        var parts = radioBox.Tag?.ToString()?.Split('/');
-        if (parts is null || parts.Length is not 2) return;
+        var slash = tag.IndexOf('/');
+        if (slash < 0) return;
 
-        var tag = parts[0];
-        var value = int.Parse(parts[1]);
-        ArgConfig<int> setting = tag switch
+        var value = int.Parse(tag[(slash + 1)..]);
+        ArgConfig<int> setting = tag[..slash] switch
         {
             "VersionRamType" => Config.Instance.MemorySolution,
             _ => throw new ArgumentOutOfRangeException()

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -107,6 +107,7 @@ public partial class PageInstanceSetup
             var ramType = Config.Instance.MemorySolution[PageInstanceLeft.McInstance.PathInstance];
             ((MyRadioBox)FindName("RadioRamType" + ramType)).Checked = true;
             SliderRamCustom.Value = Config.Instance.CustomMemorySize[PageInstanceLeft.McInstance.PathInstance];
+            RamType(ramType);
 
             // 服务器
             TextServerEnter.Text = Config.Instance.ServerToEnter[PageInstanceLeft.McInstance.PathInstance];
@@ -179,10 +180,21 @@ public partial class PageInstanceSetup
     // 将控件改变路由到设置改变
     private void RadioBoxChange(object o, ModBase.RouteEventArgs routeEventArgs)
     {
-        var sender = (MyRadioBox)o;
-        var gotCfg = sender.Tag.ToString().Split("/");
-        if (ModAnimation.AniControlEnabled == 0)
-            SetInstanceByTag(gotCfg[0], int.Parse(gotCfg[1]));
+        if (ModAnimation.AniControlEnabled != 0)
+            return;
+        if (o is not MyRadioBox radioBox) return;
+
+        var parts = radioBox.Tag?.ToString()?.Split('/');
+        if (parts is null || parts.Length is not 2) return;
+
+        var tag = parts[0];
+        var value = int.Parse(parts[1]);
+        ArgConfig<int> setting = tag switch
+        {
+            "VersionRamType" => Config.Instance.MemorySolution,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        setting[PageInstanceLeft.McInstance.PathInstance] = value;
     }
 
     private void TextBoxChange(object o, TextChangedEventArgs textChangedEventArgs)
@@ -212,26 +224,34 @@ public partial class PageInstanceSetup
 
     private void SliderChange(object o, bool user)
     {
-        var sender = (MySlider)o;
-        if (ModAnimation.AniControlEnabled == 0)
-            SetInstanceByTag(sender.Tag?.ToString(), sender.Value);
-    }
+        if (ModAnimation.AniControlEnabled != 0)
+            return;
+        if (o is not MySlider slider) return;
 
-    private static void ComboChange(MyComboBox sender, object e)
-    {
-        if (ModAnimation.AniControlEnabled == 0)
-            SetInstanceByTag(sender.Tag?.ToString(), sender.SelectedIndex);
-    }
-
-    private static void SetInstanceByTag(string tag, object value)
-    {
-        var path = PageInstanceLeft.McInstance.PathInstance;
-        switch (tag)
+        var tag = slider.Tag?.ToString();
+        var value = slider.Value;
+        ArgConfig<int> setting = tag switch
         {
-            case "VersionRamType": Config.Instance.MemorySolution[path] = (int)value; break;
-            case "VersionRamCustom": Config.Instance.CustomMemorySize[path] = (int)value; break;
-            case "VersionServerLoginRequire": Config.InstanceAuth.LoginRequirementSolution[path] = (int)value; break;
-        }
+            "VersionRamCustom" => Config.Instance.CustomMemorySize,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+    }
+
+    private void ComboChange(MyComboBox sender, object e)
+    {
+        if (ModAnimation.AniControlEnabled != 0)
+            return;
+
+        var tag = sender.Tag?.ToString();
+        var value = sender.SelectedIndex;
+        ArgConfig<int> setting = tag switch
+        {
+            "VersionServerLoginRequire" => Config.InstanceAuth.LoginRequirementSolution,
+            "VersionAdvanceRenderer" => Config.Instance.Renderer,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        setting[PageInstanceLeft.McInstance.PathInstance] = value;
     }
 
     private void CheckBoxChange(object sender, bool user)
@@ -1018,7 +1038,7 @@ public partial class PageInstanceSetup
         if (ModAnimation.AniControlEnabled != 0)
             return;
 
-        var args = (SelectionChangedEventArgs)e; // 转换事件参数
+        var args = e; // 转换事件参数
 
         if (!States.Hint.Renderer && ComboAdvanceRenderer.SelectedIndex != 0)
         {


### PR DESCRIPTION
close #3054

## Sourcery 总结

确保实例设置界面正确持久化与内存和渲染器相关的配置更改，并使控件事件处理程序与对应的配置映射精确对齐。

Bug 修复：
- 修复通过在重新加载时调用 RAM 类型处理程序，并将单选框变更直接映射到内存解决方案配置，导致 RAM 类型选择此前未被正确应用的问题。
- 修复自定义 RAM 大小滑块的更改未保存到实例特定的自定义内存大小配置中的问题。
- 修复服务器登录要求和渲染器选择下拉框未将其选定值持久化到对应配置项中的问题。

增强：
- 通过用针对每个受支持设置的类型安全映射替换通用的基于标签的分发器，并在动画处于活动状态时加入提前返回的保护，来简化和专门化控件变更处理程序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure instance setup UI correctly persists memory and renderer-related configuration changes and align control event handlers with specific config mappings.

Bug Fixes:
- Fix RAM type selection not being applied by invoking the RAM type handler on reload and mapping the radio box change directly to the memory solution config.
- Fix custom RAM size slider changes not being saved to the instance-specific custom memory size configuration.
- Fix server login requirement and renderer selection combo boxes not persisting their selected values to the corresponding configuration entries.

Enhancements:
- Simplify and specialize control change handlers by replacing the generic tag-based dispatcher with type-safe mappings for each supported setting and early-return guards when animations are active.

</details>