### PR TITLE
chore(tool-test): Collapsed `BtnCrash_Click`

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2736,14 +2736,6 @@
     <sys:String x:Key="Tools.Test.Luck.Rating10">No way!</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating0">(It's on a 0-100 scale)</sys:String>
 
-    <!-- Tools.Test.Crash -->
-
-    <sys:String x:Key="Tools.Test.Crash.Title">Crash test</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ToolTip">Clicking this will crash the launcher directly. Don't click unless you know what you're doing. No issues or problems caused by this will be accepted, and related issues will be closed immediately.</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ConfirmTitle">Crash confirmation</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">You probably clicked the wrong button. Confirm below if you really meant to do this.</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ManualCrash">Manual crash</sys:String>
-
     <!-- Tools.Test.LaunchCount -->
 
     <sys:String x:Key="Tools.Test.LaunchCount.Title">View launch count</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2736,6 +2736,10 @@
     <sys:String x:Key="Tools.Test.Luck.Rating10">No way!</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating0">(It's on a 0-100 scale)</sys:String>
 
+    <!-- Tools.Test.Crash -->
+    <sys:String x:Key="Tools.Test.Crash.Title">Crash test</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ManualCrash">Manual crash</sys:String>
+
     <!-- Tools.Test.LaunchCount -->
 
     <sys:String x:Key="Tools.Test.LaunchCount.Title">View launch count</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2736,14 +2736,6 @@
     <sys:String x:Key="Tools.Test.Luck.Rating10">不会吧！</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating0">（是百分制哦）</sys:String>
 
-    <!-- Tools.Test.Crash -->
-
-    <sys:String x:Key="Tools.Test.Crash.Title">崩溃测试</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ToolTip">点这个按钮会让启动器直接崩掉，没事别点，造成的一切问题均不受理，相关 issue 会被直接关闭</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ConfirmTitle">崩溃确认</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ConfirmMessage">你一定是点错了，如果没错请在下方确认</sys:String>
-    <sys:String x:Key="Tools.Test.Crash.ManualCrash">手动崩溃</sys:String>
-
     <!-- Tools.Test.LaunchCount -->
 
     <sys:String x:Key="Tools.Test.LaunchCount.Title">查看启动计数</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2736,6 +2736,10 @@
     <sys:String x:Key="Tools.Test.Luck.Rating10">不会吧！</sys:String>
     <sys:String x:Key="Tools.Test.Luck.Rating0">（是百分制哦）</sys:String>
 
+    <!-- Tools.Test.Crash -->
+    <sys:String x:Key="Tools.Test.Crash.Title">崩溃测试</sys:String>
+    <sys:String x:Key="Tools.Test.Crash.ManualCrash">手动崩溃</sys:String>
+
     <!-- Tools.Test.LaunchCount -->
 
     <sys:String x:Key="Tools.Test.LaunchCount.Title">查看启动计数</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
@@ -14,9 +14,6 @@
                                     Click="BtnClear_Click" />
                     <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Luck.Title}" Margin="0,0,15,15"
                                     Click="BtnLuck_Click" />
-                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Crash.Title}"
-                                    ToolTip="{DynamicResource Tools.Test.Crash.ToolTip}" ColorType="Red"
-                                    Margin="0,0,15,15" Click="BtnCrash_Click" />
                     <local:MyButton MinWidth="120" Text="{DynamicResource Tools.Test.Shortcut.Title}"
                                     ToolTip="{DynamicResource Tools.Test.Shortcut.ToolTip}" Margin="0,0,15,15"
                                     Click="BtnCreateShortcut_Click" />

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
@@ -14,9 +14,10 @@
                                     Click="BtnClear_Click" />
                     <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Luck.Title}" Margin="0,0,15,15"
                                     Click="BtnLuck_Click" />
-                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Crash.Title}" Visibility="Collapsed"
+                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Crash.Title}"
                                     ToolTip="{DynamicResource Tools.Test.Crash.ManualCrash}" ColorType="Red"
-                                    Margin="0,0,15,15" Click="BtnCrash_Click" />
+                                    Margin="0,0,15,15" Click="BtnCrash_Click"
+                                    Visibility="Collapsed" x:Name="BtnCrash" />
                     <local:MyButton MinWidth="120" Text="{DynamicResource Tools.Test.Shortcut.Title}"
                                     ToolTip="{DynamicResource Tools.Test.Shortcut.ToolTip}" Margin="0,0,15,15"
                                     Click="BtnCreateShortcut_Click" />

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
@@ -14,6 +14,9 @@
                                     Click="BtnClear_Click" />
                     <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Luck.Title}" Margin="0,0,15,15"
                                     Click="BtnLuck_Click" />
+                    <local:MyButton MinWidth="100" Text="{DynamicResource Tools.Test.Crash.Title}" Visibility="Collapsed"
+                                    ToolTip="{DynamicResource Tools.Test.Crash.ManualCrash}" ColorType="Red"
+                                    Margin="0,0,15,15" Click="BtnCrash_Click" />
                     <local:MyButton MinWidth="120" Text="{DynamicResource Tools.Test.Shortcut.Title}"
                                     ToolTip="{DynamicResource Tools.Test.Shortcut.ToolTip}" Margin="0,0,15,15"
                                     Click="BtnCreateShortcut_Click" />

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -586,6 +586,12 @@ public partial class PageToolsTest
         if (!string.IsNullOrEmpty(str2)) url += $"/{str2}";
         return url;
     }
+    
+    private void BtnCrash_Click(object sender, MouseButtonEventArgs e)
+    {
+        throw new Exception(Lang.Text("Tools.Test.Crash.ManualCrash"));
+    }
+
 
     private int GetHeadSize() => CmbHeadSize.SelectedIndex switch
     {

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -586,12 +586,11 @@ public partial class PageToolsTest
         if (!string.IsNullOrEmpty(str2)) url += $"/{str2}";
         return url;
     }
-    
+
     private void BtnCrash_Click(object sender, MouseButtonEventArgs e)
     {
         throw new Exception(Lang.Text("Tools.Test.Crash.ManualCrash"));
     }
-
 
     private int GetHeadSize() => CmbHeadSize.SelectedIndex switch
     {

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -37,6 +37,9 @@ public partial class PageToolsTest
         BtnSelectSkin.Click += BtnSelectSkin_Click;
         CmbHeadSize.SelectionChanged += CmbHeadSize_SelectionChanged;
         Loaded += (_, _) => MeLoaded();
+        #if DEBUG
+        BtnCrash.Visibility = Visibility.Visible;
+        #endif
     }
 
     private void MeLoaded()

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -587,14 +587,6 @@ public partial class PageToolsTest
         return url;
     }
 
-    private void BtnCrash_Click(object sender, MouseButtonEventArgs e)
-    {
-        if (ModMain.MyMsgBoxInput(Lang.Text("Tools.Test.Crash.ConfirmTitle"),
-                Lang.Text("Tools.Test.Crash.ConfirmMessage"), Lang.Text("Common.Action.Confirm"),
-                hintText: "\"sURe\".ToUpper()", isWarn: true) ==
-            "SURE") throw new Exception(Lang.Text("Tools.Test.Crash.ManualCrash"));
-    }
-
     private int GetHeadSize() => CmbHeadSize.SelectedIndex switch
     {
         0 => 64,


### PR DESCRIPTION
## Summary by Sourcery

增强内容：
- 从工具测试页面中移除用于手动触发崩溃的 `BtnCrash_Click` 事件处理程序及其相关的用户界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the BtnCrash_Click handler and associated UI for manually triggering a crash from the tools test page.

</details>