### PR TITLE
fix: resolve the request changes in #3031

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstance.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstance.cs
@@ -23,6 +23,11 @@ public class McInstance
         public bool IsLoaded;
 
         /// <summary>
+        /// 是否已初始化从 JAR 中读取 version.json。
+        /// </summary>
+        private bool _jsonVersionInited;
+
+        /// <summary>
         ///     是否为收藏的实例。
         /// </summary>
         public bool IsStar;
@@ -446,8 +451,8 @@ public class McInstance
                             foreach (var SubjsonNode in field["patches"].AsArray()) { var subjson = SubjsonNode.AsObject();
                                 subjsonList.Add(subjson); }
                             subjsonList.Sort((left, right) =>
-                                ModBase.Val((left["priority"] ?? "0").ToString()) <
-                                ModBase.Val((right["priority"] ?? "0").ToString()));
+                                (int)(ModBase.Val((left["priority"] ?? "0").ToString()) -
+                                      ModBase.Val((right["priority"] ?? "0").ToString())));
                             foreach (var Subjson in subjsonList)
                             {
                                 var id = (string)Subjson["id"];
@@ -542,9 +547,9 @@ public class McInstance
         {
             get
             {
-                if (!ModInstanceList._JsonVersion_jsonVersionInited)
+                if (!_jsonVersionInited)
                 {
-                    ModInstanceList._JsonVersion_jsonVersionInited = true;
+                    _jsonVersionInited = true;
                     do
                     {
                         try

--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstance.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstance.cs
@@ -451,8 +451,11 @@ public class McInstance
                             foreach (var SubjsonNode in field["patches"].AsArray()) { var subjson = SubjsonNode.AsObject();
                                 subjsonList.Add(subjson); }
                             subjsonList.Sort((left, right) =>
-                                (int)(ModBase.Val((left["priority"] ?? "0").ToString()) -
-                                      ModBase.Val((right["priority"] ?? "0").ToString())));
+                            {
+                                var leftVal = ModBase.Val((left["priority"] ?? "0").ToString());
+                                var rightVal = ModBase.Val((right["priority"] ?? "0").ToString());
+                                return leftVal.CompareTo(rightVal);
+                            });
                             foreach (var Subjson in subjsonList)
                             {
                                 var id = (string)Subjson["id"];

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModFolder.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModFolder.cs
@@ -134,9 +134,9 @@ public static class ModFolder
 
             ModBase.Log(cacheMcFolderList.Count + " 个自定义文件夹，" + originalMcFolderList.Count + " 个原始文件夹");
 
-            var unAdded = false;
             foreach (var newOriginalFolder in originalMcFolderList)
             {
+                var unAdded = true;
                 foreach (var cacheFolder in cacheMcFolderList)
                     if ((cacheFolder.Location ?? "") == (newOriginalFolder.Location ?? ""))
                     {
@@ -144,10 +144,10 @@ public static class ModFolder
                             cacheFolder.type = McFolder.Types.RenamedOriginal;
                         else
                             cacheFolder.type = McFolder.Types.Original;
-                        unAdded = true;
+                        unAdded = false;
                     }
 
-                if (!unAdded)
+                if (unAdded)
                     cacheMcFolderList.Add(newOriginalFolder); // 如果没有重命名，则添加当前文件夹
             }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModInstanceList.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModInstanceList.cs
@@ -39,8 +39,6 @@ public static class ModInstanceList
         }
     }
 
-    internal static bool _JsonVersion_jsonVersionInited;
-
     /// <summary>
     ///     当前按卡片分类的所有版本列表。
     /// </summary>


### PR DESCRIPTION
https://github.com/PCL-Community/PCL-CE/pull/3031?email_source=notifications&email_token=BP6CJL4AJW2RXXDXFG3MTC346O2FJA5CNFSNUABKM5UWIORPF5TWS5BNNB2WEL2QOVWGYUTFOF2WK43UKJSXM2LFO4XTINBUGE4DSMBQGEYKM4TFMFZW63VHMNXW23LFNZ2KKZLWMVXHJLDGN5XXIZLSL5RWY2LDNM#pullrequestreview-4441890010

## Summary by Sourcery

修复 Minecraft 实例和模组文件夹管理代码中的 JSON 版本初始化以及文件夹合并逻辑。

Bug 修复：
- 更正 JSON 版本初始化逻辑，使其按实例跟踪状态，而不是通过共享的静态标志进行跟踪。
- 修复补丁优先级排序，改为使用返回整数结果的数值比较方式。
- 解决自定义/原始模组文件夹合并逻辑问题，确保仅在缓存中不存在对应条目时才添加新的原始文件夹。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix JSON version initialization and folder merging logic in the Minecraft instance and mod folder management code.

Bug Fixes:
- Correct JSON version initialization to track state per instance instead of via a shared static flag.
- Fix patch priority sorting by using a numeric comparison that returns an integer result.
- Resolve custom/original mod folder merge logic so new original folders are added only when they do not already exist in the cache.

</details>