### PR TITLE
refactor: 用 `TrySetValue` 替代 `ByTag` 开关语句

### DIFF
--- a/PCL.Core/App/Configuration/ConfigService.cs
+++ b/PCL.Core/App/Configuration/ConfigService.cs
@@ -96,14 +96,14 @@ public sealed partial class ConfigService
     /// </summary>
     /// <param name="key">配置键</param>
     /// <param name="value">配置值</param>
-    /// <returns>若配置键存在，则为 <c>true</c>，否则为 <c>false</c></returns>
-    public static void TrySetValue(string key, object value)
+    /// <param name="argument">上下文参数（实例路径等）</param>
+    public static void TrySetValue(string key, object value, object? argument = null)
     {
         if (!TryGetConfigItemNoType(key, out var item)) return;
         if (item.Type.IsEnum && value is not string)
-            item.SetValueNoType(Enum.ToObject(item.Type, value));
+            item.SetValueNoType(Enum.ToObject(item.Type, value), argument);
         else
-            item.SetValueNoType(value);
+            item.SetValueNoType(value, argument);
     }
 
     /// <summary>

--- a/PCL.Core/App/Configuration/ConfigService.cs
+++ b/PCL.Core/App/Configuration/ConfigService.cs
@@ -92,6 +92,21 @@ public sealed partial class ConfigService
     }
 
     /// <summary>
+    /// 按键设置配置值，自动处理类型匹配。若键不存在则静默失败。
+    /// </summary>
+    /// <param name="key">配置键</param>
+    /// <param name="value">配置值</param>
+    /// <returns>若配置键存在，则为 <c>true</c>，否则为 <c>false</c></returns>
+    public static void TrySetValue(string key, object value)
+    {
+        if (!TryGetConfigItemNoType(key, out var item)) return;
+        if (item.Type.IsEnum && value is not string)
+            item.SetValueNoType(Enum.ToObject(item.Type, value));
+        else
+            item.SetValueNoType(value);
+    }
+
+    /// <summary>
     /// 向指定作用域批量注册事件观察器。
     /// </summary>
     /// <param name="scope"><see cref="IConfigScope"/> 实例</param>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -178,6 +178,13 @@ public partial class PageInstanceSetup
     }
 
     // 将控件改变路由到设置改变
+    private void SetByTag(string tag, object value)
+    {
+        if (!ConfigService.TryGetConfigItemNoType(tag, out var item))
+            throw new ArgumentOutOfRangeException(nameof(tag), tag, null);
+        item.SetValueNoType(value, PageInstanceLeft.McInstance.PathInstance);
+    }
+
     private void RadioBoxChange(object o, ModBase.RouteEventArgs routeEventArgs)
     {
         if (ModAnimation.AniControlEnabled != 0)
@@ -187,13 +194,7 @@ public partial class PageInstanceSetup
         var slash = tag.IndexOf('/');
         if (slash < 0) return;
 
-        var value = int.Parse(tag[(slash + 1)..]);
-        ArgConfig<int> setting = tag[..slash] switch
-        {
-            "VersionRamType" => Config.Instance.MemorySolution,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+        SetByTag(tag[..slash], int.Parse(tag[(slash + 1)..]));
     }
 
     private void TextBoxChange(object o, TextChangedEventArgs textChangedEventArgs)
@@ -201,24 +202,8 @@ public partial class PageInstanceSetup
         if (ModAnimation.AniControlEnabled != 0)
             return;
         if (o is not MyTextBox textBox) return;
-        
-        var tag = textBox.Tag?.ToString();
-        var value = textBox.Text;
-        ArgConfig<string> setting = tag switch 
-        {
-            "VersionArgumentTitle" => Config.Instance.Title,
-            "VersionArgumentInfo" => Config.Instance.TypeInfo,
-            "VersionServerAuthServer" => Config.InstanceAuth.AuthServerAddress,
-            "VersionServerAuthRegister" => Config.InstanceAuth.AuthRegisterAddress,
-            "VersionServerAuthName" => Config.InstanceAuth.AuthServerDisplayName,
-            "VersionServerEnter" => Config.Instance.ServerToEnter,
-            "VersionAdvanceJvm" => Config.Instance.JvmArgs,
-            "VersionAdvanceGame" => Config.Instance.GameArgs,
-            "VersionAdvanceClasspathHead" => Config.Instance.ClasspathHead,
-            "VersionAdvanceRun" => Config.Instance.PreLaunchCommand,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+
+        SetByTag(textBox.Tag?.ToString(), textBox.Text);
     }
 
     private void SliderChange(object o, bool user)
@@ -227,14 +212,7 @@ public partial class PageInstanceSetup
             return;
         if (o is not MySlider slider) return;
 
-        var tag = slider.Tag?.ToString();
-        var value = slider.Value;
-        ArgConfig<int> setting = tag switch
-        {
-            "VersionRamCustom" => Config.Instance.CustomMemorySize,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+        SetByTag(slider.Tag?.ToString(), slider.Value);
     }
 
     private void ComboChange(MyComboBox sender, object e)
@@ -242,15 +220,7 @@ public partial class PageInstanceSetup
         if (ModAnimation.AniControlEnabled != 0)
             return;
 
-        var tag = sender.Tag?.ToString();
-        var value = sender.SelectedIndex;
-        ArgConfig<int> setting = tag switch
-        {
-            "VersionServerLoginRequire" => Config.InstanceAuth.LoginRequirementSolution,
-            "VersionAdvanceRenderer" => Config.Instance.Renderer,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+        SetByTag(sender.Tag?.ToString(), sender.SelectedIndex);
     }
 
     private void CheckBoxChange(object sender, bool user)
@@ -258,23 +228,8 @@ public partial class PageInstanceSetup
         if (ModAnimation.AniControlEnabled != 0)
             return;
         if (sender is not MyCheckBox checkBox) return;
-        
-        var tag = checkBox.Tag?.ToString();
-        var value = checkBox.Checked.GetValueOrDefault();
-        ArgConfig<bool> setting = tag switch
-        {
-            "VersionArgumentTitleEmpty" => Config.Instance.UseGlobalTitle,
-            "VersionAdvanceRunWait" => Config.Instance.PreLaunchCommandWait,
-            "VersionAdvanceJava" => Config.Instance.IgnoreJavaCompatibility,
-            "VersionAdvanceAssetsV2" => Config.Instance.DisableAssetVerifyV2,
-            "VersionAdvanceUseProxyV2" => Config.Instance.UseProxy,
-            "VersionAdvanceDisableJLW" => Config.Instance.DisableJlw,
-            "VersionAdvanceDisableRW" => Config.Instance.DisableRw,
-            "VersionUseDebugLog4j2Config" => Config.Instance.UseDebugLof4j2Config,
-            "VersionAdvanceDisableLwjglUnsafeAgent" => Config.Instance.DisableLwjglUnsafeAgent,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        setting[PageInstanceLeft.McInstance.PathInstance] = value;
+
+        SetByTag(checkBox.Tag?.ToString(), checkBox.Checked.GetValueOrDefault());
     }
 
     // 切换到全局设置

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -178,12 +178,8 @@ public partial class PageInstanceSetup
     }
 
     // 将控件改变路由到设置改变
-    private void SetByTag(string tag, object value)
-    {
-        if (!ConfigService.TryGetConfigItemNoType(tag, out var item))
-            throw new ArgumentOutOfRangeException(nameof(tag), tag, null);
-        item.SetValueNoType(value, PageInstanceLeft.McInstance.PathInstance);
-    }
+    private static void SetByTag(string tag, object value)
+        => ConfigService.TrySetValue(tag, value, PageInstanceLeft.McInstance.PathInstance);
 
     private void RadioBoxChange(object o, ModBase.RouteEventArgs routeEventArgs)
     {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameLink.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameLink.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 using PCL.Core.Link.Scaffolding.EasyTier;
 
@@ -92,43 +93,28 @@ public partial class PageSetupGameLink
     }
 
     // 将控件改变路由到设置改变
-    private void TextBoxChange(object senderRaw, TextChangedEventArgs e) // , TextLinkRelay.ValidatedTextChanged
+    private void TextBoxChange(object senderRaw, TextChangedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameLinkByTag(sender.Tag?.ToString(), sender.Text);
+            SetByTag(sender.Tag?.ToString(), sender.Text);
     }
 
-    private static void
-        ComboBoxChange(MyComboBox sender,
-            object e) // Handles ComboRelayType.SelectionChanged, ComboServerType.SelectionChanged
+    private static void ComboBoxChange(MyComboBox sender, object e)
     {
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameLinkByTag(sender.Tag?.ToString(), sender.SelectedIndex);
+            SetByTag(sender.Tag?.ToString(), sender.SelectedIndex);
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameLinkByTag(sender.Tag?.ToString(), sender.Checked);
+            SetByTag(sender.Tag?.ToString(), sender.Checked);
     }
 
-    private static void SetGameLinkByTag(string tag, object value)
-    {
-        switch (tag)
-        {
-            case "LinkUsername": Config.Link.Username = (string)value; break;
-            case "LinkRelayServer": Config.Link.CustomRelayServer = (string)value; break;
-            case "LinkRelayType": Config.Link.RelayType = (LinkRelayBehavior)(int)value; break;
-            case "LinkServerType": Config.Link.ServerType = (int)value; break;
-            case "LinkProtocolPreference": Config.Link.ProtocolPreference = (LinkProtocolPreference)(int)value; break;
-            case "LinkLatencyFirstMode": Config.Link.UseLatencyFirstMode = (bool)value; break;
-            case "LinkTryPunchSym": Config.Link.TryPunchSym = (bool)value; break;
-            case "LinkEnableIPv6": Config.Link.EnableIPv6 = (bool)value; break;
-            case "LinkEnableCliOutput": Config.Link.EnableCliOutput = (bool)value; break;
-        }
-    }
+    private static void SetByTag(string tag, object value)
+        => ConfigService.TrySetValue(tag, value);
 
     private void LinkProtocolPerferenceChange(object sender, SelectionChangedEventArgs e)
     {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 using PCL.Core.Utils;
 
@@ -95,44 +96,25 @@ public partial class PageSetupGameManage
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameManageByTag(sender.Tag?.ToString(), sender.Checked);
+            SetByTag(sender.Tag?.ToString(), sender.Checked);
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameManageByTag(sender.Tag?.ToString(), sender.Value);
+            SetByTag(sender.Tag?.ToString(), sender.Value);
     }
 
     private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetGameManageByTag(sender.Tag?.ToString(), sender.SelectedIndex);
+            SetByTag(sender.Tag?.ToString(), sender.SelectedIndex);
     }
 
-    private static void SetGameManageByTag(string tag, object value)
-    {
-        switch (tag)
-        {
-            case "ToolDownloadThread": Config.Download.ThreadLimit = (int)value; break;
-            case "ToolDownloadSpeed": Config.Download.SpeedLimit = (int)value; break;
-            case "ToolDownloadSource": Config.Download.FileSource = (int)value; break;
-            case "ToolDownloadVersion": Config.Download.VersionListSource = (int)value; break;
-            case "ToolDownloadAutoSelectVersion": Config.Download.AutoSelectInstance = (bool)value; break;
-            case "ToolFixAuthlib": Config.Download.FixAuthLib = (bool)value; break;
-            case "ToolDownloadTranslateV2": Config.Download.Comp.NameFormatV2 = (int)value; break;
-            case "ToolDownloadMod": Config.Download.Comp.CompSourceSolution = (int)value; break;
-            case "ToolModLocalNameStyle": Config.Download.Comp.UiCompNameSolution = (int)value; break;
-            case "ToolDownloadIgnoreQuilt": Config.Download.Comp.IgnoreQuilt = (bool)value; break;
-            case "ToolDownloadClipboard": Config.Download.Comp.ReadClipboard = (bool)value; break;
-            case "ToolUpdateRelease": Config.Tool.ReleaseNotification = (bool)value; break;
-            case "ToolUpdateSnapshot": Config.Tool.SnapshotNotification = (bool)value; break;
-            case "ToolHelpChinese": Config.Tool.AutoChangeLanguage = (bool)value; break;
-            case "ToolDownloadAutoInstallDependencies": Config.Download.Comp.AutoInstallDependencies = (bool)value; break;
-        }
-    }
+    private static void SetByTag(string tag, object value)
+        => ConfigService.TrySetValue(tag, value);
 
     // 滑动条
     private void SliderLoad()

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.Utils.OS;
 using PCL.Core.App.Localization;
 
@@ -122,28 +123,28 @@ public partial class PageSetupLaunch
         var sender = (MyRadioBox)senderRaw;
         var gotCfg = sender.Tag?.ToString()?.Split("/") ?? Array.Empty<string>();
         if (ModAnimation.AniControlEnabled == 0 && gotCfg.Length >= 2)
-            SetLaunchByTag(gotCfg[0], int.Parse(gotCfg[1]));
+            SetByTag(gotCfg[0], int.Parse(gotCfg[1]));
     }
 
     private void TextBoxChange(object senderRaw, RoutedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetLaunchByTag(sender.Tag?.ToString(), sender.Text);
+            SetByTag(sender.Tag?.ToString(), sender.Text);
     }
 
     private void TextArgumentTitle_OnTextChanged(object senderRaw, TextChangedEventArgs e)
     {
         var sender = (MyTextBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetLaunchByTag(sender.Tag?.ToString(), sender.Text);
+            SetByTag(sender.Tag?.ToString(), sender.Text);
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetLaunchByTag(sender.Tag?.ToString(), sender.Value);
+            SetByTag(sender.Tag?.ToString(), sender.Value);
     }
 
     private void ComboChange(object senderRaw, SelectionChangedEventArgs e)
@@ -152,7 +153,7 @@ public partial class PageSetupLaunch
         if (ModAnimation.AniControlEnabled == 0)
         {
             var senderTag = sender.Tag?.ToString();
-            SetLaunchByTag(senderTag,
+            SetByTag(senderTag,
                 senderTag == "LaunchArgumentPriority" ? Convert.ToInt32(sender.SelectedValue) : sender.SelectedIndex);
             if (senderTag == "LaunchArgumentWindowType") WindowTypeUIRefresh();
         }
@@ -162,37 +163,11 @@ public partial class PageSetupLaunch
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetLaunchByTag(sender.Tag?.ToString(), sender.Checked);
+            SetByTag(sender.Tag?.ToString(), sender.Checked);
     }
 
-    private static void SetLaunchByTag(string tag, object value)
-    {
-        switch (tag)
-        {
-            case "LaunchRamType": Config.Launch.MemoryAllocationMode = (int)value; break;
-            case "LaunchRamCustom": Config.Launch.CustomMemorySize = (int)value; break;
-            case "LaunchArgumentTitle": Config.Launch.Title = (string)value; break;
-            case "LaunchArgumentInfo": Config.Launch.TypeInfo = (string)value; break;
-            case "LaunchArgumentIndieV2": Config.Launch.IndieSolutionV2 = (int)value; break;
-            case "LaunchArgumentVisible": Config.Launch.LauncherVisibility = (LauncherVisibility)(int)value; break;
-            case "LaunchArgumentPriority": Config.Launch.ProcessPriority = (GameProcessPriority)(int)value; break;
-            case "LaunchArgumentWindowType": Config.Launch.GameWindowMode = (GameWindowSizeMode)(int)value; break;
-            case "LaunchArgumentWindowWidth": Config.Launch.GameWindowWidth = int.Parse((string)value); break;
-            case "LaunchArgumentWindowHeight": Config.Launch.GameWindowHeight = int.Parse((string)value); break;
-            case "LoginMsAuthType": Config.Launch.LoginMsAuthType = (int)value; break;
-            case "LaunchPreferredIpStack": Config.Launch.PreferredIpStack = (JvmPreferredIpStack)(int)value; break;
-            case "LaunchAdvanceRenderer": Config.Launch.Renderer = (int)value; break;
-            case "LaunchAdvanceJvm": Config.Launch.JvmArgs = (string)value; break;
-            case "LaunchAdvanceGame": Config.Launch.GameArgs = (string)value; break;
-            case "LaunchAdvanceRun": Config.Launch.PreLaunchCommand = (string)value; break;
-            case "LaunchAdvanceRunWait": Config.Launch.PreLaunchCommandWait = (bool)value; break;
-            case "LaunchAdvanceDisableJLW": Config.Launch.DisableJlw = (bool)value; break;
-            case "LaunchAdvanceDisableRW": Config.Launch.DisableRw = (bool)value; break;
-            case "LaunchAdvanceGraphicCard": Config.Launch.SetGpuPreference = (bool)value; break;
-            case "LaunchAdvanceNoJavaw": Config.Launch.NoJavaw = (bool)value; break;
-            case "LaunchAdvanceDisableLwjglUnsafeAgent": Config.Launch.DisableLwjglUnsafeAgent = (bool)value; break;
-        }
-    }
+    private static void SetByTag(string tag, object value)
+        => ConfigService.TrySetValue(tag, value);
 
     // 切换到实例独立设置
     private void BtnSwitch_Click(object sender, MouseButtonEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherMisc.xaml.cs
@@ -86,7 +86,7 @@ public partial class PageSetupLauncherMisc
     {
         var sender = (MyComboBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetMiscByTag(sender.Tag?.ToString(), sender.SelectedIndex);
+            SetByTag(sender.Tag?.ToString(), sender.SelectedIndex);
     }
 
     private void RadioBoxChange(object senderRaw, ModBase.RouteEventArgs e)
@@ -94,39 +94,25 @@ public partial class PageSetupLauncherMisc
         var sender = (MyRadioBox)senderRaw;
         var gotCfg = sender.Tag?.ToString()?.Split("/") ?? Array.Empty<string>();
         if (ModAnimation.AniControlEnabled == 0 && gotCfg.Length >= 2)
-            SetMiscByTag(gotCfg[0], int.Parse(gotCfg[1]));
+            SetByTag(gotCfg[0], int.Parse(gotCfg[1]));
     }
 
     private void CheckBoxChange(object senderRaw, bool user)
     {
         var sender = (MyCheckBox)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetMiscByTag(sender.Tag?.ToString(), sender.Checked);
+            SetByTag(sender.Tag?.ToString(), sender.Checked);
     }
 
     private void SliderChange(object senderRaw, bool user)
     {
         var sender = (MySlider)senderRaw;
         if (ModAnimation.AniControlEnabled == 0)
-            SetMiscByTag(sender.Tag?.ToString(), sender.Value);
+            SetByTag(sender.Tag?.ToString(), sender.Value);
     }
 
-    private static void SetMiscByTag(string tag, object value)
-    {
-        switch (tag)
-        {
-            case "SystemMaxLog": Config.System.MaxGameLog = (int)value; break;
-            case "SystemDebugMode": Config.Debug.Enabled = (bool)value; break;
-            case "SystemDebugAnim": Config.Debug.AnimationSpeed = (int)value; break;
-            case "SystemDebugDelay": Config.Debug.AddRandomDelay = (bool)value; break;
-            case "SystemDebugSkipCopy": Config.Debug.DontCopy = (bool)value; break;
-            case "SystemDisableHardwareAcceleration": Config.System.DisableHardwareAcceleration = (bool)value; break;
-            case "SystemHttpProxyType": Config.Network.HttpProxy.Type = (int)value; break;
-            case "SystemNetEnableDoH": Config.Network.EnableDoH = (bool)value; break;
-            case "SystemTelemetry": Config.System.Telemetry = (bool)value; break;
-            case "UiAniFPS": Config.System.AnimationFpsLimit = (int)value; break;
-        }
-    }
+    private static void SetByTag(string tag, object value)
+        => ConfigService.TrySetValue(tag, value);
 
     // 网络
     private void ApplyHttpProxyBtn_OnClicked(object sender, MouseButtonEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
@@ -223,6 +223,8 @@ public partial class PageSetupUI
     private static void SetByTag(string tag, object value)
     {
         ConfigService.TrySetValue(tag, value);
+        if (tag == "UiHintAlignRight")
+            ModMain.Hint(Lang.Text("Setup.Ui.Basic.HintAlignRight.Changed"));
     }
 
     private void ComboFontChange(object sender, SelectionChangedEventArgs e)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using PCL.Core.App;
+using PCL.Core.App.Configuration;
 using PCL.Core.UI;
 using PCL.Core.Utils;
 using PCL.Core.App.Localization;
@@ -221,69 +222,7 @@ public partial class PageSetupUI
 
     private static void SetByTag(string tag, object value)
     {
-        switch (tag)
-        {
-            case "UiLauncherTransparent": Config.Preference.Theme.WindowOpacity = (int)value; break;
-            case "UiBackgroundOpacity": Config.Preference.Background.WallpaperOpacity = (int)value; break;
-            case "UiBackgroundBlur": Config.Preference.Background.WallpaperBlurRadius = (int)value; break;
-            case "UiBlurValue": Config.Preference.Blur.Radius = (int)value; break;
-            case "UiBlurSamplingRate": Config.Preference.Blur.SamplingRate = (int)value; break;
-            case "UiMusicVolume": Config.Preference.Music.Volume = (int)value; break;
-
-            case "UiLauncherLogo": Config.Preference.ShowStartupLogo = (bool)value; break;
-            case "UiShowLaunchingHint": Config.Preference.ShowLaunchingHint = (bool)value; break;
-            case "UiHintAlignRight": Config.Preference.HintAlignRight = (bool)value; ModMain.Hint(Lang.Text("Setup.Ui.Basic.HintAlignRight.Changed")); break;
-            case "UiLockWindowSize": Config.Preference.LockWindowSize = (bool)value; break;
-            case "UiBlur": Config.Preference.Blur.IsEnabled = (bool)value; break;
-            case "UiAutoPauseVideo": Config.Preference.Background.AutoPauseVideo = (bool)value; break;
-            case "UiBackgroundColorful": Config.Preference.Background.BackgroundColorful = (bool)value; break;
-            case "UiMusicRandom": Config.Preference.Music.ShufflePlayback = (bool)value; break;
-            case "UiMusicAuto": Config.Preference.Music.StartOnStartup = (bool)value; break;
-            case "UiMusicStart": Config.Preference.Music.StartInGame = (bool)value; break;
-            case "UiMusicStop": Config.Preference.Music.StopInGame = (bool)value; break;
-            case "UiMusicSMTC": Config.Preference.Music.EnableSMTC = (bool)value; break;
-            case "UiLogoLeft": Config.Preference.TopBarLeftAlign = (bool)value; break;
-
-            case "UiDarkMode": Config.Preference.Theme.ColorMode = (ColorMode)(int)value; break;
-            case "UiDarkColor": Config.Preference.Theme.DarkColor = (ColorTheme)(int)value; break;
-            case "UiLightColor": Config.Preference.Theme.LightColor = (ColorTheme)(int)value; break;
-            case "UiBlurType": Config.Preference.Blur.KernelType = (int)value; break;
-            case "UiBackgroundSuit": Config.Preference.Background.WallpaperSuitMode = (int)value; break;
-            case "UiCustomPreset": Config.Preference.Homepage.SelectedPreset = (int)value; break;
-            case "UiCustomNet": Config.Preference.Homepage.CustomUrl = (string)value; break;
-            case "UiLogoType": Config.Preference.WindowTitleType = (LauncherTitleType)(int)value; break;
-            case "UiLogoText": Config.Preference.WindowTitleCustomText = (string)value; break;
-            case "UiCustomType": Config.Preference.Homepage.Type = (int)value; break;
-
-            case "UiHiddenPageDownload": Config.Preference.Hide.PageDownload = (bool)value; break;
-            case "UiHiddenPageSetup": Config.Preference.Hide.PageSetup = (bool)value; break;
-            case "UiHiddenPageTools": Config.Preference.Hide.PageTools = (bool)value; break;
-            case "UiHiddenSetupLaunch": Config.Preference.Hide.SetupLaunch = (bool)value; break;
-            case "UiHiddenSetupUi": Config.Preference.Hide.SetupUi = (bool)value; break;
-            case "UiHiddenSetupLauncherLanguage": Config.Preference.Hide.SetupLauncherLanguage = (bool)value; break;
-            case "UiHiddenSetupLauncherMisc": Config.Preference.Hide.SetupLauncherMisc = (bool)value; break;
-            case "UiHiddenSetupGameManage": Config.Preference.Hide.SetupGameManage = (bool)value; break;
-            case "UiHiddenSetupJava": Config.Preference.Hide.SetupJava = (bool)value; break;
-            case "UiHiddenSetupUpdate": Config.Preference.Hide.SetupUpdate = (bool)value; break;
-            case "UiHiddenSetupGameLink": Config.Preference.Hide.SetupGameLink = (bool)value; break;
-            case "UiHiddenSetupAbout": Config.Preference.Hide.SetupAbout = (bool)value; break;
-            case "UiHiddenSetupFeedback": Config.Preference.Hide.SetupFeedback = (bool)value; break;
-            case "UiHiddenSetupLog": Config.Preference.Hide.SetupLog = (bool)value; break;
-            case "UiHiddenToolsGameLink": Config.Preference.Hide.ToolsGameLink = (bool)value; break;
-            case "UiHiddenToolsTest": Config.Preference.Hide.ToolsTest = (bool)value; break;
-            case "UiHiddenVersionEdit": Config.Preference.Hide.InstanceEdit = (bool)value; break;
-            case "UiHiddenVersionExport": Config.Preference.Hide.InstanceExport = (bool)value; break;
-            case "UiHiddenVersionSave": Config.Preference.Hide.InstanceSave = (bool)value; break;
-            case "UiHiddenVersionScreenshot": Config.Preference.Hide.InstanceScreenshot = (bool)value; break;
-            case "UiHiddenVersionMod": Config.Preference.Hide.InstanceMod = (bool)value; break;
-            case "UiHiddenVersionResourcePack": Config.Preference.Hide.InstanceResourcePack = (bool)value; break;
-            case "UiHiddenVersionShader": Config.Preference.Hide.InstanceShader = (bool)value; break;
-            case "UiHiddenVersionSchematic": Config.Preference.Hide.InstanceSchematic = (bool)value; break;
-            case "UiHiddenVersionServer": Config.Preference.Hide.InstanceServer = (bool)value; break;
-            case "UiHiddenFunctionSelect": Config.Preference.Hide.FunctionSelect = (bool)value; break;
-            case "UiHiddenFunctionModUpdate": Config.Preference.Hide.FunctionModUpdate = (bool)value; break;
-            case "UiHiddenFunctionHidden": Config.Preference.Hide.FunctionHidden = (bool)value; break;
-        }
+        ConfigService.TrySetValue(tag, value);
     }
 
     private void ComboFontChange(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
## Summary by Sourcery

重构 UI 配置绑定机制，将控件数值变更统一通过集中化的配置服务进行处理。

增强内容：
- 使用共享的 `ConfigService.TrySetValue` 帮助方法替换各页面中基于标签到配置键的 `switch` 语句，通过键来设置配置值。
- 在实例、启动、UI、游戏链接、游戏管理以及启动器杂项页面中统一 `SetByTag` 帮助方法，以减少重复代码并集中配置更新逻辑。
- 扩展 `ConfigService`，新增类型感知的 `TrySetValue` 方法，在应用配置变更时支持枚举类型以及可选的上下文参数（例如实例路径）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor UI configuration bindings to route control value changes through a centralized configuration service.

Enhancements:
- Replace page-specific tag-to-config switch statements with a shared ConfigService.TrySetValue helper for setting configuration values by key.
- Unify SetByTag helpers across instance, launch, UI, game link, game manage, and launcher misc pages to reduce duplication and centralize config update logic.
- Extend ConfigService with a type-aware TrySetValue method that handles enums and optional context arguments (such as instance paths) when applying configuration changes.

</details>