### PR TITLE
fix(mod-main): 修复提示右对齐时被右下角附加按钮遮挡 (#3147)

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml
+++ b/Plain Craft Launcher 2/FormMain.xaml
@@ -224,7 +224,7 @@
                 <StackPanel x:Name="PanHint" IsHitTestVisible="False" UseLayoutRounding="True"
                             SnapsToDevicePixels="True" HorizontalAlignment="Left" VerticalAlignment="Bottom"
                             Margin="0,0,0,20"
-                            Grid.Row="0" Grid.RowSpan="2" />
+                            Grid.Row="0" Grid.RowSpan="2" Panel.ZIndex="1" />
                 <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom" Grid.Row="1" Margin="15">
                     <local:MyExtraButton x:Name="BtnExtraUpdateRestart" HorizontalAlignment="Right"
                                          Click="BtnExtraUpdateRestart_Click"

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -278,6 +278,8 @@ public static class ModMain
             frmMain!.PanHint.HorizontalAlignment = Config.Preference.HintAlignRight
                 ? HorizontalAlignment.Right
                 : HorizontalAlignment.Left;
+            // 右置时抬高提示层级，避免被右下角附加按钮（音乐、下载、关闭游戏等）遮挡（#3147）
+            Panel.SetZIndex(frmMain.PanHint, Config.Preference.HintAlignRight ? 1 : 0);
 
             // Tag 存储了：{ 是否可以重用, Uuid }
             if (!HintWaiting.Any())

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -278,8 +278,6 @@ public static class ModMain
             frmMain!.PanHint.HorizontalAlignment = Config.Preference.HintAlignRight
                 ? HorizontalAlignment.Right
                 : HorizontalAlignment.Left;
-            // 右置时抬高提示层级，避免被右下角附加按钮（音乐、下载、关闭游戏等）遮挡（#3147）
-            Panel.SetZIndex(frmMain.PanHint, Config.Preference.HintAlignRight ? 1 : 0);
 
             // Tag 存储了：{ 是否可以重用, Uuid }
             if (!HintWaiting.Any())


### PR DESCRIPTION
> 第一次用 Claude 诶……

This PR fixes #3147
本 PR 通过抬高 `z-index` 修复了提示右置时可能被右下角按钮遮挡的问题。

## Summary by Sourcery

错误修复：
- 通过提高右对齐提示的显示层级，防止其被右下角的辅助按钮遮挡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent right-aligned hints from being covered by bottom-right auxiliary buttons by raising their display layer.

</details>