### PR TITLE
fix(setup-game-manage): 修复自动安装前置功能无法关闭

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -223,8 +223,8 @@ public static class ModCompDependency
             var message = "以下必需前置无法解析：\n\n" +
                           string.Join("\n", result.Unresolved
                               .Select(dep => $"- {dep.Source} {dep.ProjectId}: {dep.Reason}"));
-            ModMain.MyMsgBox(message, "无法安装必需前置", button1: "确定", isWarn: true, forceWait: true);
-            return false;
+            var dialogResult = ModMain.MyMsgBox(message, "无法安装必需前置", button1: "继续下载", button2: "取消", isWarn: true, forceWait: true);
+            return dialogResult == 1;
         }
 
         if (result.ToInstall is { Count: > 0 })

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -223,8 +223,8 @@ public static class ModCompDependency
             var message = "以下必需前置无法解析：\n\n" +
                           string.Join("\n", result.Unresolved
                               .Select(dep => $"- {dep.Source} {dep.ProjectId}: {dep.Reason}"));
-            var dialogResult = ModMain.MyMsgBox(message, "无法安装必需前置", button1: "继续下载", button2: "取消", isWarn: true, forceWait: true);
-            return dialogResult == 1;
+            var selectedButton = ModMain.MyMsgBox(message, "无法安装必需前置", button1: "继续下载", button2: "取消", isWarn: true, forceWait: true);
+            return selectedButton == 1;
         }
 
         if (result.ToInstall is { Count: > 0 })

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -130,6 +130,7 @@ public partial class PageSetupGameManage
             case "ToolUpdateRelease": Config.Tool.ReleaseNotification = (bool)value; break;
             case "ToolUpdateSnapshot": Config.Tool.SnapshotNotification = (bool)value; break;
             case "ToolHelpChinese": Config.Tool.AutoChangeLanguage = (bool)value; break;
+            case "ToolDownloadAutoInstallDependencies": Config.Download.Comp.AutoInstallDependencies = (bool)value; break;
         }
     }
 


### PR DESCRIPTION
close #3112

## Summary by Sourcery

错误修复：
- 修复游戏管理设置中自动依赖安装选项对用户切换操作无响应的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the automatic dependency installation option not responding to user toggles in the game management settings.

</details>