### PR TITLE
fix(mod-download-lib): 修复安装 LabyMod 时因 JsonNode 重复挂载导致的崩溃

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -4651,7 +4651,7 @@ public static class ModDownloadLib
                 var regexMatchResult = Library["name"].ToString().RegexSeek(RegexPatterns.CatchLwjglInLib);
                 if (regexMatchResult is null ||
                     !isolatedLibraries.Contains(new KeyValuePair<string, bool>(regexMatchResult, true)))
-                    outputLibraries.Add(Library);
+                    outputLibraries.Add(Library.DeepClone());
             }
 
             foreach (var Library in labyModLib["libraries"].AsArray())


### PR DESCRIPTION
close #3111

## Summary by Sourcery

Bug Fixes:
- 修复了在安装 LabyMod 过程中，由于在聚合库时重复挂载同一个 JsonNode 实例而导致的崩溃问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a crash during LabyMod installation caused by repeatedly mounting the same JsonNode instance when aggregating libraries.

</details>