### PR TITLE
refactor(crash): 取最后匹配项而非首次匹配

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/Crash/MinecraftCrashController.cs
@@ -101,13 +101,14 @@ public sealed class MinecraftCrashController
             if (string.IsNullOrWhiteSpace(logFile) || !File.Exists(logFile)) return null;
             using var stream = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(stream);
+            string? result = null;
             while (reader.ReadLine() is { } line)
             {
                 var index = line.IndexOf(key, StringComparison.OrdinalIgnoreCase);
                 if (index < 0) continue;
-                return line[(index + key.Length)..].Trim();
+                result = line[(index + key.Length)..].Trim();
             }
-            return null;
+            return result;
         }
         catch
         {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当存在多个匹配项时，确保崩溃日志解析器对某个键使用最后一个匹配的行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure crash log parser uses the last matching line for a key when multiple matches exist.

</details>