### PR TITLE
feat(i18n): 非中国大陆地区禁用地区特供功能

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -679,14 +679,14 @@
 
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.Banned">This account appears to have been banned by Microsoft and cannot log in.</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.XboxNotRegistered">You have not registered an Xbox account. Please register one first and then log in.</sys:String>
-    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">The country or region of your network cannot log in to Microsoft accounts.&#x0a;Please use an accelerator or VPN.</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">Microsoft account login is not available in your country or region.&#x0a;Please check your network settings or try again later.</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.Underage.Message">The account is underage. You need to modify the date of birth before logging in.&#x0a;Is the age currently set on this account over 13?</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.Underage.AgeOver13">13 or older</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.Underage.AgeUnder13">12 or younger</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.ChangeBirthDate.Message">Please modify the account's date of birth on the opened webpage (change to at least 18 years old).&#x0a;Wait one minute after the modification is successful, then return to PCL and you can log in normally!</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.ChangeBirthDate.SupportMessage">Please modify the account's date of birth on the opened webpage (change to at least 18 years old).&#x0a;Wait one minute after the modification is successful, then return to PCL and you can log in normally!</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.TooManyRequests">Too many login attempts. Please wait a few minutes and try again!</sys:String>
-    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">Abnormal login attempts from this IP.&#x0a;If you are using a VPN or proxy, please turn it off or switch nodes and try again!</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">Abnormal login attempts from this IP.&#x0a;Please check your network settings or try again later.</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.NotPurchased">Unable to get account information. This account may not have purchased Minecraft: Java Edition, or its Xbox Game Pass may have expired.</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.PurchaseMinecraft">Purchase Minecraft</sys:String>
     <sys:String x:Key="Minecraft.Launch.Login.Microsoft.CreateProfile.Message">Please create a Minecraft player profile first, then log in again.</sys:String>
@@ -2783,7 +2783,7 @@
     <sys:String x:Key="Tools.GameLink.Agreement.PrivacyPolicyInfo">Learn how PCL CE handles your personal information.</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTerms">Natayark OpenID ToS</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.NatayarkTermsInfo">View Natayark OpenID terms of service.</sys:String>
-    <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I agree to strictly comply with relevant laws and regulations of Chinese Mainland and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I agree to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE lobby privacy policy and the Natayark OpenID terms of service.</sys:String>
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">By using the lobby feature, you agree to the following terms:&#x0A;&#x0A;I agree to comply with applicable laws and regulations and will not use the lobby feature for illegal or prohibited purposes.&#x0A;I agree to bear all risks associated with using the lobby feature.&#x0A;I acknowledge and agree that PCL CE collects processed device identifiers, Natayark ID, and other information, and may provide them to law enforcement when necessary.&#x0A;To protect minors' personal information, I confirm that I am at least 14 years old before using the lobby.&#x0A;&#x0A;Additionally, you must also agree to the PCL CE lobby privacy policy and the Natayark OpenID terms of service.</sys:String>
     <sys:String x:Key="Tools.GameLink.Agreement.Accept">I have read and agree</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Title">NAT type</sys:String>
     <sys:String x:Key="Tools.GameLink.Nat.Test">Click to test</sys:String>

--- a/PCL.Core/App/Localization/Languages/es-ES.xaml
+++ b/PCL.Core/App/Localization/Languages/es-ES.xaml
@@ -6,4 +6,25 @@
 
     <sys:String x:Key="Localization.Meta.Code">es-ES</sys:String>
     <sys:String x:Key="Localization.Meta.Name">Español (España)</sys:String>
+
+    <!-- Network / VPN overrides (remove VPN/accelerator references from zh-CN fallback) -->
+
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions">La página de inicio de sesión se abrirá automáticamente. Introduce el código de autorización {0} (se copiará automáticamente).&#x0a;&#x0a;Si tienes problemas de red, la página puede no cargar. Vuelve a intentarlo.&#x0a;También puedes abrir {1} en otro dispositivo e introducir el código manualmente.</sys:String>
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions.WithAutoFill">La página de inicio de sesión se abrirá automáticamente y el código de autorización se rellenará automáticamente.&#x0a;&#x0a;Si tienes problemas de red, la página puede no cargar. Vuelve a intentarlo.&#x0a;Si el código no se rellena automáticamente, pega este código de autorización {0} manualmente (se copiará automáticamente).&#x0a;También puedes abrir {1} en otro dispositivo e introducir el código manualmente.</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">El inicio de sesión con cuenta de Microsoft no está disponible en tu país o región.&#x0a;Verifica tu configuración de red o inténtalo de nuevo más tarde.</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">Intentos de inicio de sesión anómalos desde esta IP.&#x0a;Verifica tu configuración de red o inténtalo de nuevo más tarde.</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.Message">Error de inicio de sesión: se agotó el tiempo de conexión al servidor de autenticación.&#x0a;Por favor, verifica tu conexión de red.</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.DetailMessage">$Error de inicio de sesión: se agotó el tiempo de conexión al servidor de autenticación.&#x0a;Por favor, verifica tu conexión de red.&#x0a;Detalles:</sys:String>
+
+    <sys:String x:Key="Download.Comp.Hint.ModrinthUnreachable">No se puede conectar a Modrinth; solo se muestra el contenido de CurseForge. Los resultados pueden estar incompletos.&#x0a;Verifica tu conexión a internet e inténtalo de nuevo.</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.ModrinthUnavailable">No se puede conectar a Modrinth; solo se muestra el contenido de CurseForge. Los resultados de búsqueda pueden estar incompletos.&#x0a;Verifica tu conexión a internet e inténtalo de nuevo.</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.CurseForgeUnavailable">No se puede conectar a CurseForge; solo se muestra el contenido de Modrinth. Los resultados de búsqueda pueden estar incompletos.&#x0a;Verifica tu conexión a internet e inténtalo de nuevo.</sys:String>
+
+    <sys:String x:Key="Setup.Left.Feedback.Message">Por favor, revisa la lista de comentarios para problemas similares antes de enviar un nuevo comentario para evitar duplicados.</sys:String>
+
+    <!-- Legal text override (remove Chinese Mainland law references) -->
+
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">Al usar la función de lobby, aceptas los siguientes términos:&#x0A;&#x0A;Acepto cumplir con las leyes y reglamentos aplicables y no usar la función de lobby con fines ilegales o prohibidos.&#x0A;Acepto asumir todos los riesgos asociados con el uso de la función de lobby.&#x0A;Reconozco y acepto que PCL CE recopila identificadores de dispositivo procesados, Natayark ID y otra información, y puede proporcionarlos a las autoridades competentes cuando sea necesario.&#x0A;Para proteger la información personal de menores, confirmo que tengo al menos 14 años antes de usar el lobby.&#x0A;&#x0A;Además, también debes aceptar la política de privacidad del lobby de PCL CE y los términos de servicio de Natayark OpenID.</sys:String>
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/fr-FR.xaml
+++ b/PCL.Core/App/Localization/Languages/fr-FR.xaml
@@ -6,4 +6,25 @@
 
     <sys:String x:Key="Localization.Meta.Code">fr-FR</sys:String>
     <sys:String x:Key="Localization.Meta.Name">Français (France)</sys:String>
+
+    <!-- Network / VPN overrides (remove VPN/accelerator references from zh-CN fallback) -->
+
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions">La page de connexion s'ouvrira automatiquement. Entrez le code d'autorisation {0} (il sera copié automatiquement).&#x0a;&#x0a;En cas de problèmes réseau, la page peut ne pas se charger. Veuillez réessayer.&#x0a;Vous pouvez également ouvrir {1} sur un autre appareil et saisir le code manuellement.</sys:String>
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions.WithAutoFill">La page de connexion s'ouvrira automatiquement et le code d'autorisation sera rempli automatiquement.&#x0a;&#x0a;En cas de problèmes réseau, la page peut ne pas se charger. Veuillez réessayer.&#x0a;Si le code n'est pas rempli automatiquement, collez ce code d'autorisation {0} manuellement (il sera copié automatiquement).&#x0a;Vous pouvez également ouvrir {1} sur un autre appareil et saisir le code manuellement.</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">La connexion au compte Microsoft n'est pas disponible dans votre pays ou région.&#x0a;Veuillez vérifier vos paramètres réseau ou réessayer plus tard.</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">Tentatives de connexion anormales depuis cette adresse IP.&#x0a;Veuillez vérifier vos paramètres réseau ou réessayer plus tard.</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.Message">Échec de la connexion : le délai de connexion au serveur d'authentification a expiré.&#x0a;Veuillez vérifier votre connexion réseau.</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.DetailMessage">$Échec de la connexion : le délai de connexion au serveur d'authentification a expiré.&#x0a;Veuillez vérifier votre connexion réseau.&#x0a;Détails :</sys:String>
+
+    <sys:String x:Key="Download.Comp.Hint.ModrinthUnreachable">Impossible de se connecter à Modrinth ; seul le contenu de CurseForge est affiché. Les résultats peuvent être incomplets.&#x0a;Veuillez vérifier votre connexion internet et réessayer.</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.ModrinthUnavailable">Impossible de se connecter à Modrinth ; seul le contenu de CurseForge est affiché. Les résultats de recherche peuvent être incomplets.&#x0a;Veuillez vérifier votre connexion internet et réessayer.</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.CurseForgeUnavailable">Impossible de se connecter à CurseForge ; seul le contenu de Modrinth est affiché. Les résultats de recherche peuvent être incomplets.&#x0a;Veuillez vérifier votre connexion internet et réessayer.</sys:String>
+
+    <sys:String x:Key="Setup.Left.Feedback.Message">Veuillez vérifier la liste des commentaires pour des problèmes similaires avant de soumettre un nouveau retour afin d'éviter les doublons.</sys:String>
+
+    <!-- Legal text override (remove Chinese Mainland law references) -->
+
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">En utilisant la fonctionnalité de lobby, vous acceptez les conditions suivantes :&#x0A;&#x0A;J'accepte de me conformer aux lois et règlements applicables et de ne pas utiliser le lobby à des fins illégales ou interdites.&#x0A;J'accepte d'assumer tous les risques associés à l'utilisation du lobby.&#x0A;Je reconnais et accepte que PCL CE collecte les identifiants d'appareil traités, le Natayark ID et d'autres informations, et puisse les fournir aux autorités compétentes si nécessaire.&#x0A;Pour protéger les informations personnelles des mineurs, je confirme avoir au moins 14 ans avant d'utiliser le lobby.&#x0A;&#x0A;De plus, vous devez également accepter la politique de confidentialité du lobby PCL CE et les conditions d'utilisation de Natayark OpenID.</sys:String>
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/ja-JP.xaml
+++ b/PCL.Core/App/Localization/Languages/ja-JP.xaml
@@ -6,4 +6,25 @@
 
     <sys:String x:Key="Localization.Meta.Code">ja-JP</sys:String>
     <sys:String x:Key="Localization.Meta.Name">日本語（日本）</sys:String>
+
+    <!-- Network / VPN overrides (remove VPN/accelerator references from zh-CN fallback) -->
+
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions">ログインページが自動的に開きます。認証コード {0} を入力してください（自動的にコピーされます）。&#x0a;&#x0a;ネットワークに問題がある場合、ページが読み込まれないことがあります。その場合は再度お試しください。&#x0a;別のデバイスで {1} を開き、認証コードを手動で入力することもできます。</sys:String>
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions.WithAutoFill">ログインページが自動的に開き、認証コードが自動入力されます。&#x0a;&#x0a;ネットワークに問題がある場合、ページが読み込まれないことがあります。その場合は再度お試しください。&#x0a;自動入力されない場合は、認証コード {0} を手動で貼り付けてください（自動的にコピーされます）。&#x0a;別のデバイスで {1} を開き、認証コードを入力することもできます。</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">お住まいの国または地域では Microsoft アカウントにログインできません。&#x0a;ネットワーク設定を確認するか、しばらくしてから再度お試しください。</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">この IP からのログイン試行が異常です。&#x0a;ネットワーク設定を確認するか、しばらくしてから再度お試しください。</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.Message">ログインに失敗しました：ログインサーバーへの接続がタイムアウトしました。&#x0a;ネットワーク接続を確認してください。</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.DetailMessage">$ログインに失敗しました：ログインサーバーへの接続がタイムアウトしました。&#x0a;ネットワーク接続を確認してください。&#x0a;詳細：</sys:String>
+
+    <sys:String x:Key="Download.Comp.Hint.ModrinthUnreachable">Modrinth に接続できません。CurseForge のコンテンツのみ表示しています。結果が不完全な場合があります。&#x0a;ネットワーク接続を確認し、再度お試しください。</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.ModrinthUnavailable">Modrinth に接続できません。CurseForge のコンテンツのみ表示しています。検索結果が不完全な場合があります。&#x0a;ネットワーク接続を確認し、再度お試しください。</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.CurseForgeUnavailable">CurseForge に接続できません。Modrinth のコンテンツのみ表示しています。検索結果が不完全な場合があります。&#x0a;ネットワーク接続を確認し、再度お試しください。</sys:String>
+
+    <sys:String x:Key="Setup.Left.Feedback.Message">新しいフィードバックを送信する前に、重複を避けるために類似の問題がないかリストをご確認ください。</sys:String>
+
+    <!-- Legal text override (remove Chinese Mainland law references) -->
+
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">ロビー機能を使用することにより、以下の条件に同意したものとみなされます：&#x0A;&#x0A;私は適用される法律および規則を遵守し、ロビー機能を違法または禁止された目的で使用しないことに同意します。&#x0A;私はロビー機能の使用に伴うすべてのリスクを負うことに同意します。&#x0A;私は PCL CE が処理済みのデバイス識別子、Natayark ID などの情報を収集し、必要に応じて法執行機関に提供することを承知し、同意します。&#x0A;未成年者の個人情報を保護するため、ロビーを使用する前に自分が14歳以上であることを確認します。&#x0A;&#x0A;また、PCL CE ロビーのプライバシーポリシーおよび Natayark OpenID 利用規約にも同意する必要があります。</sys:String>
 </ResourceDictionary>

--- a/PCL.Core/App/Localization/Languages/zh-TW.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-TW.xaml
@@ -6,4 +6,25 @@
 
     <sys:String x:Key="Localization.Meta.Code">zh-TW</sys:String>
     <sys:String x:Key="Localization.Meta.Name">繁體中文（台灣）</sys:String>
+
+    <!-- Network / VPN overrides (remove VPN/accelerator references from zh-CN fallback) -->
+
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions">登入頁面將自動開啟，請在網頁中輸入授權碼 {0}（將自動複製）。&#x0a;&#x0a;如果網路環境不佳，網頁可能一直載入不出來，請重新嘗試。&#x0a;您也可以用其他裝置開啟 {1} 並輸入上述授權碼。</sys:String>
+    <sys:String x:Key="Launch.Account.LoginDialog.MicrosoftInstructions.WithAutoFill">登入頁面將自動開啟，授權碼將自動填入。&#x0a;&#x0a;如果網路環境不佳，網頁可能一直載入不出來，請重新嘗試。&#x0a;如果沒有自動填入，請在頁面內貼上此授權碼 {0}（將自動複製）。&#x0a;您也可以用其他裝置開啟 {1} 並輸入授權碼。</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.RegionBlocked">您所在的國家或地區無法登入 Microsoft 帳戶。&#x0a;請檢查您的網路設定或稍後再試。</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Microsoft.AbnormalIp">此 IP 的登入嘗試異常。&#x0a;請檢查您的網路設定或稍後再試。</sys:String>
+
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.Message">登入失敗：連線至登入伺服器逾時。&#x0a;請檢查您的網路連線是否正常。</sys:String>
+    <sys:String x:Key="Minecraft.Launch.Login.Auth.Timeout.DetailMessage">$登入失敗：連線至登入伺服器逾時。&#x0a;請檢查您的網路連線是否正常。&#x0a;詳細資訊：</sys:String>
+
+    <sys:String x:Key="Download.Comp.Hint.ModrinthUnreachable">無法連線至 Modrinth，目前僅顯示來自 CurseForge 的內容，結果可能不完整。&#x0a;請檢查您的網路連線並重試。</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.ModrinthUnavailable">無法連線至 Modrinth，目前僅顯示來自 CurseForge 的內容，搜尋結果可能不完整。&#x0a;請檢查您的網路連線並重試。</sys:String>
+    <sys:String x:Key="Download.Comp.List.Source.CurseForgeUnavailable">無法連線至 CurseForge，目前僅顯示來自 Modrinth 的內容，搜尋結果可能不完整。&#x0a;請檢查您的網路連線並重試。</sys:String>
+
+    <sys:String x:Key="Setup.Left.Feedback.Message">提交新的意見回饋前，請先檢查回饋列表中是否有類似的問題，以避免重複提交。</sys:String>
+
+    <!-- Legal text override (remove Chinese Mainland law references) -->
+
+    <sys:String x:Key="Tools.GameLink.Agreement.Body">使用大廳功能即表示您同意以下條款：&#x0A;&#x0A;本人同意遵守適用的法律法規，不會將大廳功能用於非法或禁止的目的。&#x0A;本人同意承擔使用大廳功能所產生的一切風險。&#x0A;本人知曉並同意 PCL CE 收集處理後的裝置識別碼、Natayark ID 及其他資訊，並可能在必要時提供給執法機關。&#x0A;為保護未成年人個人資訊，本人確認在使用大廳前已年滿十四歲。&#x0A;&#x0A;此外，您還需同意 PCL CE 大廳隱私權政策及 Natayark OpenID 服務條款。</sys:String>
 </ResourceDictionary>

--- a/PCL.Core/Minecraft/McFormatter.cs
+++ b/PCL.Core/Minecraft/McFormatter.cs
@@ -1,8 +1,34 @@
-﻿namespace PCL.Core.Minecraft;
+﻿using System;
+using PCL.Core.App.Localization;
+
+namespace PCL.Core.Minecraft;
 
 public static class McFormatter {
+    /// <summary>
+    ///     根据当前 UI 语言返回 Minecraft Wiki 的基础 URL。
+    /// </summary>
+    public static string GetWikiBaseUrl() {
+        var langCode = LocalizationService.CurrentLanguage.Code;
+        var prefix = langCode switch {
+            _ when langCode.StartsWith("zh") => "zh",
+            _ when langCode.StartsWith("ja") => "ja",
+            _ when langCode.StartsWith("fr") => "fr",
+            _ when langCode.StartsWith("es") => "es",
+            _ => null
+        };
+        return prefix is null
+            ? "https://minecraft.wiki"
+            : $"https://{prefix}.minecraft.wiki";
+    }
+
     public static string GetWikiUrlSuffix(string gameVersion) {
         var formattedVersion = FormatVersion(gameVersion);
+        var langCode = LocalizationService.CurrentLanguage.Code;
+
+        // 非 zh 语言使用搜索 URL
+        if (!langCode.StartsWith("zh")) {
+            return "/w/Special:Search?search=" + Uri.EscapeDataString("Java Edition " + formattedVersion);
+        }
 
         if (gameVersion.Contains('w')) return formattedVersion;
 

--- a/PCL.Core/Minecraft/McFormatter.cs
+++ b/PCL.Core/Minecraft/McFormatter.cs
@@ -10,10 +10,10 @@ public static class McFormatter {
     public static string GetWikiBaseUrl() {
         var langCode = LocalizationService.CurrentLanguage.Code;
         var prefix = langCode switch {
-            _ when langCode.StartsWith("zh") => "zh",
-            _ when langCode.StartsWith("ja") => "ja",
-            _ when langCode.StartsWith("fr") => "fr",
-            _ when langCode.StartsWith("es") => "es",
+            _ when langCode.StartsWith("zh", StringComparison.Ordinal) => "zh",
+            _ when langCode.StartsWith("ja", StringComparison.Ordinal) => "ja",
+            _ when langCode.StartsWith("fr", StringComparison.Ordinal) => "fr",
+            _ when langCode.StartsWith("es", StringComparison.Ordinal) => "es",
             _ => null
         };
         return prefix is null
@@ -26,8 +26,8 @@ public static class McFormatter {
         var langCode = LocalizationService.CurrentLanguage.Code;
 
         // 非 zh 语言使用搜索 URL
-        if (!langCode.StartsWith("zh")) {
-            return "/w/Special:Search?search=" + Uri.EscapeDataString("Java Edition " + formattedVersion);
+        if (!langCode.StartsWith("zh", StringComparison.Ordinal)) {
+            return $"/w/Special:Search?search={Uri.EscapeDataString($"Java Edition {formattedVersion}")}";
         }
 
         if (gameVersion.Contains('w')) return formattedVersion;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -1458,9 +1458,11 @@ public static class ModComp
         /// <summary>
         ///     翻译后的中文名。若数据库没有则等同于 RawName。
         /// </summary>
-        public string TranslatedName => DatabaseEntry is null || string.IsNullOrEmpty(DatabaseEntry.ChineseName)
+        public string TranslatedName => !RegionUtils.IsRestrictedFeatAllowed
             ? RawName
-            : DatabaseEntry.ChineseName;
+            : DatabaseEntry is null || string.IsNullOrEmpty(DatabaseEntry.ChineseName)
+                ? RawName
+                : DatabaseEntry.ChineseName;
 
         /// <summary>
         ///     中文描述。若为 Nothing 则没有。
@@ -2240,7 +2242,7 @@ public static class ModComp
         LogWrapper.Info("[Comp] 工程列表搜索原始文本：" + rawFilter);
 
         // 中文请求关键字处理
-        var isChineseSearch = RegexPatterns.HasChineseChar.IsMatch(rawFilter) && !string.IsNullOrEmpty(rawFilter);
+        var isChineseSearch = RegionUtils.IsRestrictedFeatAllowed && RegexPatterns.HasChineseChar.IsMatch(rawFilter) && !string.IsNullOrEmpty(rawFilter);
         if (isChineseSearch && (request.type == CompType.Mod || request.type == CompType.DataPack))
         {
             var searchEntries = new List<ModBase.SearchEntry<CompDatabaseEntry>>();
@@ -2505,7 +2507,7 @@ public static class ModComp
             foreach (var res in realResults)
             {
                 scores.Add(res,
-                    (res.WikiId > 0 ? 0.2 : 0) +
+                    (RegionUtils.IsRestrictedFeatAllowed && res.WikiId > 0 ? 0.2 : 0) +
                     Math.Log10(Math.Max(res.DownloadCount, 1) * getDownloadCountMult(res)) / 9);
                 searchEntries.Add(new ModBase.SearchEntry<CompProject>
                 {

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -10,6 +10,7 @@ using PCL.Core.App;
 using PCL.Core.App.Localization;
 using PCL.Core.Minecraft.ResourceProject;
 using PCL.Core.UI;
+using PCL.Core.Utils;
 using PCL.Core.Utils.Validate;
 using PCL.Network;
 using PCL.Network.Loaders;
@@ -46,7 +47,12 @@ public partial class PageDownloadCompDetail
 
         // 决定按钮显示
         BtnIntroWeb.Text = _project.FromCurseForge ? "CurseForge" : "Modrinth";
-        BtnIntroWiki.Visibility = _project.WikiId == 0 ? Visibility.Collapsed : Visibility.Visible;
+        BtnIntroWiki.Visibility = !RegionUtils.IsRestrictedFeatAllowed || _project.WikiId == 0
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+        BtnTranslate.Visibility = RegionUtils.IsRestrictedFeatAllowed
+            ? Visibility.Visible
+            : Visibility.Collapsed;
         RefreshFavoriteButton();
 
         ModAnimation.AniControlEnabled -= 1;

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -557,7 +557,8 @@ public static class ModDownloadLib
     public static void McUpdateLogShow(JsonNode versionJson)
     {
         var wikiName = McFormatter.GetWikiUrlSuffix(versionJson["id"].ToString());
-        ModBase.OpenWebsite("https://zh.minecraft.wiki/w/Special:Search?search=" + wikiName);
+        var wikiUrl = McFormatter.GetWikiBaseUrl() + wikiName;
+        ModBase.OpenWebsite(wikiUrl);
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -15,6 +15,7 @@ using PCL.Network.Loaders;
 using FileSystem = Microsoft.VisualBasic.FileSystem;
 using SearchOption = System.IO.SearchOption;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -2481,9 +2482,9 @@ public partial class PageInstanceCompResource : IRefreshable
 
                     modSearchName = modSearchName.Replace("++", "+").Replace("pti+Fine", "ptiFine");
                     // 显示
-                    if (currentCompType == ModComp.CompType.Schematic)
+                    if (currentCompType == ModComp.CompType.Schematic || !RegionUtils.IsRestrictedFeatAllowed)
                     {
-                        // 投影原理图文件不显示百科搜索选项
+                        // 投影原理图文件或非中文区域不显示百科搜索选项
                         if (modEntry.Url is null)
                             ModMain.MyMsgBox(contentLines.Join("\r\n"), modEntry.Name, Lang.Text("Instance.Resource.Item.Info.Return"));
                         else if (ModMain.MyMsgBox(contentLines.Join("\r\n"), modEntry.Name, Lang.Text("Instance.Resource.Item.Info.OpenWebsite"), Lang.Text("Instance.Resource.Item.Info.Return")) ==

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml
@@ -134,6 +134,7 @@
                         local:CustomEventService.EventType="打开网页"
                         Text="{DynamicResource Setup.About.SpecialThanks.SponsorMirror}" />
                     <local:MyListItem
+                        x:Name="ItemMcmod"
                         Grid.Row="1"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
@@ -142,6 +143,7 @@
                         IsHitTestVisible="False"
                         Title="{DynamicResource Setup.About.SpecialThanks.Name.Mcmod}" />
                     <local:MyButton
+                        x:Name="BtnMcmod"
                         Grid.Row="1"
                         Grid.Column="2"
                         Height="35"
@@ -221,6 +223,7 @@
                         </Image.Clip>
                     </Image>
                     <Image
+                        x:Name="ImgMcmod"
                         Grid.Row="1"
                         Margin="3"
                         Source="/Plain Craft Launcher 2;component/Images/Heads/wiki.png">

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -36,6 +36,14 @@ public partial class PageSetupAbout
         ItemAboutPcl.Info = ItemAboutPcl.Info.Replace("%VERSION%", ModBase.versionBaseName)
             .Replace("%VERSIONCODE%", ModBase.versionCode.ToString()).Replace("%BRANCH%", ModBase.versionBranchName)
             .Replace("%COMMIT_HASH%", ModBase.commitHashShort);
+
+        if (!RegionUtils.IsRestrictedFeatAllowed)
+        {
+            ItemMcmod.Visibility = Visibility.Collapsed;
+            BtnMcmod.Visibility = Visibility.Collapsed;
+            ImgMcmod.Visibility = Visibility.Collapsed;
+        }
+
         LoadContributersAsync();
     }
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -95,7 +95,7 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.Source.PreferOfficialWithFallback}" IsSelected="True" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Source.UseOfficial}" />
                         </local:MyComboBox>
-                        <TextBlock Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.FilenameFormat}"
+                        <TextBlock Grid.Row="2" x:Name="TextFilenameFormat" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.FilenameFormat}"
                                    Margin="0,0,25,0" />
                         <local:MyComboBox Grid.Row="2" x:Name="ComboDownloadTranslateV2" Grid.ColumnSpan="2"
                                           Tag="ToolDownloadTranslateV2" Grid.Column="1" SelectionChanged="ComboChange"
@@ -106,7 +106,7 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.FilenameFormat.Style3}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.FilenameFormat.Style4}" />
                         </local:MyComboBox>
-                        <TextBlock Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.ModManageStyle}"
+                        <TextBlock Grid.Row="4" x:Name="TextModManageStyle" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.ModManageStyle}"
                                    Margin="0,0,25,0" />
                         <local:MyComboBox Grid.Row="4" x:Name="ComboModLocalNameStyle" Grid.ColumnSpan="2"
                                           Tag="ToolModLocalNameStyle" Grid.Column="1" SelectionChanged="ComboChange"

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using PCL.Core.App;
 using PCL.Core.App.Localization;
+using PCL.Core.Utils;
 
 namespace PCL;
 
@@ -28,6 +29,15 @@ public partial class PageSetupGameManage
         ModAnimation.AniControlEnabled += 1;
         Reload();
         SliderLoad();
+
+        if (!RegionUtils.IsRestrictedFeatAllowed)
+        {
+            TextFilenameFormat.Visibility = Visibility.Collapsed;
+            ComboDownloadTranslateV2.Visibility = Visibility.Collapsed;
+            TextModManageStyle.Visibility = Visibility.Collapsed;
+            ComboModLocalNameStyle.Visibility = Visibility.Collapsed;
+        }
+
         ModAnimation.AniControlEnabled -= 1;
     }
 

--- a/Plain Craft Launcher 2/Resources/Custom.xml
+++ b/Plain Craft Launcher 2/Resources/Custom.xml
@@ -59,7 +59,7 @@
     <TextBlock TextWrapping="Wrap" Margin="0,0,0,10"
                Text="将按钮的 EventType 属性设为 打开网页，然后在 EventData 属性中写入网址，即可通过点击按钮打开网页。"/>
     <local:MyButton Width="140" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"
-                    Text="打开 Minecraft Wiki" EventType="打开网页" EventData="https://zh.minecraft.wiki/"/>
+                    Text="打开 Minecraft Wiki" EventType="打开网页" EventData="https://minecraft.wiki/"/>
     <TextBlock TextWrapping="Wrap" Margin="0,10,0,10"
                Text="或者将 EventType 属性改为 弹出窗口，然后在 EventData 属性中写入弹窗的标题与内容……"/>
     <local:MyButton Width="140" Height="35" HorizontalAlignment="Left" Padding="13,0,13,0"


### PR DESCRIPTION
This PR resolves #3068. Partially generated by GLM-5.1, reviewed manually.

## Summary by Sourcery

将与中国相关的内容和 Wiki 集成功能置于区域特性开关之后，并根据 UI 语言对 Minecraft Wiki URL 进行本地化。

新功能：
- 新增基于区域语言的 Minecraft Wiki 基础 URL 选择逻辑，并在打开版本更新日志页面时使用该 URL。

增强改进：
- 当不允许使用区域受限功能时，隐藏与中国相关的模组翻译、搜索行为以及 Mcmod/wiki 相关的 UI。
- 调整模组搜索评分和关键词处理，使与 wiki 相关的加权和中文搜索路径仅在允许的区域中生效。

文档：
- 更新自定义控件使用示例，将链接从中国特定子域改为通用的 Minecraft Wiki 主域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate China-specific content and wiki integrations behind a regional feature flag and localize Minecraft Wiki URLs based on UI language.

New Features:
- Add regional language-based Minecraft Wiki base URL selection and use it when opening version update log pages.

Enhancements:
- Hide Chinese-specific mod translation, search behaviour, and Mcmod/wiki-related UI when regional restricted features are not allowed.
- Adjust mod search scoring and keyword handling so wiki-related boosts and Chinese search paths only apply in allowed regions.

Documentation:
- Update the custom control usage example to link to the generic Minecraft Wiki domain instead of the Chinese-specific subdomain.

</details>

## Summary by Sourcery

将中国特定的模组翻译、Wiki 集成和搜索行为置于区域功能开关之后，并根据 UI 语言本地化 Minecraft Wiki 的 URL。

New Features:
- 引入 Minecraft Wiki 基础 URL 选择器，根据当前 UI 语言选择对应语言的子域名。
- 在打开版本更新日志页面时，使用本地化的 Minecraft Wiki URL，而不是硬编码的中文 Wiki URL。

Enhancements:
- 当区域受限功能被禁用时，隐藏中国特定的翻译选项、与 Mcmod/wiki 相关的控件以及 wiki 按钮。
- 将中文搜索处理以及基于 wiki 的评分加权限制在允许受限功能的区域内。
- 对于结构蓝图（schematic）资源以及在受限功能被禁用的区域，禁用 wiki 搜索选项。

Documentation:
- 更新自定义控件示例，使其链接到通用的 Minecraft Wiki 域名，而不是中国特定的子域名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate China-specific mod translation, wiki integration, and search behaviour behind a regional feature flag and localize Minecraft Wiki URLs based on UI language.

New Features:
- Introduce a Minecraft Wiki base URL selector that chooses language-specific subdomains based on the current UI language.
- Use localized Minecraft Wiki URLs when opening version update log pages instead of a hardcoded Chinese wiki URL.

Enhancements:
- Hide Chinese-specific translation options, Mcmod/wiki-related controls, and wiki buttons when regional restricted features are disabled.
- Restrict Chinese search handling and wiki-based scoring boosts in mod search to regions where restricted features are allowed.
- Suppress wiki search options for schematic resources and for regions where restricted features are disabled.

Documentation:
- Update the custom control example to link to the generic Minecraft Wiki domain instead of the Chinese-specific subdomain.

</details>