### PR TITLE
fix(crash): 修复错误分析读取自身启动日志时因文件锁定返回空 & 读不到 Java 信息

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
@@ -101,12 +101,13 @@ public sealed class MinecraftCrashController
             if (string.IsNullOrWhiteSpace(logFile) || !File.Exists(logFile)) return null;
             using var stream = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(stream);
-            var text = reader.ReadToEnd();
-            var start = text.IndexOf(key, StringComparison.OrdinalIgnoreCase);
-            if (start < 0) return null;
-            start += key.Length;
-            var end = text.IndexOf('[', start);
-            return (end < 0 ? text[start..] : text[start..end]).Trim();
+            while (reader.ReadLine() is { } line)
+            {
+                var index = line.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+                if (index < 0) continue;
+                return line[(index + key.Length)..].Trim();
+            }
+            return null;
         }
         catch
         {

--- a/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
@@ -99,7 +99,9 @@ public sealed class MinecraftCrashController
         {
             var logFile = LogWrapper.CurrentLogger.CurrentLogFiles.LastOrDefault();
             if (string.IsNullOrWhiteSpace(logFile) || !File.Exists(logFile)) return null;
-            var text = ModBase.ReadFile(logFile);
+            using var stream = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            var text = reader.ReadToEnd();
             var start = text.IndexOf(key, StringComparison.OrdinalIgnoreCase);
             if (start < 0) return null;
             start += key.Length;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复在日志文件被锁定时，崩溃分析无法读取启动日志的问题：通过使用共享的 `FileStream` 读取日志，而不是使用通用文件读取器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix crash analysis failing to read startup logs when the log file is locked, by reading via a shared FileStream instead of the generic file reader.

</details>