### PR TITLE
fix(i18n): “自动下载模组前置”缺少国际化

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1738,6 +1738,8 @@
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleFilename">Title shows file name, details show translated name</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt">Hide Quilt loader</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt.ToolTip">Hide Quilt from the community resource loader display.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies">Auto-check and install required dependencies when downloading mods</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies.ToolTip">When installing a mod, if missing required dependencies are detected, a list will be shown for confirmation before auto-downloading and installing them (can be cancelled during confirmation)</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.Title">Accessibility</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.GameUpdateNotice">Game update notification</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.ReleaseNotice">Release notification</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1738,6 +1738,8 @@
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleFilename">标题显示文件名，详情显示译名</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt">不显示 Quilt 加载器</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt.ToolTip">不在社区资源的加载器展示中显示 Quilt 加载器</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies">下载 Mod 时自动检查并安装必需前置</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies.ToolTip">安装 Mod 时，若检测到缺少必需前置，将列出前置列表供确认后自动下载安装（可在确认时取消）</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.Title">辅助功能</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.GameUpdateNotice">游戏更新提示</sys:String>
     <sys:String x:Key="Setup.GameManage.Accessibility.ReleaseNotice">正式版更新提示</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -126,7 +126,7 @@
                         <local:MyCheckBox Margin="0,2,0,4" Text="{DynamicResource Setup.GameManage.Community.HideQuilt}" ToolTip="{DynamicResource Setup.GameManage.Community.HideQuilt.ToolTip}"
                                           Grid.Row="0" Height="22" Grid.Column="0" Change="CheckBoxChange"
                                           x:Name="CheckDownloadIgnoreQuilt" Tag="ToolDownloadIgnoreQuilt" />
-                        <local:MyCheckBox Margin="0,2,0,4" Text="下载 Mod 时自动检查并安装必需前置" ToolTip="安装 Mod 时，若检测到缺少必需前置，将列出前置列表供确认后自动下载安装（可在确认时取消）"
+                        <local:MyCheckBox Margin="0,2,0,4" Text="{DynamicResource Setup.GameManage.Community.AutoInstallDependencies}" ToolTip="{DynamicResource Setup.GameManage.Community.AutoInstallDependencies.ToolTip}"
                                           Grid.Row="1" Height="22" Grid.Column="0" Change="CheckBoxChange"
                                           x:Name="CheckDownloadAutoInstallDependencies" Tag="ToolDownloadAutoInstallDependencies" />
                     </Grid>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 为此前未翻译的 i18n 资源文本“自动下载模组前置”提供英文和中文翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Provide English and Chinese translations for the previously untranslated "自动下载模组前置" text in the i18n resources.

</details>