### PR TITLE
ci: upgrade checkout

### DIFF
--- a/.github/workflows/release-beta_publish.yml
+++ b/.github/workflows/release-beta_publish.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ github.event.release.prerelease }}
     steps:
       - name: Checkout all
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-stable_publish.yml
+++ b/.github/workflows/release-stable_publish.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Checkout all
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Describe
         run: |


### PR DESCRIPTION
## Summary by Sourcery

将用于发布和可重用构建工作流中的 GitHub Actions `checkout` 版本升级到最新的主版本。

CI：
- 在测试版发布工作流中，将 `actions/checkout` 从 `v4` 升级到 `v6`。
- 在稳定版发布工作流中，将 `actions/checkout` 从 `v4` 升级到 `v6`。
- 在可重用构建工作流中，将 `actions/checkout` 从 `v4` 升级到 `v6`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade GitHub Actions checkout version used in release and reusable build workflows to the latest major version.

CI:
- Bump actions/checkout from v4 to v6 in beta release publish workflow.
- Bump actions/checkout from v4 to v6 in stable release publish workflow.
- Bump actions/checkout from v4 to v6 in reusable build workflow.

</details>