### PR TITLE
chore: remove `FodyWeavers.xml`

### DIFF
--- a/Plain Craft Launcher 2/FodyWeavers.xml
+++ b/Plain Craft Launcher 2/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
-</Weavers>


### PR DESCRIPTION
No Fody/Costura package reference exists in is project.

## Summary by Sourcery

Chores:
- 删除已废弃的 FodyWeavers.xml 文件，因为现在不再引用任何 Fody/Costura 包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Delete obsolete FodyWeavers.xml now that no Fody/Costura packages are referenced.

</details>