### PR TITLE
chore: 不打包accountsx模组配置

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
@@ -110,7 +110,7 @@
                                 <local:MyCheckBox.Tag>
                                     <local:ExportOption
                                         Title="{DynamicResource Instance.Export.Option.ModSettings}"
-                                        Rules="config/|!config/jei/world/|!config/worldedit/|config/worldedit/worldedit.properties|!config/spark/|config/spark/config.json|defaultconfigs/|journeymap/config/|journeymap/server/|TrashSlotSaveState.json|customfov.txt|gg.essential.mod/|essential/|!essential/*/|!essential/*.jar*|!essential/screenshot-checksum-caches.json|!essential/microsoft_accounts.json|paragliderSettings.nbt|local/client_config.json|local/ftbl.json|local/client/sidebar_buttons.json|local/client/ftbutilities.cfg|local/client/ftblib.cfg|local/client/xencraft.cfg|liteloader.properties|default_reference.xml|CustomSkinLoader/CustomSkinLoader.json"
+                                        Rules="config/|!config/accountsx/|!config/jei/world/|!config/worldedit/|config/worldedit/worldedit.properties|!config/spark/|config/spark/config.json|defaultconfigs/|journeymap/config/|journeymap/server/|TrashSlotSaveState.json|customfov.txt|gg.essential.mod/|essential/|!essential/*/|!essential/*.jar*|!essential/screenshot-checksum-caches.json|!essential/microsoft_accounts.json|paragliderSettings.nbt|local/client_config.json|local/ftbl.json|local/client/sidebar_buttons.json|local/client/ftbutilities.cfg|local/client/ftblib.cfg|local/client/xencraft.cfg|liteloader.properties|default_reference.xml|CustomSkinLoader/CustomSkinLoader.json"
                                         DefaultChecked="True" />
                                 </local:MyCheckBox.Tag>
                             </local:MyCheckBox>


### PR DESCRIPTION
由于accountsx模组明文存储账号Token,不打包 "config/accountsx/" 可防止账号被盗

## Summary by Sourcery

构建：
- 更新实例导出打包规则，为了安全起见省略 `config/accountsx/` 目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update instance export packaging rules to omit the config/accountsx/ directory for security.

</details>