### PR TITLE
fix(mod-base): 修复浏览器配置错误时未观测到的异步异常

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -2821,7 +2821,7 @@ public static class ModBase
             {
                 UseShellExecute = true,
             };
-            _ = Task.Run(() => Process.Start(psi));
+            Process.Start(psi);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- 修复 #2993：`OpenWebsite` 在浏览器配置错误时抛出「未观测到的异步任务异常」，未走既有降级提示
- 将 `Process.Start` 从 `Task.Run` 中移出，改为同步调用，使外层 `try/catch` 能正确捕获失败并显示「无法打开网页」弹窗（与 `ShellOnly` 一致）

## 原因说明

`Process.Start` 在 `Task.Run` 后台执行时，异常不会被外层 `catch` 捕获，最终由 .NET 以未观测异步异常形式上报。

## 复现步骤（修复前）

在 Windows 11 上临时禁用 Edge 作为 HTTPS 处理程序：

```powershell
$edge = "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
Rename-Item $edge "$edge.bak"
```

1. 启动 PCL CE
2. **启动** → 实例设置 → 模组 → 详情 → 点击 **🌐 MC 百科**
3. 等待片刻，出现「未观测到的异步任务异常」

**修复前截图：**

![修复前](https://i.imgur.com/xOIimLj.png)

测毕恢复：

```powershell
Rename-Item "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe.bak" $edge
```

## 修复后行为

相同复现条件下：

- 显示「无法打开网页」提示，并将网址复制到剪贴板
- 不再出现「未观测到的异步任务异常」

**修复后截图：**

![修复后](https://i.imgur.com/WxBPRX0.png)

## Test plan

- [x] 按上述步骤复现修复前问题（Release 版）
- [x] 应用本 PR 后重新编译 Debug x64，复现条件下显示降级提示而非未观测异常
- [x] 恢复 Edge 后点击「前往官网」可正常打开网页
- [x] `dotnet build -p:Configuration=Debug -p:Platform=x64` 通过（0 错误）

Close #2993

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 修复在由于浏览器配置问题导致打开网站失败时出现未被观察到的异步异常的问题，方式是让外层错误处理来捕获该失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix unobserved async exceptions when opening a website fails due to browser configuration issues by letting the outer error handling capture the failure.

</details>