### PR TITLE
fix(request): 为 CurseForge 下载 CDN 应用 API Key

### DIFF
--- a/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
@@ -21,8 +21,10 @@ public static class RequestSigning
     {
         client.Version = HttpVersion.Version20;
         client.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
-        if (url.Contains("api.curseforge.com"))
+        if (url.Contains("api.curseforge.com") || url.Contains("edge.forgecdn.net") || url.Contains("mediafilez.forgecdn.net") || url.Contains("forgecdn.net"))
+        {
             client.Headers.Add("x-api-key", Secrets.CurseForgeAPIKey);
+        }
         var userAgent = !string.IsNullOrEmpty(customUserAgent)
             ? customUserAgent
             : useBrowserUserAgent

--- a/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
@@ -21,7 +21,10 @@ public static class RequestSigning
     {
         client.Version = HttpVersion.Version20;
         client.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
-        if (url.Contains("api.curseforge.com") || url.Contains("edge.forgecdn.net") || url.Contains("mediafilez.forgecdn.net") || url.Contains("forgecdn.net"))
+        Uri.TryCreate(url, UriKind.Absolute, out Uri parsedUri);
+        if (parsedUri.Host == "api.curseforge.com"
+            || parsedUri.Host == "edge.forgecdn.net"
+            || parsedUri.Host == "mediafilez.forgecdn.net")
         {
             client.Headers.Add("x-api-key", Secrets.CurseForgeAPIKey);
         }

--- a/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/RequestSigning.cs
@@ -21,10 +21,10 @@ public static class RequestSigning
     {
         client.Version = HttpVersion.Version20;
         client.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
-        Uri.TryCreate(url, UriKind.Absolute, out Uri parsedUri);
-        if (parsedUri.Host == "api.curseforge.com"
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri) 
+            && (parsedUri.Host == "api.curseforge.com"
             || parsedUri.Host == "edge.forgecdn.net"
-            || parsedUri.Host == "mediafilez.forgecdn.net")
+            || parsedUri.Host == "mediafilez.forgecdn.net"))
         {
             client.Headers.Add("x-api-key", Secrets.CurseForgeAPIKey);
         }


### PR DESCRIPTION
fixed #3107 

自 7 月 16 日起，CurseForge 下载 CDN 将开始强制要求使用 API Key 进行鉴权，对未携带 API Key 的请求将直接返回 401。

参阅：https://blog.curseforge.com/introducing-api-key-authentication-for-curseforge-file-downloads/

## Summary by Sourcery

错误修复：
- 在发送到 CurseForge CDN 主机的文件下载请求中附加 CurseForge API 密钥请求头，以避免出现 401 Unauthorized 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Attach the CurseForge API key header to file download requests sent to CurseForge CDN hosts to avoid 401 Unauthorized errors.

</details>