### PR TITLE
fix(crash): 修复部分证据来源显示异常 & 略微加粗 Code 控件边框

### DIFF
--- a/PCL.Core/Minecraft/CrashAnalysis/Parsing/CrashFactExtractor.cs
+++ b/PCL.Core/Minecraft/CrashAnalysis/Parsing/CrashFactExtractor.cs
@@ -186,7 +186,9 @@ internal static class CrashFactFactory
         IReadOnlyDictionary<string, string>? properties = null,
         CrashFactVisibility visibility = CrashFactVisibility.Technical,
         CrashFactStrength? strength = null,
-        CrashFactScope? scope = null)
+        CrashFactScope? scope = null,
+        CrashLogKind? sourceKind = null,
+        string? sourceName = null)
     {
         return new CrashFact
         {
@@ -196,7 +198,10 @@ internal static class CrashFactFactory
             Strength = strength ?? _DefaultStrength(kind),
             Scope = scope ?? _DefaultScope(kind),
             Visibility = visibility,
-            Properties = properties ?? new Dictionary<string, string>()
+            Properties = properties ?? new Dictionary<string, string>(),
+            Evidence = sourceKind is not null
+                ? [new CrashFactEvidence { SourceKind = sourceKind.Value, SourceName = sourceName }]
+                : []
         };
     }
 

--- a/PCL.Core/Minecraft/CrashAnalysis/Parsing/Parsers/JavaCrashParser.cs
+++ b/PCL.Core/Minecraft/CrashAnalysis/Parsing/Parsers/JavaCrashParser.cs
@@ -50,13 +50,15 @@ internal sealed partial class JavaCrashParser : ICrashLogParser
         facts.Add(CrashFactFactory.CreateFromContext(
             CrashFactKind.JavaVersionDetected,
             javaInfo,
-            properties));
+            properties,
+            sourceKind: CrashLogKind.LauncherLog));
 
         if (_JavaVendorRegex().Match(javaInfo) is { Success: true } vendor)
             facts.Add(CrashFactFactory.CreateFromContext(
                 CrashFactKind.JavaVendorDetected,
                 vendor.Groups["vendor"].Value,
-                visibility: CrashFactVisibility.Technical));
+                visibility: CrashFactVisibility.Technical,
+                sourceKind: CrashLogKind.LauncherLog));
     }
 
     private static void _AppendManualDebugCrashFact(

--- a/PCL.Core/Minecraft/CrashAnalysis/Parsing/Parsers/MinecraftCrashReportParser.cs
+++ b/PCL.Core/Minecraft/CrashAnalysis/Parsing/Parsers/MinecraftCrashReportParser.cs
@@ -63,7 +63,8 @@ internal sealed partial class MinecraftCrashReportParser : ICrashLogParser
 
         facts.Add(CrashFactFactory.CreateFromContext(
             CrashFactKind.MinecraftVersionDetected,
-            minecraftVersion));
+            minecraftVersion,
+            sourceKind: CrashLogKind.LauncherLog));
     }
 
     private static void _AppendMinecraftVersionFact(

--- a/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashVisualFactory.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashVisualFactory.cs
@@ -509,7 +509,7 @@ public static class MinecraftCrashVisualFactory
         var border = new Border
         {
             Child = new MyScrollViewer { Content = box, MaxHeight = 220d, Margin = new Thickness(0, 4, 0, 8) },
-            BorderThickness = new Thickness(ModBase.GetWPFSize(1d)),
+            BorderThickness = new Thickness(ModBase.GetWPFSize(2d)),
             CornerRadius = new CornerRadius(5d),
         };
         border.SetResourceReference(Border.BackgroundProperty, "ColorBrush7");


### PR DESCRIPTION

<img width="633" height="159" alt="PixPin_2026-06-08_01-06-34" src="https://github.com/user-attachments/assets/558998d8-d957-4d4c-9dd4-a9678d09c155" />

<img width="656" height="420" alt="PixPin_2026-06-08_01-03-36" src="https://github.com/user-attachments/assets/4c3810f2-08c2-4606-bd59-c0214fbe4e7c" />

## Summary by Sourcery

为崩溃事实（crash facts）添加证据元数据，并略微增加崩溃界面中代码块的可视边框厚度。

New Features:
- 在从解析上下文创建崩溃事实时，附加崩溃证据元数据（来源类型和名称）。

Bug Fixes:
- 确保与运行时相关的崩溃事实能正确记录其证据来源，适用于 Java 启动器日志和 Minecraft 版本检测。

Enhancements:
- 加粗崩溃可视化界面中代码 UI 元素的边框，以提升可见度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Annotate crash facts with evidence metadata and slightly increase the visual border thickness of code blocks in crash UI.

New Features:
- Attach crash evidence metadata (source kind and name) when creating crash facts from parsing context.

Bug Fixes:
- Ensure runtime-related crash facts correctly record their evidence source for Java launcher logs and Minecraft version detection.

Enhancements:
- Thicken the border of code UI elements in the crash visualization to improve visibility.

</details>