### PR TITLE
fix(java): 尝试提升 Java 查找速度

### DIFF
--- a/PCL.Core/Minecraft/Java/JavaConsts.cs
+++ b/PCL.Core/Minecraft/Java/JavaConsts.cs
@@ -16,5 +16,5 @@ public class JavaConsts
         "pcl", "hmcl", "baka", "minecraft"
     ];
 
-    public static readonly string[] AllKeyworkds = [.. PossibleKeywords, .. MostPossibleKeywords];
+    public static readonly string[] AllKeywords = [.. PossibleKeywords, .. MostPossibleKeywords];
 }

--- a/PCL.Core/Minecraft/Java/JavaConsts.cs
+++ b/PCL.Core/Minecraft/Java/JavaConsts.cs
@@ -12,7 +12,7 @@ public class JavaConsts
 
     public static readonly string[] PossibleKeywords =
     [
-        "environment", "env", "runtime", "x86_64", "amd64", "arm64",
+        "environment", "env", "runtime", "x86_64", "amd64", "arm64", "x64",
         "pcl", "hmcl", "baka", "minecraft"
     ];
 

--- a/PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/DefaultPathsScanner.cs
@@ -10,7 +10,7 @@ namespace PCL.Core.Minecraft.Java.Scanner;
 
 public class DefaultPathsScanner : IJavaScanner
 {
-    private const int MaxSearchDepth = 8;
+    private const int MaxSearchDepth = 6;
 
     public void Scan(ICollection<string> results)
     {
@@ -34,7 +34,7 @@ public class DefaultPathsScanner : IJavaScanner
     {
         var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ".minecraft", "runtime"),
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             Path.Combine(Basics.ExecutableDirectory, "PCL")
@@ -96,23 +96,17 @@ public class DefaultPathsScanner : IJavaScanner
 
             try
             {
-                // 深度0时只遍历含关键词的目录
-                var dirsToScan = depth == 0
-                    ? Directory.EnumerateDirectories(current)
-                        .Where(dir => _ShouldScanDirectory(dir))
-                    : Directory.EnumerateDirectories(current);
-
-                foreach (var dir in dirsToScan)
+                foreach (var subDir in Directory.EnumerateDirectories(current))
                 {
-                    var javaExe = Path.Combine(dir, "java.exe");
+                    var javaExe = Path.Combine(subDir, "java.exe");
                     if (File.Exists(javaExe))
                     {
                         results.Add(javaExe);
+                        continue;
                     }
-                    else
-                    {
-                        queue.Enqueue((dir, depth + 1));
-                    }
+
+                    if (_ShouldExploreDeeper(subDir))
+                        queue.Enqueue((subDir, depth + 1));
                 }
             }
             catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or DirectoryNotFoundException)
@@ -126,12 +120,38 @@ public class DefaultPathsScanner : IJavaScanner
         }
     }
 
-    private static bool _ShouldScanDirectory(string path)
+    private static bool _ShouldExploreDeeper(string path)
     {
-        var name = Path.GetFileName(path);
-        if (JavaConsts.ExcludeFolderNames.Any(ex => name.Contains(ex, StringComparison.OrdinalIgnoreCase)))
+        var name = Path.GetFileName(path).AsSpan();
+
+        foreach (var ex in JavaConsts.ExcludeFolderNames)
+            if (name.Contains(ex, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+        foreach (var kw in JavaConsts.AllKeywords)
+            if (name.Contains(kw, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+        return _IsVersionLikeDirectory(name);
+    }
+
+    private static bool _IsVersionLikeDirectory(ReadOnlySpan<char> name)
+    {
+        if (name.IsEmpty || name.Length > 20)
             return false;
 
-        return JavaConsts.AllKeyworkds.Any(k => name.Contains(k, StringComparison.OrdinalIgnoreCase));
+        var hasDigit = false;
+        foreach (var c in name)
+        {
+            if (char.IsDigit(c))
+            {
+                hasDigit = true;
+            }
+            else if (c != '.' && c != '_' && c != '-')
+            {
+                return false;
+            }
+        }
+        return hasDigit;
     }
 }


### PR DESCRIPTION
缩小了搜索深度，并进一步框定扫描范围

Resolved #3134

> Partly generated by DeepSeek v4 Pro

## Summary by Sourcery

提高 Java 运行时扫描性能，并缩小查找 `java.exe` 安装位置时的搜索范围。

改进内容：
- 在扫描 Java 运行时时，减少目录遍历的最大深度。
- 将默认搜索根目录限制在应用数据下更相关的 Minecraft 运行时位置。
- 引入基于启发式的目录过滤（关键词、排除名称以及类似版本号的模式），以避免遍历无关文件夹。
- 修复并统一用于目录过滤的 Java 搜索关键词常量名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Java runtime scanning performance and narrow the search scope for locating java.exe installations.

Enhancements:
- Reduce maximum directory traversal depth when scanning for Java runtimes.
- Restrict default search roots to more relevant Minecraft runtime locations under application data.
- Introduce heuristic-based directory filtering (keywords, excluded names, and version-like patterns) to avoid exploring irrelevant folders.
- Fix and standardize the Java search keyword constant name for use in directory filtering.

</details>