### PR TITLE
fix(download-install): 修复安装 Quilt 加载器时选择 Fabric API 版本导致崩溃

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -1805,7 +1805,7 @@ public partial class PageDownloadInstall
                 if (!IsFabricApiCompatible(version))
                     continue;
                 PanFabricApi.Children.Add(
-                    ModDownloadLib.FabricApiDownloadListItem(version, (a, b) => this.Fabric_Selected((dynamic)a, b)));
+                    ModDownloadLib.FabricApiDownloadListItem(version, (a, b) => this.FabricApi_Selected((dynamic)a, b)));
             }
 
             // 自动选择 Fabric API


### PR DESCRIPTION
close #3141

## Summary by Sourcery

Bug Fixes:
- 解决在安装 Quilt 加载器时选择 Fabric API 版本会触发的崩溃问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve a crash triggered when choosing a Fabric API version while installing the Quilt loader.

</details>