### PR TITLE
fix(mod-launch): .ToString -> .ToString()

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -3492,7 +3492,7 @@ public static class ModLaunch
         McLaunchLog("版本隔离：" + ((ModInstanceList.McMcInstanceSelected.PathIndie ?? "") ==
                                (ModInstanceList.McMcInstanceSelected.PathInstance ?? "")));
         McLaunchLog("HMCL 格式：" + ModInstanceList.McMcInstanceSelected.IsHmclFormatJson);
-        McLaunchLog("Java 信息：" + (mcLaunchJavaSelected is not null ? mcLaunchJavaSelected.ToString : "无可用 Java"));
+        McLaunchLog("Java 信息：" + (mcLaunchJavaSelected is not null ? mcLaunchJavaSelected.ToString() : "无可用 Java"));
         // McLaunchLog("环境变量：" & If(McLaunchJavaSelected IsNot Nothing, If(McLaunchJavaSelected.HasEnvironment, "已设置", "未设置"), "未设置"))
         McLaunchLog("Natives 文件夹：" + GetNativesFolder());
         McLaunchLog("");


### PR DESCRIPTION
谁写的这玩意，拖出去炖了😡

## Summary by Sourcery

错误修复：
- 通过对选定的 Java 实例调用 `ToString()`，而不是引用方法组，来纠正 Java 信息日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Java information logging by calling ToString() on the selected Java instance instead of referencing the method group.

</details>