### PR TITLE
chore: 移除未使用的 NuGet 库

### DIFF
--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -47,7 +47,6 @@
     <ItemGroup>
         <!-- UI -->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
         <PackageReference Include="Wacton.Unicolour" Version="6.4.0" />
         <!-- 语言和系统特性 -->
@@ -62,7 +61,6 @@
         <PackageReference Include="YamlDotNet" Version="17.0.1" />
         <PackageReference Include="fNbt" Version="1.0.0" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
-        <PackageReference Include="protobuf-net" Version="3.2.56" />
         <!-- 网络 -->
         <PackageReference Include="Ae.Dns.Client" Version="3.1.0" />
         <PackageReference Include="Stun.Net" Version="9.0.1" />

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.csproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.csproj
@@ -65,21 +65,16 @@
         <DefineConstants>BETA</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="CacheCow.Client" Version="2.13.1" />
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="DotNet.Glob" Version="3.1.3" />
         <PackageReference Include="Downloader" Version="5.5.0" />
         <PackageReference Include="fNbt" Version="1.0.0" />
-        <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />
-        <PackageReference Include="IPNetwork2" Version="3.4.851" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
         <PackageReference Include="NAudio" Version="2.2.1" />
-        <PackageReference Include="System.Management" Version="10.0.3" />
+        <PackageReference Include="protobuf-net" Version="3.2.56" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Private.Uri" Version="4.3.2" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="TagLibSharp" Version="2.3.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\PCL.Core\PCL.Core.csproj" />


### PR DESCRIPTION
发布体积直接从 23.7 降到 17.4 了😰
前置: #3128

## 由 Sourcery 提供的摘要

从核心项目和启动器项目中移除未使用的 NuGet 包引用，以减小应用程序体积。

Enhancements:
- 通过从核心库和启动器项目中移除未使用的 NuGet 包，清理项目依赖。

Build:
- 通过从 .csproj 文件中裁剪未使用的 NuGet 包引用，简化项目构建配置。

Chores:
- 通过移除不必要的 NuGet 库执行依赖清理，以减小发布产物的体积。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused NuGet package references from core and launcher projects to reduce application size.

Enhancements:
- Clean up project dependencies by removing unused NuGet packages from the core library and launcher projects.

Build:
- Simplify project build configuration by trimming unused NuGet package references from .csproj files.

Chores:
- Perform dependency housekeeping to reduce published artifact size by removing unnecessary NuGet libraries.

</details>