### PR TITLE
fix(setup-launch): 修复自定义尺寸输入框不显示

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -60,6 +60,7 @@ public partial class PageSetupLaunch
             TextArgumentWindowHeight.Text = Config.Launch.GameWindowHeight.ToString();
             ComboMsAuthType.SelectedIndex = Config.Launch.LoginMsAuthType;
             ComboPreferredIpStack.SelectedIndex = (int)Config.Launch.PreferredIpStack;
+            WindowTypeUIRefresh();
 
             // 游戏内存
             ((MyRadioBox)FindName("RadioRamType" + Config.Launch.MemoryAllocationMode)).Checked = true;
@@ -153,6 +154,7 @@ public partial class PageSetupLaunch
             var senderTag = sender.Tag?.ToString();
             SetLaunchByTag(senderTag,
                 senderTag == "LaunchArgumentPriority" ? Convert.ToInt32(sender.SelectedValue) : sender.SelectedIndex);
+            if (senderTag == "LaunchArgumentWindowType") WindowTypeUIRefresh();
         }
     }
 
@@ -175,6 +177,8 @@ public partial class PageSetupLaunch
             case "LaunchArgumentVisible": Config.Launch.LauncherVisibility = (LauncherVisibility)(int)value; break;
             case "LaunchArgumentPriority": Config.Launch.ProcessPriority = (GameProcessPriority)(int)value; break;
             case "LaunchArgumentWindowType": Config.Launch.GameWindowMode = (GameWindowSizeMode)(int)value; break;
+            case "LaunchArgumentWindowWidth": Config.Launch.GameWindowWidth = int.Parse((string)value); break;
+            case "LaunchArgumentWindowHeight": Config.Launch.GameWindowHeight = int.Parse((string)value); break;
             case "LoginMsAuthType": Config.Launch.LoginMsAuthType = (int)value; break;
             case "LaunchPreferredIpStack": Config.Launch.PreferredIpStack = (JvmPreferredIpStack)(int)value; break;
             case "LaunchAdvanceRenderer": Config.Launch.Renderer = (int)value; break;


### PR DESCRIPTION
close #3118

## Summary by Sourcery

修复自定义游戏窗口尺寸控件在启动设置页面中不能正确反映和保存用户输入的问题。

Bug Fixes:
- 确保在页面重新加载以及窗口类型选择发生变化时刷新窗口类型 UI，使自定义尺寸输入字段按预期显示。
- 将输入字段中的自定义窗口宽度和高度值持久化保存到启动配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix custom game window size controls not reflecting and persisting user input in the launch setup page.

Bug Fixes:
- Ensure window type UI is refreshed on page reload and when the window type selection changes so custom size inputs become visible as expected.
- Persist custom window width and height values from the input fields into the launch configuration.

</details>