### PR TITLE
chore(bump): 2.15.0-beta.3

### DIFF
--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -3,8 +3,8 @@
   "version": {
     "base": "2.15.0",
     "upstream": "2.12.1",
-    "suffix": "beta.2",
-    "code": 516
+    "suffix": "beta.3",
+    "code": 517
   },
   "licenses": [
     {


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

构建：
- 将启动器元数据版本更新为 2.15.0-beta.3。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update launcher metadata version to 2.15.0-beta.3.

</details>