### PR TITLE
fix: 修复未自动删除下载失败/取消的实例

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModLoader.cs
@@ -769,16 +769,17 @@ public static class ModLoader
         {
             lock (lockState)
             {
-                if (State == ModBase.LoadState.Loading || State == ModBase.LoadState.Waiting)
-                    State = ModBase.LoadState.Aborted;
-                else
+                if (State != ModBase.LoadState.Loading && State != ModBase.LoadState.Waiting)
                     return;
             }
 
-            ModBase.RunInThread(() =>
+            foreach (var Loader in loaders) Loader.Abort();
+
+            lock (lockState)
             {
-                foreach (var Loader in loaders) Loader.Abort();
-            });
+                if (State == ModBase.LoadState.Loading || State == ModBase.LoadState.Waiting)
+                    State = ModBase.LoadState.Aborted;
+            }
         }
 
         /// <summary>

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -95,6 +95,10 @@ public static class FileDownloader
         };
 
         using var downloader = new DownloadService(configuration);
+        using var cancelReg = cancellationToken.Register(() =>
+        {
+            try { downloader.CancelAsync(); } catch {  } // 忽略
+        });
         var tcs = new TaskCompletionSource<bool>();
         void UpdateDownloadStat(DownloadProgressChangedEventArgs args)
         {
@@ -163,9 +167,17 @@ public static class FileDownloader
                 throw new IOException($"下载未产生任何文件：{localPath}");
             ModBase.Log($"[Download] 下载成功：{localPath}");
         }
+        catch (TaskCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
         catch (TaskCanceledException ex)
         {
             throw new TimeoutException($"下载超时（{url}）", ex);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -114,6 +114,8 @@ public class LoaderDownload : ModLoader.LoaderBase
         if (!file.Loaders.Contains(this))
             file.Loaders.Add(this);
 
+        if (State >= ModBase.LoadState.Finished)
+            return;
         Directory.CreateDirectory(Path.GetDirectoryName(file.LocalPath) ?? throw new IOException("下载路径无效"));
         if (file.Check?.canUseExistsFile == true && file.Check.Check(file.LocalPath) is null)
         {

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -3809,26 +3809,10 @@ public static class ModDownloadLib
                 ((ModLoader.LoaderBase)loader).State == ModBase.LoadState.Aborted)
             {
                 // 删除实例文件夹
-                if (Directory.Exists(
-                        $"{((ModLoader.LoaderCombo)loader).input}saves\\") ||
-                    Directory.Exists(
-                        $"{((ModLoader.LoaderCombo)loader).input}versions\\") ||
-                    Directory.Exists(
-                        $"{((ModLoader.LoaderCombo)loader).input}mods\\") ||
-                    File.Exists($"{((ModLoader.LoaderCombo)loader).input}server.dat"))
-                {
-                    ModBase.Log(
-                        $"[Download] 由于实例已被独立启动，不清理实例文件夹：{((ModLoader.LoaderCombo)loader).input}", ModBase.LogLevel.Developer);
-                }
-                else
-                {
-                    ModBase.Log(
-                        $"[Download] 由于下载失败或取消，清理实例文件夹：{((ModLoader.LoaderCombo)loader).input}", ModBase.LogLevel.Developer);
-                    var instancePath = (string)((ModLoader.LoaderCombo)loader).input;
-                    ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance))
-                        .InvalidateCache(instancePath);
+                ModBase.Log($"[Download] 由于下载失败或取消，清理实例文件夹：{((ModLoader.LoaderCombo)loader).input}", ModBase.LogLevel.Developer);
+                var instancePath = (string)((ModLoader.LoaderCombo)loader).input;
+                    ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance)).InvalidateCache(instancePath);
                     ModBase.DeleteDirectory(instancePath);
-                }
             }
         }
         catch (Exception ex)

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -7,6 +7,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
+using PCL.Core.App.Configuration.Storage;
 using PCL.Core.App.Localization;
 using PCL.Core.IO.Net.Http;
 using PCL.Core.Minecraft;
@@ -3822,7 +3824,10 @@ public static class ModDownloadLib
                 {
                     ModBase.Log(
                         $"[Download] 由于下载失败或取消，清理实例文件夹：{((ModLoader.LoaderCombo)loader).input}", ModBase.LogLevel.Developer);
-                    ModBase.DeleteDirectory((string)((ModLoader.LoaderCombo)loader).input);
+                    var instancePath = (string)((ModLoader.LoaderCombo)loader).input;
+                    ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance))
+                        .InvalidateCache(instancePath);
+                    ModBase.DeleteDirectory(instancePath);
                 }
             }
         }
@@ -3862,6 +3867,24 @@ public static class ModDownloadLib
         catch (Exception ex)
         {
             ModBase.Log(ex, "开始合并安装失败", ModBase.LogLevel.Feedback);
+            try
+            {
+                if (Directory.Exists(request.targetInstanceFolder))
+                {
+                    var files = Directory.GetFiles(request.targetInstanceFolder);
+                    var dirs = Directory.GetDirectories(request.targetInstanceFolder);
+                    if (files.Length <= 1 && dirs.Length == 0)
+                    {
+                        ((DynamicCacheConfigStorage)ConfigService.GetProvider(ConfigSource.GameInstance))
+                            .InvalidateCache(request.targetInstanceFolder);
+                        ModBase.DeleteDirectory(request.targetInstanceFolder);
+                    }
+                }
+            }
+            catch (Exception innerEx)
+            {
+                ModBase.Log(innerEx, "清理未完成的实例文件夹失败");
+            }
             return false;
         }
     }


### PR DESCRIPTION
close #3084
> Partly generated by deepseek-v4-pro

## Summary by Sourcery

确保在下载失败或被取消时，清理部分创建的游戏实例，并在各类加载器和文件下载器中更可靠地处理取消操作。

Bug Fixes:
- 始终删除下载失败或被取消的游戏实例文件夹，并使其对应的缓存配置项失效。
- 当在合并流程的早期阶段安装失败时，清理几乎为空的实例文件夹。
- 确保复合加载器正确传播中止请求，避免与状态机产生竞态条件。
- 使文件下载器能够正确响应外部取消令牌，并区分用户取消与超时。
- 防止已完成的下载加载器在结束后再次重新处理文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure failed or cancelled downloads clean up partially created game instances and handle cancellation more reliably across loaders and the file downloader.

Bug Fixes:
- Always delete failed or cancelled game instance folders and invalidate their cached configuration entries.
- Clean up nearly-empty instance folders when installation fails early in the merge process.
- Ensure composite loaders propagate abort requests correctly without racing the state machine.
- Make the file downloader respond properly to external cancellation tokens and distinguish user cancellation from timeouts.
- Prevent completed download loaders from reprocessing files after they have finished.

</details>