### PR TITLE
chore(mod-main): 移除空的 `#region 页面声明`

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -908,38 +908,6 @@ public static class ModMain
 
     #endregion
 
-    #region 页面声明
-
-    // 在最后进行页面声明，避免颜色尚未加载完毕
-
-    // 窗体声明
-
-
-    // 页面声明（出于单元测试考虑，初始化页面已转入 FormMain 中）
-
-
-    // 工具页面声明
-
-
-    // 下载页面声明
-
-
-    // 设置页面声明
-
-
-    // 登录页面声明
-
-
-    // 实例设置页面声明
-
-
-    // 实例存档页面
-
-
-    // 资源信息分页声明
-    
-    #endregion
-
     #region 愚人节
 
     public static bool isAprilEnabled = DateTime.Now.Month == 4 && DateTime.Now.Day == 1;


### PR DESCRIPTION
## 由 Sourcery 提供的总结

日常维护：
- 清理 ModMain，删除已不再包含任何声明的空 `#region 页面声明` 区块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Clean up ModMain by deleting an empty `#region 页面声明` section that no longer contains any declarations.

</details>