### PR TITLE
fix(file): 缺少默认打开程序时使用记事本兜底

### DIFF
--- a/PCL.Core/App/Basics.cs
+++ b/PCL.Core/App/Basics.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -157,7 +158,19 @@ public static class Basics
             UseShellExecute = true,
             CreateNoWindow = true
         };
-        Process.Start(psi);
+        try
+        {
+            Process.Start(psi);
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == 1155 && File.Exists(path))
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "notepad.exe",
+                Arguments = $"\"{path}\"",
+                UseShellExecute = false
+            });
+        }
     }
     #endregion
 


### PR DESCRIPTION
This PR resolves #3086.

## Summary by Sourcery

Bug Fixes:
- 确保对于没有关联默认应用程序的文件，仍然可以通过在记事本中打开它们作为回退方案来打开。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure files without an associated default application are still opened by launching them in Notepad as a fallback.

</details>