### PR TITLE
hotfix: fix 6 compilation errors in test project due to API refactoring

### DIFF
--- a/PCL.Core.Test/LoggerTest.cs
+++ b/PCL.Core.Test/LoggerTest.cs
@@ -14,9 +14,7 @@ public class LoggerTest
     public void TestSimpleWrite()
     {
         var loggerOps = new LoggerConfiguration(
-            Path.Combine(Path.GetTempPath(), "PCLTest", "Logger"),
-            LoggerSegmentMode.BySize,
-            10 * 1024 * 1024);
+            Path.Combine(Path.GetTempPath(), "PCLTest", "Logger"));
         var logger = new Logger(loggerOps);
         for (var i = 0; i < 10; i++)
             logger.Info($"Current we got {i}");
@@ -41,6 +39,6 @@ public class LoggerTest
             }));
         }
         await Task.WhenAll(tasks.ToArray());
-        logger.Dispose();
+        await logger.DisposeAsync();
     }
 }

--- a/PCL.Core.Test/Minecraft/McPing.cs
+++ b/PCL.Core.Test/Minecraft/McPing.cs
@@ -1,8 +1,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
-using System.Net.Sockets;
-using PCL.Core.Link;
+using PCL.Core.Link.McPing;
 
 namespace PCL.Core.Test.Minecraft;
 
@@ -12,13 +11,12 @@ public class McPingTest
     [TestMethod]
     public async Task PingTest()
     {
-        using var so = new Socket(SocketType.Stream, ProtocolType.Tcp);
-        using var ping2 = new McPing("mc.hypixel.net", 25565);
+        using var ping2 = McPingServiceFactory.CreateService("mc.hypixel.net", 25565);
         var res = await ping2.PingAsync();
         Assert.IsNotNull(res);
         Console.WriteLine(res.Description);
 
-        using var ping1 = new McPing("mc233.cn", 25565);
+        using var ping1 = McPingServiceFactory.CreateService("mc233.cn", 25565);
         res = await ping1.PingAsync();
         Assert.IsNotNull(res);
         Console.WriteLine(res.Description);
@@ -27,8 +25,8 @@ public class McPingTest
     [TestMethod]
     public async Task PingTestOld()
     {
-        using var ping = new McPing("127.0.0.1", 58383);
-        var res = await ping.PingOldAsync();
+        using var ping = McPingServiceFactory.CreateLegacyService("127.0.0.1", 58383);
+        var res = await ping.PingAsync();
         Assert.IsNotNull(res);
         Console.WriteLine(res.Description);
     }


### PR DESCRIPTION
LoggerConfiguration refactored to record type, LoggerSegmentMode enum removed. Logger upgraded from IDisposable to IAsyncDisposable. McPing class refactored to McPingServiceFactory + IMcPingService pattern.

Changes:
- LoggerTest.cs: Remove deleted LoggerSegmentMode.BySize param, Dispose -> DisposeAsync
- McPing.cs: McPing() -> McPingServiceFactory.CreateService(), remove unused Socket

Build: 0 warnings, 0 errors
Tests: 89/93 passed (4 failures are environment-related)

## Summary by Sourcery

使测试与最近的日志记录和 Minecraft ping API 重构保持一致，以恢复测试项目的编译。

Bug Fixes:
- 更新 McPing 测试以使用新的 `McPingServiceFactory` 和旧版服务 API。
- 调整 logger 测试以适配新的 `LoggerConfiguration` 结构以及 `Logger` 上的异步释放（async disposal）。

Tests:
- 刷新 McPing 和 Logger 测试，以便在更新后的核心 API 上成功编译并运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align tests with recent logging and Minecraft ping API refactors to restore compilation in the test project.

Bug Fixes:
- Update McPing tests to use the new McPingServiceFactory and legacy service APIs.
- Adjust logger tests to the new LoggerConfiguration shape and async disposal on Logger.

Tests:
- Refresh McPing and Logger tests to compile and run against the updated core APIs.

</details>