### PR TITLE
feat(launch): 添加禁用自动崩溃分析的设置项

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -534,6 +534,11 @@ public static partial class Config
         /// 禁用 LWJGL Unsafe Agent。
         /// </summary>
         [ConfigItem<bool>("LaunchAdvanceDisableLwjglUnsafeAgent", false)] public partial bool DisableLwjglUnsafeAgent { get; set; }
+
+        /// <summary>
+        /// 禁用自动崩溃分析。
+        /// </summary>
+        [ConfigItem<bool>("LaunchAdvanceDisableCrashAnalysis", false, ConfigSource.Local)] public partial bool DisableCrashAnalysis { get; set; }
         
         /// <summary>
         /// 渲染器。

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1669,6 +1669,8 @@
     <sys:String x:Key="Setup.Launch.Advanced.UseJavaExe.ToolTip">If the game window does not appear for a long time, try enabling this option. PCL will use java.exe to run the game, giving the game process standard input/output streams to avoid possible issues when logs are printed.&#x0a;&#x0a;Depending on the behavior of different Java distributions, java.exe may not support features that depend on operating system support, such as HDR colors. Therefore, do not enable this option if everything works normally.</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.DisableLwjglUnsafeAgent">Disable LWJGL Unsafe Agent</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip">Minecraft 26.1 uses LWJGL 3.4.1, which uses the FFM API to access native memory on JDK 25+. Due to JDK optimization limitations, this may cause severe performance issues in some cases.&#x0a;PCL uses LWJGL Unsafe Agent to fix this issue and avoid possible performance problems.&#x0a;There is generally no need to disable this option, but if you encounter additional issues, you can try temporarily disabling it for troubleshooting.&#x0a;&#x0a;This feature only takes effect when the LWJGL version is 3.4.1.</sys:String>
+    <sys:String x:Key="Setup.Launch.Advanced.DisableCrashAnalysis">Disable automatic crash analysis</sys:String>
+    <sys:String x:Key="Setup.Launch.Advanced.DisableCrashAnalysis.ToolTip">When enabled, the crash analysis page will no longer automatically appear when the game crashes.&#x0a;The crash analysis page can still be opened manually.</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.MoreInInstanceSetup">You can find more advanced launch options in instance settings.</sys:String>
 
     <!-- Setup.Launch.Misc -->

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1669,6 +1669,8 @@
     <sys:String x:Key="Setup.Launch.Advanced.UseJavaExe.ToolTip">如果遇到游戏窗口长时间不出现等故障可尝试启用此项，PCL 将使用 java.exe 来运行游戏，这样会让游戏进程拥有标准输入/输出流，以尽可能避免打印日志时出现问题。&#x0a;&#x0a;取决于不同 Java 发行版的行为，java.exe 可能无法使用 HDR 颜色等依赖操作系统支持的特性。因此，如果正常使用没有问题，请勿启用该选项。</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.DisableLwjglUnsafeAgent">禁用 LWJGL Unsafe Agent</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip">Minecraft 26.1 使用了 LWJGL 3.4.1，LWJGL 3.4.1 使用了 FFM API 以在 JDK 25+ 上访问原生内存。由于 JDK 优化能力限制，某些情况下这会产生严重的性能问题。&#x0a;PCL 会使用 LWJGL Unsafe Agent 修复这个问题，以解决可能存在的性能问题。&#x0a;一般情况下没有禁用该选项的必要，但如果你遇到了额外问题，也可以尝试暂时禁用该选项以排查错误。&#x0a;&#x0a;该功能仅会在 LWJGL 版本为 3.4.1 时生效。</sys:String>
+    <sys:String x:Key="Setup.Launch.Advanced.DisableCrashAnalysis">禁用自动崩溃分析</sys:String>
+    <sys:String x:Key="Setup.Launch.Advanced.DisableCrashAnalysis.ToolTip">启用后，游戏崩溃时将不再自动弹出崩溃分析页面。&#x0a;崩溃分析页面仍可通过手动方式打开。</sys:String>
     <sys:String x:Key="Setup.Launch.Advanced.MoreInInstanceSetup">你还可以在实例独立设置中找到更多高级启动选项。</sys:String>
 
     <!-- Setup.Launch.Misc -->

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModWatcher.cs
@@ -689,6 +689,7 @@ public static class ModWatcher
             // 崩溃分析
             WatcherLog(Lang.Text("Watcher.Crash.Detected"));
             ModMain.Hint(Lang.Text("Watcher.Crash.Hint"));
+            if (Config.Launch.DisableCrashAnalysis) return;
             ModBase.FeedbackInfo();
             ModBase.RunInNewThread(() =>
             {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -300,6 +300,8 @@
                             ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.UseJavaExe.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent}" x:Name="CheckAdvanceDisableLwjglUnsafeAgent" Tag="LaunchAdvanceDisableLwjglUnsafeAgent"  Change="CheckBoxChange"
                                           ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip}" />
+                        <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableCrashAnalysis}" x:Name="CheckAdvanceDisableCrashAnalysis" Tag="LaunchAdvanceDisableCrashAnalysis"  Change="CheckBoxChange"
+                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableCrashAnalysis.ToolTip}" />
                     </StackPanel>
                     <local:MyHint Text="{DynamicResource Setup.Launch.Advanced.MoreInInstanceSetup}" Margin="0,5,0,10" Theme="Blue" Grid.Row="9"
                                   Grid.ColumnSpan="2"

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -75,6 +75,7 @@ public partial class PageSetupLaunch
             CheckAdvanceGraphicCard.Checked = Config.Launch.SetGpuPreference;
             CheckAdvanceNoJavaw.Checked = Config.Launch.NoJavaw;
             CheckAdvanceDisableLwjglUnsafeAgent.Checked = Config.Launch.DisableLwjglUnsafeAgent;
+            CheckAdvanceDisableCrashAnalysis.Checked = Config.Launch.DisableCrashAnalysis;
             if (SystemInfo.IsArm64System)
             {
                 CheckAdvanceDisableJLW.Checked = true;
@@ -187,6 +188,7 @@ public partial class PageSetupLaunch
             case "LaunchAdvanceGraphicCard": Config.Launch.SetGpuPreference = (bool)value; break;
             case "LaunchAdvanceNoJavaw": Config.Launch.NoJavaw = (bool)value; break;
             case "LaunchAdvanceDisableLwjglUnsafeAgent": Config.Launch.DisableLwjglUnsafeAgent = (bool)value; break;
+            case "LaunchAdvanceDisableCrashAnalysis": Config.Launch.DisableCrashAnalysis = (bool)value; break;
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

在 Minecraft 启动期间新增一个可配置选项，用于禁用自动崩溃分析，并将其接入启动器设置界面和崩溃监视逻辑。

新功能：
- 引入本地存储的配置标志 `LaunchAdvanceDisableCrashAnalysis`，用于控制是否启用自动崩溃分析。
- 在高级启动设置页面中提供一个复选框，用于开启或关闭自动崩溃分析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable option to disable automatic crash analysis during Minecraft launch and wire it into the launcher settings UI and crash watcher logic.

New Features:
- Introduce a LaunchAdvanceDisableCrashAnalysis config flag stored locally for controlling automatic crash analysis.
- Expose a checkbox in the advanced launch settings page to toggle automatic crash analysis on or off.

</details>