### PR TITLE
refactor: remove origin issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/23-feature.yml.disabled
+++ b/.github/ISSUE_TEMPLATE/23-feature.yml.disabled
@@ -17,21 +17,15 @@ body:
       required: true
     - label: "我已知悉本项目的开发者均为不带薪志愿者，社区不对这类 Issue 的完成时间作出任何保证，并有足够的耐心等待社区开发者的处理，同时已知悉如果我作出催促、质问或类似的举动，这个 Issue 可能会被直接关闭"
       required: true
-- type: input
-  id: "yml-2"
-  attributes:
-    label: "官方版原 Issue 编号"
-    description: "如果这个 Issue 是从官方版转交过来的，请将原 Issue 标题旁的**编号**输入到下方预设文本的`#`后，不要输入任何其他非数字字符。**若不是，请清空下方输入框。**"
-    value: "- Meloong-Git/PCL2#"
 - type: textarea
-  id: "yml-3"
+  id: "yml-2"
   attributes:
     label: 描述
     description: "详细描述你想添加的功能具体是怎样的。"
   validations:
     required: true
 - type: textarea
-  id: "yml-4"
+  id: "yml-3"
   attributes:
     label: 原因
     description: "详细描述你为什么需要这项功能，这有助于开发者评估它的优先度。"

--- a/.github/ISSUE_TEMPLATE/24-improve.yml
+++ b/.github/ISSUE_TEMPLATE/24-improve.yml
@@ -25,21 +25,15 @@ body:
       required: true
     - label: "我已知悉社区不对这类 Issue 的完成时间作出任何保证，并有足够的耐心等待社区开发者的处理，同时已知悉如果我作出催促、质问或类似的举动，这个 Issue 可能会被直接关闭"
       required: true
-- type: input
-  id: "yml-2"
-  attributes:
-    label: "官方版原 Issue 编号"
-    description: "如果这个 Issue 是从官方版转交过来的，请将原 Issue 标题旁的**编号**输入到下方预设文本的`#`后，不要输入任何其他非数字字符。**若不是，请清空下方输入框。**"
-    value: "- Meloong-Git/PCL2#"
 - type: textarea
-  id: "yml-3"
+  id: "yml-2"
   attributes:
     label: 描述
     description: "详细描述具体需要优化哪些地方，要改成怎样的。"
   validations:
     required: true
 - type: textarea
-  id: "yml-4"
+  id: "yml-3"
   attributes:
     label: 原因
     description: "详细描述你为什么需要这项优化，这有助于开发者评估它的优先度。"


### PR DESCRIPTION
不再要求填写官方版 Issue

由于我们基本上不从官方版同步代码了，所以这东西完全没用（事实上也有不少人没有按要求正确填写）

## Summary by Sourcery

Documentation:
- 通过删除必填的官方 issue 编号字段并重新编号其余字段，简化改进类 issue 模板。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Simplify the improvement issue template by dropping the required official-issue number field and renumbering the remaining fields.

</details>