### PR TITLE
ci(help): remove help packaging workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -34,19 +34,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Update Help
-        continue-on-error: true
-        run: |
-          cd ..
-          git clone https://github.com/PCL-Community/PCL2CEHelp.git -b master --single-branch --depth 1
-          cd PCL2CEHelp
-          rm -f ./* || true
-          zip -r Help.zip . -x "./.*/*"
-          cp -f Help.zip "${{ github.workspace }}/Plain Craft Launcher 2/Resources/Help.zip"
-          cd ..
-          rm -rf PCL2CEHelp
-          cd "${{ github.workspace }}"
-
       - name: Build Project
         env:
           PCL_WRITE_SECRET: '1'


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 从 reusable-build GitHub Actions 工作流中移除 Help 更新和打包步骤

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Drop the Help update and packaging step from the reusable-build GitHub Actions workflow

</details>