### PR TITLE
fix: didn't call InitializeAsync

### DIFF
--- a/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
+++ b/PCL.Core/Minecraft/IdentityModel/Extensions/OpenId/OpenIdClient.cs
@@ -20,6 +20,7 @@ public class OpenIdClient(OpenIdOptions options):IOAuthClient
     /// <exception cref="IdentityModelConfigurationException">当要求检查地址并不存在任何授权端点时，将触发此错误</exception>
     public async Task InitializeAsync(CancellationToken token,bool checkAddress = false)
     {
+        await options.InitializeAsync(token);
         var opt = await options.BuildOAuthOptionsAsync(token);
         if (checkAddress && opt.Meta.AuthorizeEndpoint.IsNullOrEmpty() && opt.Meta.DeviceEndpoint.IsNullOrEmpty())
             throw new IdentityModelConfigurationException("OpenID 元数据缺少授权代码流端点和设备代码流端点");


### PR DESCRIPTION
This pull request fixed a bug where calling InitializeAsync always failed because InitializeAsync was not calling options.InitializeAsync().

## Summary by Sourcery

Bug Fixes:
- 修复 `OpenIdClient.InitializeAsync`，使其能够正确调用选项初始化流程，防止初始化始终失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix OpenIdClient.InitializeAsync so it correctly calls the options initialization routine, preventing initialization from always failing.

</details>