### PR TITLE
feat: 使用应用内 Toast 代替老的 Hint

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -198,11 +198,6 @@ public static partial class Config
         [ConfigItem<bool>("UiShowLaunchingHint", true, ConfigSource.Local)] public partial bool ShowLaunchingHint { get; set; }
 
         /// <summary>
-        /// 提示气泡靠右弹出。
-        /// </summary>
-        [ConfigItem<bool>("UiHintAlignRight", false, ConfigSource.Local)] public partial bool HintAlignRight { get; set; }
-
-        /// <summary>
         /// 标题内容类型。
         /// </summary>
         [ConfigItem<LauncherTitleType>("UiLogoType", LauncherTitleType.Default, ConfigSource.Local)] public partial LauncherTitleType WindowTitleType { get; set; }

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1392,8 +1392,6 @@
     <sys:String x:Key="Setup.Ui.Basic.ShowLogo">Display the PCL logo while opening the launcher</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.LockWindow">Lock launcher size</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.ShowTriviaHint">Show &quot;Trivia&quot; when launching the game</sys:String>
-    <sys:String x:Key="Setup.Ui.Basic.HintAlignRight">Show popup hints on the right side</sys:String>
-    <sys:String x:Key="Setup.Ui.Basic.HintAlignRight.Changed">Changes applied!</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.AdvancedMaterial">Advanced material</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.AdvancedMaterial.ToolTip">When enabled, blur effects will be applied to some transparent areas, such as cards.&#x0a;Note that this feature consumes significant GPU resources and may cause lag!</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.BlurRadius">Blur radius</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1392,8 +1392,6 @@
     <sys:String x:Key="Setup.Ui.Basic.ShowLogo">打开启动器时显示 PCL 图标</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.LockWindow">锁定启动器大小</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.ShowTriviaHint">在启动游戏时显示"你知道吗"</sys:String>
-    <sys:String x:Key="Setup.Ui.Basic.HintAlignRight">弹出提示靠右显示</sys:String>
-    <sys:String x:Key="Setup.Ui.Basic.HintAlignRight.Changed">切换成功！</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.AdvancedMaterial">高级材质</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.AdvancedMaterial.ToolTip">启用此功能后会在部分透明区域（例如卡片）实现模糊效果。&#x0a;请注意，该功能会消耗大量 GPU 算力，并导致卡顿！</sys:String>
     <sys:String x:Key="Setup.Ui.Basic.BlurRadius">模糊半径</sys:String>

--- a/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
@@ -52,20 +52,15 @@ public partial class MyHint
         Unloaded += (_, _) => Dispose();
     }
 
-    // 边框
     public bool HasBorder
     {
         get => BorderThickness.Top > 0d;
         set
         {
             if (value)
-                BorderThickness = Config.Preference.HintAlignRight
-                    ? new Thickness(ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d), 3d, ModBase.GetWPFSize(1d))
-                    : new Thickness(3d, ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d));
+                BorderThickness = new Thickness(ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d), 3d, ModBase.GetWPFSize(1d));
             else
-                BorderThickness = Config.Preference.HintAlignRight
-                    ? new Thickness(0d, 0d, 3d, 0d)
-                    : new Thickness(3d, 0d, 0d, 0d);
+                BorderThickness = new Thickness(0d, 0d, 3d, 0d);
         }
     }
 

--- a/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
@@ -52,6 +52,7 @@ public partial class MyHint
         Unloaded += (_, _) => Dispose();
     }
 
+    // 边框
     public bool HasBorder
     {
         get => BorderThickness.Top > 0d;

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -1,0 +1,43 @@
+<Border x:Class="PCL.MyToast"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:svgIcon="clr-namespace:PCL.Core.UI.Controls.SvgIcon;assembly=PCL.Core"
+        xmlns:local="clr-namespace:PCL"
+        x:Name="Root"
+        HorizontalAlignment="Right"
+        CornerRadius="8" Padding="16" BorderThickness="1"
+        UseLayoutRounding="True" SnapsToDevicePixels="True"
+        RenderOptions.BitmapScalingMode="NearestNeighbor">
+    <Border.Effect>
+        <DropShadowEffect BlurRadius="16" Opacity="0.2" ShadowDepth="4" Direction="270" Color="#000000" />
+    </Border.Effect>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Top"
+                         Margin="0,1,10,0" UseOriginalColor="False" />
+
+        <StackPanel Grid.Column="1">
+            <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis" TextWrapping="Wrap" />
+            <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
+                       Margin="0,4,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
+                       Visibility="Collapsed" />
+        </StackPanel>
+
+        <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
+                            Margin="10,0,0,0" SvgIcon="lucide/x" Theme="Custom" />
+
+        <Rectangle x:Name="ProgressBar" Height="3" Grid.ColumnSpan="3"
+                   HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+                   RenderTransformOrigin="0,0.5" Margin="0,8,0,0">
+            <Rectangle.RenderTransform>
+                <ScaleTransform ScaleX="1" ScaleY="1" />
+            </Rectangle.RenderTransform>
+        </Rectangle>
+    </Grid>
+</Border>

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -11,7 +11,7 @@
     <Border.Effect>
         <DropShadowEffect BlurRadius="16" Opacity="0.2" ShadowDepth="4" Direction="270" Color="#000000" />
     </Border.Effect>
-    <Grid>
+    <Grid x:Name="RootGrid" SizeChanged="RootGrid_SizeChanged">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="3" />

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -17,26 +17,26 @@
             <RowDefinition Height="3" />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Margin="16,16,16,10">
+        <Grid Grid.Row="0" Margin="10,8,10,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Top"
-                             Margin="0,1,10,0" UseOriginalColor="False" />
+            <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Center"
+                             Margin="0,0,6,0" UseOriginalColor="False" />
 
-            <StackPanel Grid.Column="1">
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
                 <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
                            TextTrimming="CharacterEllipsis" TextWrapping="Wrap" />
                 <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
-                           Margin="0,4,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
+                           Margin="0,2,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
                            Visibility="Collapsed" />
             </StackPanel>
 
             <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
-                                Margin="10,0,0,0" SvgIcon="lucide/x" Theme="Custom" />
+                                Margin="8,0,0,0" SvgIcon="lucide/x" Theme="Custom" />
         </Grid>
 
         <Rectangle x:Name="ProgressBar" Height="3" Grid.Row="1"

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -29,9 +29,9 @@
 
             <StackPanel Grid.Column="1" VerticalAlignment="Center">
                 <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
-                           TextTrimming="CharacterEllipsis" TextWrapping="Wrap" />
+                           TextTrimming="CharacterEllipsis" />
                 <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
-                           Margin="0,2,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
+                           Margin="0,2,0,0" TextTrimming="CharacterEllipsis"
                            Visibility="Collapsed" />
             </StackPanel>
 

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -27,13 +27,9 @@
             <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Center"
                              Margin="0,0,6,0" UseOriginalColor="False" />
 
-            <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
-                           TextTrimming="CharacterEllipsis" />
-                <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
-                           Margin="0,2,0,0" TextTrimming="CharacterEllipsis"
-                           Visibility="Collapsed" />
-            </StackPanel>
+            <TextBlock x:Name="TitleText" Grid.Column="1" VerticalAlignment="Center"
+                       FontSize="13" FontWeight="SemiBold"
+                       TextTrimming="CharacterEllipsis" />
 
             <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
                                 Margin="8,0,0,0" SvgIcon="lucide/x" Theme="Custom" />

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -5,36 +5,43 @@
         xmlns:local="clr-namespace:PCL"
         x:Name="Root"
         HorizontalAlignment="Right"
-        CornerRadius="8" Padding="16" BorderThickness="1"
+        CornerRadius="8" BorderThickness="1"
         UseLayoutRounding="True" SnapsToDevicePixels="True"
         RenderOptions.BitmapScalingMode="NearestNeighbor">
     <Border.Effect>
         <DropShadowEffect BlurRadius="16" Opacity="0.2" ShadowDepth="4" Direction="270" Color="#000000" />
     </Border.Effect>
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="3" />
+        </Grid.RowDefinitions>
 
-        <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Top"
-                         Margin="0,1,10,0" UseOriginalColor="False" />
+        <Grid Grid.Row="0" Margin="16,16,16,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
 
-        <StackPanel Grid.Column="1">
-            <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
-                       TextTrimming="CharacterEllipsis" TextWrapping="Wrap" />
-            <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
-                       Margin="0,4,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
-                       Visibility="Collapsed" />
-        </StackPanel>
+            <svgIcon:SvgIcon x:Name="ToastIcon" Width="20" Height="20" VerticalAlignment="Top"
+                             Margin="0,1,10,0" UseOriginalColor="False" />
 
-        <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
-                            Margin="10,0,0,0" SvgIcon="lucide/x" Theme="Custom" />
+            <StackPanel Grid.Column="1">
+                <TextBlock x:Name="TitleText" FontSize="13" FontWeight="SemiBold"
+                           TextTrimming="CharacterEllipsis" TextWrapping="Wrap" />
+                <TextBlock x:Name="DescText" FontSize="13" Opacity="0.6"
+                           Margin="0,4,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap"
+                           Visibility="Collapsed" />
+            </StackPanel>
 
-        <Rectangle x:Name="ProgressBar" Height="3" Grid.ColumnSpan="3"
+            <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
+                                Margin="10,0,0,0" SvgIcon="lucide/x" Theme="Custom" />
+        </Grid>
+
+        <Rectangle x:Name="ProgressBar" Height="3" Grid.Row="1"
                    HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
-                   RenderTransformOrigin="0,0.5" Margin="0,8,0,0">
+                   RenderTransformOrigin="0,0.5">
             <Rectangle.RenderTransform>
                 <ScaleTransform ScaleX="1" ScaleY="1" />
             </Rectangle.RenderTransform>

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -126,9 +126,9 @@ public partial class MyToast
         };
         var s = ThemeService.CurrentTone;
         var bgLight = ToastType == ModMain.HintType.Critical && !ThemeService.IsDarkMode ? 90d : s.L7 * 100;
-        var bg = new ModBase.MyColor().FromHSL2(baseHue, 90, bgLight);
-        var fg = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L2 * 100);
-        var border = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L4 * 100);
+        var bg = new ModBase.MyColor().FromHSL2(baseHue, 70, bgLight);
+        var fg = new ModBase.MyColor().FromHSL2(baseHue, 70, s.L2 * 100);
+        var border = new ModBase.MyColor().FromHSL2(baseHue, 70, s.L4 * 100);
 
         Root.Background = bg;
         Root.BorderBrush = border;

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -126,7 +126,9 @@ public partial class MyToast
         };
         var res = System.Windows.Application.Current.Resources;
         var accent = new ModBase.MyColor().FromHSL2(baseHue, 75, 60);
-        var bg = (Brush)res["ColorBrushBackground"];
+        var bg = ThemeService.IsDarkMode
+            ? new SolidColorBrush(LabColor.FromLch(0.35))
+            : (Brush)res["ColorBrushBackground"];
         var text = (SolidColorBrush)res["ColorBrushGray1"];
         var accentBrush = new SolidColorBrush(accent);
 

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -20,6 +20,7 @@ public partial class MyToast
             ModAnimation.AniStop($"Toast Show {Uuid}");
             ModAnimation.AniStop($"Toast Hide {Uuid}");
             ModAnimation.AniStop($"Toast Dismiss {Uuid}");
+            ModAnimation.AniStop($"Toast Emphasize {Uuid}");
             ProgressBar.BeginAnimation(WidthProperty, null);
         };
     }
@@ -38,6 +39,8 @@ public partial class MyToast
 
     public bool IsDismissing { get; private set; }
 
+    private double _targetHeight;
+
     public void Show()
     {
         if (Parent is not Panel)
@@ -49,7 +52,7 @@ public partial class MyToast
 
         Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
         Arrange(new Rect(0, 0, DesiredSize.Width, DesiredSize.Height));
-        var targetHeight = Math.Max(ActualHeight, 45d);
+        _targetHeight = Math.Max(ActualHeight, 45d);
         Height = 0;
 
         RenderTransform = new TranslateTransform(60, 0);
@@ -57,25 +60,45 @@ public partial class MyToast
         var enterAnimations = new List<ModAnimation.AniData>
         {
             ModAnimation.AaTranslateX(this, -60, 400, ease: new ModAnimation.AniEaseOutFluent()),
-            ModAnimation.AaHeight(this, targetHeight, 150, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaHeight(this, _targetHeight, 150, ease: new ModAnimation.AniEaseOutFluent()),
             ModAnimation.AaOpacity(this, 1, 100)
         };
         ModAnimation.AniStart(enterAnimations, $"Toast Show {Uuid}");
 
+        RestartHideAnimation();
+    }
+
+    public void Emphasize()
+    {
+        ModAnimation.AniStop($"Toast Hide {Uuid}");
+        ModAnimation.AniStop($"Toast Emphasize {Uuid}");
+        ProgressBar.BeginAnimation(WidthProperty, null);
+        if (RenderTransform is TranslateTransform tt) tt.X = 0;
+        Opacity = 1;
+        Height = _targetHeight;
+        ModAnimation.AniStart(new List<ModAnimation.AniData>
+        {
+            ModAnimation.AaTranslateX(this, -8, 70, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaTranslateX(this, 16, 70, after: true),
+            ModAnimation.AaTranslateX(this, -8, 60, after: true, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaCode(RestartHideAnimation, after: true),
+        }, $"Toast Emphasize {Uuid}");
+    }
+
+    private void RestartHideAnimation()
+    {
         var delay = (int)Math.Round(DisplayDuration);
-        var hideAnimations = new List<ModAnimation.AniData>
+        ModAnimation.AniStart(new List<ModAnimation.AniData>
         {
             ModAnimation.AaTranslateX(this, 60, 200, delay, new ModAnimation.AniEaseInFluent()),
             ModAnimation.AaOpacity(this, -1, 150, delay),
-            ModAnimation.AaHeight(this, -targetHeight, 100, ease: new ModAnimation.AniEaseOutFluent(), after: true),
+            ModAnimation.AaHeight(this, -_targetHeight, 100, ease: new ModAnimation.AniEaseOutFluent(), after: true),
             ModAnimation.AaCode(() =>
             {
                 if (Parent is Panel p)
                     p.Children.Remove(this);
             }, after: true)
-        };
-        ModAnimation.AniStart(hideAnimations, $"Toast Hide {Uuid}");
-
+        }, $"Toast Hide {Uuid}");
         StartProgressAnimation(DisplayDuration);
     }
 
@@ -85,6 +108,7 @@ public partial class MyToast
         IsDismissing = true;
         ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
+        ModAnimation.AniStop($"Toast Emphasize {Uuid}");
         ProgressBar.BeginAnimation(WidthProperty, null);
         ModAnimation.AniStart(new List<ModAnimation.AniData>
         {

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -70,6 +70,7 @@ public partial class MyToast
 
     public void Emphasize()
     {
+        ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
         ModAnimation.AniStop($"Toast Emphasize {Uuid}");
         ProgressBar.BeginAnimation(WidthProperty, null);

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -124,19 +124,19 @@ public partial class MyToast
             ModMain.HintType.Critical => 355d,
             _ => 210d
         };
-        var s = ThemeService.CurrentTone;
-        var bgLight = ToastType == ModMain.HintType.Critical && !ThemeService.IsDarkMode ? 90d : s.L7 * 100;
-        var bg = new ModBase.MyColor().FromHSL2(baseHue, 70, bgLight);
-        var fg = new ModBase.MyColor().FromHSL2(baseHue, 70, s.L2 * 100);
-        var border = new ModBase.MyColor().FromHSL2(baseHue, 70, s.L4 * 100);
+        var res = System.Windows.Application.Current.Resources;
+        var accent = new ModBase.MyColor().FromHSL2(baseHue, 75, 60);
+        var bg = (Brush)res["ColorBrushBackground"];
+        var text = (SolidColorBrush)res["ColorBrushGray1"];
+        var accentBrush = new SolidColorBrush(accent);
 
         Root.Background = bg;
-        Root.BorderBrush = border;
-        TitleText.Foreground = fg;
-        ProgressBar.Fill = fg;
-        BtnClose.Foreground = fg;
+        Root.BorderBrush = bg;
+        TitleText.Foreground = text;
+        ProgressBar.Fill = accentBrush;
+        BtnClose.Foreground = text;
         ToastIcon.Icon = Icon;
-        ToastIcon.IconBrush = fg;
+        ToastIcon.IconBrush = accentBrush;
         ToastIcon.StrokeThickness = 0;
     }
 }

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -36,7 +36,7 @@ public partial class MyToast
 
     public double DisplayDuration { get; set; } = 5000;
 
-    public event Action? Dismissed;
+    public bool IsDismissing { get; private set; }
 
     public void Show()
     {
@@ -72,7 +72,6 @@ public partial class MyToast
             {
                 if (Parent is Panel p)
                     p.Children.Remove(this);
-                Dismissed?.Invoke();
             }, after: true)
         };
         ModAnimation.AniStart(hideAnimations, $"Toast Hide {Uuid}");
@@ -82,6 +81,8 @@ public partial class MyToast
 
     public void Dismiss()
     {
+        if (IsDismissing) return;
+        IsDismissing = true;
         ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
         ProgressBar.BeginAnimation(WidthProperty, null);
@@ -93,7 +94,6 @@ public partial class MyToast
             {
                 if (Parent is Panel p)
                     p.Children.Remove(this);
-                Dismissed?.Invoke();
             }, after: true)
         }, $"Toast Dismiss {Uuid}");
     }

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -62,7 +62,7 @@ public partial class MyToast
 
         Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
         Arrange(new Rect(0, 0, DesiredSize.Width, DesiredSize.Height));
-        var targetHeight = Math.Max(ActualHeight, 60);
+        var targetHeight = Math.Max(ActualHeight, 45d);
         Height = 0;
 
         RenderTransform = new TranslateTransform(60, 0);

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -1,6 +1,5 @@
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using PCL.Core.UI.Theme;
@@ -25,24 +24,10 @@ public partial class MyToast
         };
     }
 
-    public string Title
+    public string Context
     {
         get => TitleText.Text;
-        set
-        {
-            TitleText.Text = value;
-            TitleText.Visibility = string.IsNullOrEmpty(value) ? Visibility.Collapsed : Visibility.Visible;
-        }
-    }
-
-    public string Description
-    {
-        get => DescText.Text;
-        set
-        {
-            DescText.Text = value;
-            DescText.Visibility = string.IsNullOrEmpty(value) ? Visibility.Collapsed : Visibility.Visible;
-        }
+        set => TitleText.Text = value;
     }
 
     public string Icon { get; set; } = "lucide/info";
@@ -55,10 +40,10 @@ public partial class MyToast
 
     public void Show()
     {
-        if (Parent is not Panel panel)
+        if (Parent is not Panel)
             return;
-        if (Application.Current.MainWindow is { } window)
-            MaxWidth = window.ActualWidth * 0.9;
+        if (System.Windows.Application.Current.MainWindow is not null)
+            MaxWidth = System.Windows.Application.Current.MainWindow.ActualWidth * 0.9;
         Margin = new Thickness(0, 0, 16, 4);
         Opacity = 0;
 
@@ -148,7 +133,6 @@ public partial class MyToast
         Root.Background = bg;
         Root.BorderBrush = border;
         TitleText.Foreground = fg;
-        DescText.Foreground = fg;
         ProgressBar.Fill = fg;
         BtnClose.Foreground = fg;
         ToastIcon.Icon = Icon;

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -128,7 +128,7 @@ public partial class MyToast
     {
         var baseHue = ToastType switch
         {
-            ModMain.HintType.Finish => 120d,
+            ModMain.HintType.Finish => 145d,
             ModMain.HintType.Critical => 355d,
             _ => 210d
         };

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -57,6 +57,8 @@ public partial class MyToast
     {
         if (Parent is not Panel panel)
             return;
+        if (Application.Current.MainWindow is { } window)
+            MaxWidth = window.ActualWidth * 0.9;
         Margin = new Thickness(0, 0, 16, 4);
         Opacity = 0;
 

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -1,0 +1,146 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using PCL.Core.UI.Theme;
+
+namespace PCL;
+
+public partial class MyToast
+{
+    public int Uuid = ModBase.GetUuid();
+
+    public MyToast()
+    {
+        InitializeComponent();
+        BtnClose.Click += (_, _) => Dismiss();
+        Loaded += (_, _) => UpdateColors();
+        Unloaded += (_, _) =>
+        {
+            ModAnimation.AniStop($"Toast Show {Uuid}");
+            ModAnimation.AniStop($"Toast Hide {Uuid}");
+            ModAnimation.AniStop($"Toast Dismiss {Uuid}");
+            ModAnimation.AniStop($"Toast Progress {Uuid}");
+        };
+    }
+
+    public string Title
+    {
+        get => TitleText.Text;
+        set
+        {
+            TitleText.Text = value;
+            TitleText.Visibility = string.IsNullOrEmpty(value) ? Visibility.Collapsed : Visibility.Visible;
+        }
+    }
+
+    public string Description
+    {
+        get => DescText.Text;
+        set
+        {
+            DescText.Text = value;
+            DescText.Visibility = string.IsNullOrEmpty(value) ? Visibility.Collapsed : Visibility.Visible;
+        }
+    }
+
+    public string Icon { get; set; } = "lucide/info";
+
+    public ModMain.HintType ToastType { get; set; } = ModMain.HintType.Info;
+
+    public double DisplayDuration { get; set; } = 5000;
+
+    public event Action? Dismissed;
+
+    public void Show()
+    {
+        if (Parent is not Panel panel)
+            return;
+        Margin = new Thickness(0, 0, 16, 4);
+        Opacity = 0;
+
+        Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        Arrange(new Rect(0, 0, DesiredSize.Width, DesiredSize.Height));
+        var targetHeight = Math.Max(ActualHeight, 60);
+        Height = 0;
+
+        RenderTransform = new TranslateTransform(60, 0);
+
+        var enterAnimations = new List<ModAnimation.AniData>
+        {
+            ModAnimation.AaTranslateX(this, -60, 400, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaHeight(this, targetHeight, 150, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaOpacity(this, 1, 100)
+        };
+        ModAnimation.AniStart(enterAnimations, $"Toast Show {Uuid}");
+
+        var delay = (int)Math.Round(DisplayDuration);
+        var hideAnimations = new List<ModAnimation.AniData>
+        {
+            ModAnimation.AaTranslateX(this, 60, 200, delay, new ModAnimation.AniEaseInFluent()),
+            ModAnimation.AaOpacity(this, -1, 150, delay),
+            ModAnimation.AaHeight(this, -targetHeight, 100, ease: new ModAnimation.AniEaseOutFluent(), after: true),
+            ModAnimation.AaCode(() =>
+            {
+                if (Parent is Panel p)
+                    p.Children.Remove(this);
+                Dismissed?.Invoke();
+            }, after: true)
+        };
+        ModAnimation.AniStart(hideAnimations, $"Toast Hide {Uuid}");
+
+        StartProgressAnimation(DisplayDuration);
+    }
+
+    public void Dismiss()
+    {
+        ModAnimation.AniStop($"Toast Show {Uuid}");
+        ModAnimation.AniStop($"Toast Hide {Uuid}");
+        ModAnimation.AniStop($"Toast Progress {Uuid}");
+        ModAnimation.AniStart(new List<ModAnimation.AniData>
+        {
+            ModAnimation.AaTranslateX(this, 60, 150, ease: new ModAnimation.AniEaseInFluent()),
+            ModAnimation.AaOpacity(this, -1, 100),
+            ModAnimation.AaCode(() =>
+            {
+                if (Parent is Panel p)
+                    p.Children.Remove(this);
+                Dismissed?.Invoke();
+            }, after: true)
+        }, $"Toast Dismiss {Uuid}");
+    }
+
+    private void StartProgressAnimation(double duration)
+    {
+        var totalMs = (int)Math.Round(duration);
+        if (totalMs <= 0)
+            return;
+        ModAnimation.AniStart(
+            ModAnimation.AaScaleTransform(ProgressBar, -1, totalMs),
+            $"Toast Progress {Uuid}");
+    }
+
+    private void UpdateColors()
+    {
+        var baseHue = ToastType switch
+        {
+            ModMain.HintType.Finish => 120d,
+            ModMain.HintType.Critical => 355d,
+            _ => 210d
+        };
+        var s = ThemeService.CurrentTone;
+        var bg = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L7 * 100);
+        var fg = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L2 * 100);
+        var border = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L4 * 100);
+
+        Root.Background = bg;
+        Root.BorderBrush = border;
+        TitleText.Foreground = fg;
+        DescText.Foreground = fg;
+        ProgressBar.Fill = fg;
+        BtnClose.Foreground = fg;
+        ToastIcon.Icon = Icon;
+        ToastIcon.IconBrush = fg;
+        ToastIcon.StrokeThickness = 0;
+    }
+}

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -124,6 +124,11 @@ public partial class MyToast
         ProgressBar.BeginAnimation(WidthProperty, anim);
     }
 
+    private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        RootGrid.Clip = new RectangleGeometry(new Rect(0, 0, RootGrid.ActualWidth, RootGrid.ActualHeight), 8, 8);
+    }
+
     private void UpdateColors()
     {
         var baseHue = ToastType switch

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -140,7 +140,8 @@ public partial class MyToast
             _ => 210d
         };
         var s = ThemeService.CurrentTone;
-        var bg = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L7 * 100);
+        var bgLight = ToastType == ModMain.HintType.Critical && !ThemeService.IsDarkMode ? 90d : s.L7 * 100;
+        var bg = new ModBase.MyColor().FromHSL2(baseHue, 90, bgLight);
         var fg = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L2 * 100);
         var border = new ModBase.MyColor().FromHSL2(baseHue, 90, s.L4 * 100);
 

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using PCL.Core.UI.Theme;
 
 namespace PCL;
@@ -20,7 +21,7 @@ public partial class MyToast
             ModAnimation.AniStop($"Toast Show {Uuid}");
             ModAnimation.AniStop($"Toast Hide {Uuid}");
             ModAnimation.AniStop($"Toast Dismiss {Uuid}");
-            ModAnimation.AniStop($"Toast Progress {Uuid}");
+            ProgressBar.BeginAnimation(WidthProperty, null);
         };
     }
 
@@ -96,7 +97,7 @@ public partial class MyToast
     {
         ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
-        ModAnimation.AniStop($"Toast Progress {Uuid}");
+        ProgressBar.BeginAnimation(WidthProperty, null);
         ModAnimation.AniStart(new List<ModAnimation.AniData>
         {
             ModAnimation.AaTranslateX(this, 60, 150, ease: new ModAnimation.AniEaseInFluent()),
@@ -115,9 +116,12 @@ public partial class MyToast
         var totalMs = (int)Math.Round(duration);
         if (totalMs <= 0)
             return;
-        ModAnimation.AniStart(
-            ModAnimation.AaScaleTransform(ProgressBar, -1, totalMs),
-            $"Toast Progress {Uuid}");
+        var w = ProgressBar.ActualWidth;
+        if (w <= 0) w = 300;
+        ProgressBar.HorizontalAlignment = HorizontalAlignment.Left;
+        ProgressBar.Width = w;
+        var anim = new DoubleAnimation(w, 0d, TimeSpan.FromMilliseconds(totalMs));
+        ProgressBar.BeginAnimation(WidthProperty, anim);
     }
 
     private void UpdateColors()

--- a/Plain Craft Launcher 2/FormMain.xaml
+++ b/Plain Craft Launcher 2/FormMain.xaml
@@ -221,7 +221,7 @@
                                 UseLayoutRounding="False" SnapsToDevicePixels="False" />
                     </Border>
                 </Grid>
-                <StackPanel x:Name="PanHint" IsHitTestVisible="False" UseLayoutRounding="True"
+                <StackPanel x:Name="PanHint" UseLayoutRounding="True"
                             SnapsToDevicePixels="True" HorizontalAlignment="Left" VerticalAlignment="Bottom"
                             Margin="0,0,0,20"
                             Grid.Row="0" Grid.RowSpan="2" Panel.ZIndex="1" />

--- a/Plain Craft Launcher 2/FormMain.xaml
+++ b/Plain Craft Launcher 2/FormMain.xaml
@@ -225,7 +225,7 @@
                             SnapsToDevicePixels="True" HorizontalAlignment="Left" VerticalAlignment="Bottom"
                             Margin="0,0,0,20"
                             Grid.Row="0" Grid.RowSpan="2" Panel.ZIndex="1" />
-                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Bottom" Grid.Row="1" Margin="15">
+                <StackPanel x:Name="PanExtraButtons" HorizontalAlignment="Right" VerticalAlignment="Bottom" Grid.Row="1" Margin="15">
                     <local:MyExtraButton x:Name="BtnExtraUpdateRestart" HorizontalAlignment="Right"
                                          Click="BtnExtraUpdateRestart_Click"
                                          VerticalAlignment="Center" ToolTip="{DynamicResource Main.Extra.UpdateRestart.ToolTip}"

--- a/Plain Craft Launcher 2/FormMain.xaml
+++ b/Plain Craft Launcher 2/FormMain.xaml
@@ -256,7 +256,7 @@
                                          Visibility="Collapsed" CanRightClick="True" />
                 </StackPanel>
                 <controls:BlurBorder x:Name="PanMsgBackground" Grid.Row="0" Grid.RowSpan="2" Background="#00000000"
-                                     Visibility="Collapsed">
+                                     Panel.ZIndex="2" Visibility="Collapsed">
                     <Grid x:Name="PanMsg" Background="#00000000" MouseLeftButtonDown="FormDragMove" />
                 </controls:BlurBorder>
             </Grid>

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -277,39 +277,46 @@ public static class ModMain
             frmMain!.PanHint.HorizontalAlignment = HorizontalAlignment.Right;
             frmMain.PanHint.VerticalAlignment = VerticalAlignment.Bottom;
 
+            // Keep toasts above any visible extra buttons in the same corner
+            var extraHeight = frmMain.PanExtraButtons.ActualHeight;
+            frmMain.PanHint.Margin = new Thickness(0, 0, 0, extraHeight > 0 ? extraHeight + 20 : 20);
+
             if (!HintWaiting.Any())
                 return;
-            while (HintWaiting.Any())
+
+            // Only count toasts that are still visible (not mid-dismiss-animation)
+            var activeCount = frmMain.PanHint.Children.OfType<MyToast>().Count(t => !t.IsDismissing);
+            if (activeCount >= 5)
             {
-                var currentHint = HintWaiting[0];
-                currentHint.Text = currentHint.Text.Replace("\r\n", " ").Replace("\r", " ")
-                    .Replace("\n", " ");
-                if (frmMain.PanHint.Children.Count >= 5)
-                {
-                    var oldest = frmMain.PanHint.Children.OfType<MyToast>().FirstOrDefault();
-                    oldest?.Dismiss();
-                }
-
-                var toast = new MyToast
-                {
-                    Context = currentHint.Text,
-                    ToastType = currentHint.Type,
-                    Icon = currentHint.Type switch
-                    {
-                        HintType.Finish => "lucide/circle-check",
-                        HintType.Critical => "lucide/circle-minus",
-                        _ => "lucide/info"
-                    },
-                    DisplayDuration = (800d + ModBase.MathClamp(currentHint.Text.Length, 5d, 23d) * 180d) * ModAnimation.aniSpeed
-                };
-
-                frmMain.PanHint.Children.Add(toast);
-                toast.Show();
-
-                if (currentHint.Log)
-                    ModBase.Log("[UI] 弹出提示：" + currentHint.Text);
-                HintWaiting.RemoveAt(0);
+                // Dismiss the oldest active toast and wait for it to leave before adding the next one
+                var oldest = frmMain.PanHint.Children.OfType<MyToast>().FirstOrDefault(t => !t.IsDismissing);
+                oldest?.Dismiss();
+                return;
             }
+
+            var currentHint = HintWaiting[0];
+            currentHint.Text = currentHint.Text.Replace("\r\n", " ").Replace("\r", " ")
+                .Replace("\n", " ");
+
+            var toast = new MyToast
+            {
+                Context = currentHint.Text,
+                ToastType = currentHint.Type,
+                Icon = currentHint.Type switch
+                {
+                    HintType.Finish => "lucide/circle-check",
+                    HintType.Critical => "lucide/circle-minus",
+                    _ => "lucide/info"
+                },
+                DisplayDuration = (800d + ModBase.MathClamp(currentHint.Text.Length, 5d, 23d) * 180d) * ModAnimation.aniSpeed
+            };
+
+            frmMain.PanHint.Children.Add(toast);
+            toast.Show();
+
+            if (currentHint.Log)
+                ModBase.Log("[UI] 弹出提示：" + currentHint.Text);
+            HintWaiting.RemoveAt(0);
         }
         catch (Exception ex)
         {

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -256,6 +256,7 @@ public static class ModMain
     /// </summary>
     public static void Hint(string? text, HintType type = HintType.Info, bool log = true)
     {
+        if (HintWaiting.Count >= 20) return; // 超过 20 条以后的直接砸掉
         HintWaiting.Add(new HintMessage { Text = text ?? "", Type = type, Log = log });
     }
 

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -256,8 +256,9 @@ public static class ModMain
     /// </summary>
     public static void Hint(string? text, HintType type = HintType.Info, bool log = true)
     {
-        if (HintWaiting.Count >= 20) return; // 超过 20 条以后的直接砸掉
-        HintWaiting.Add(new HintMessage { Text = text ?? "", Type = type, Log = log });
+        var normalized = (text ?? "").Replace("\r\n", " ").Replace("\r", " ").Replace("\n", " ");
+        if (HintWaiting.Any(h => h.Text == normalized && h.Type == type)) return;
+        HintWaiting.Add(new HintMessage { Text = normalized, Type = type, Log = log });
     }
 
     public static void HintWrapper_OnShow(string message, HintTheme messageTheme)
@@ -296,8 +297,16 @@ public static class ModMain
             }
 
             var currentHint = HintWaiting[0];
-            currentHint.Text = currentHint.Text.Replace("\r\n", " ").Replace("\r", " ")
-                .Replace("\n", " ");
+
+            // If a visible toast already shows this exact message, shake it instead of stacking a new one
+            var duplicate = frmMain.PanHint.Children.OfType<MyToast>()
+                .FirstOrDefault(t => !t.IsDismissing && t.Context == currentHint.Text && t.ToastType == currentHint.Type);
+            if (duplicate != null)
+            {
+                duplicate.Emphasize();
+                HintWaiting.RemoveAt(0);
+                return;
+            }
 
             var toast = new MyToast
             {

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -760,38 +760,6 @@ public static class ModMain
 
     #endregion
 
-    #region 页面声明
-
-    // 在最后进行页面声明，避免颜色尚未加载完毕
-
-    // 窗体声明
-
-
-    // 页面声明（出于单元测试考虑，初始化页面已转入 FormMain 中）
-
-
-    // 工具页面声明
-
-
-    // 下载页面声明
-
-
-    // 设置页面声明
-
-
-    // 登录页面声明
-
-
-    // 实例设置页面声明
-
-
-    // 实例存档页面
-
-
-    // 资源信息分页声明
-    
-    #endregion
-
     #region 愚人节
 
     public static bool isAprilEnabled = DateTime.Now.Month == 4 && DateTime.Now.Day == 1;

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -286,6 +286,19 @@ public static class ModMain
             if (!HintWaiting.Any())
                 return;
 
+            var currentHint = HintWaiting[0];
+
+            // If a visible toast already shows this exact message, shake it instead of stacking a new one.
+            // This must run before the cap check — a duplicate needs no new slot, so no existing toast should be evicted.
+            var duplicate = frmMain.PanHint.Children.OfType<MyToast>()
+                .FirstOrDefault(t => !t.IsDismissing && t.Context == currentHint.Text && t.ToastType == currentHint.Type);
+            if (duplicate != null)
+            {
+                duplicate.Emphasize();
+                HintWaiting.RemoveAt(0);
+                return;
+            }
+
             // Only count toasts that are still visible (not mid-dismiss-animation)
             var activeCount = frmMain.PanHint.Children.OfType<MyToast>().Count(t => !t.IsDismissing);
             if (activeCount >= 5)
@@ -293,18 +306,6 @@ public static class ModMain
                 // Dismiss the oldest active toast and wait for it to leave before adding the next one
                 var oldest = frmMain.PanHint.Children.OfType<MyToast>().FirstOrDefault(t => !t.IsDismissing);
                 oldest?.Dismiss();
-                return;
-            }
-
-            var currentHint = HintWaiting[0];
-
-            // If a visible toast already shows this exact message, shake it instead of stacking a new one
-            var duplicate = frmMain.PanHint.Children.OfType<MyToast>()
-                .FirstOrDefault(t => !t.IsDismissing && t.Context == currentHint.Text && t.ToastType == currentHint.Type);
-            if (duplicate != null)
-            {
-                duplicate.Emphasize();
-                HintWaiting.RemoveAt(0);
                 return;
             }
 

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -274,171 +274,35 @@ public static class ModMain
     {
         try
         {
-            // 根据配置更新提示气泡对齐方向
-            frmMain!.PanHint.HorizontalAlignment = Config.Preference.HintAlignRight
-                ? HorizontalAlignment.Right
-                : HorizontalAlignment.Left;
+            frmMain!.PanHint.HorizontalAlignment = HorizontalAlignment.Right;
+            frmMain.PanHint.VerticalAlignment = VerticalAlignment.Bottom;
 
-            // Tag 存储了：{ 是否可以重用, Uuid }
             if (!HintWaiting.Any())
                 return;
             while (HintWaiting.Any())
             {
-                // '清除空提示
-                // If IsNothing(HintWaiting(0)) OrElse IsNothing(HintWaiting(0)(0)) Then
-                // HintWaiting.RemoveAt(0)
-                // Continue Do
-                // End If
                 var currentHint = HintWaiting[0];
-                // 去回车
                 currentHint.Text = currentHint.Text.Replace("\r\n", " ").Replace("\r", " ")
                     .Replace("\n", " ");
-                // 超量提示直接忽略
-                if (frmMain!.PanHint.Children.Count >= 20)
+                if (frmMain.PanHint.Children.Count >= 5)
                     goto EndHint;
-                // 检查是否有重复提示
-                Border? doubleStack = null;
-                foreach (Border stack in frmMain.PanHint.Children)
-                    if (stack.Tag is object[] tagArray && (bool)tagArray[0] &&
-                                              (((TextBlock)stack.Child).Text ?? "") == (currentHint.Text ?? ""))
-                        doubleStack = stack;
-                // 获取渐变颜色
-                ModBase.MyColor targetColor0, targetColor1;
-                var percent = 0.3d;
-                switch (currentHint.Type)
+
+                var toast = new MyToast
                 {
-                    case HintType.Info:
+                    Title = currentHint.Text,
+                    ToastType = currentHint.Type,
+                    Icon = currentHint.Type switch
                     {
-                        targetColor0 = new ModBase.MyColor(215d, 37d, 155d, 252d);
-                        targetColor1 = new ModBase.MyColor(215d, 10d, 142d, 252d);
-                        break;
-                    }
-                    case HintType.Finish:
-                    {
-                        targetColor0 = new ModBase.MyColor(215d, 33d, 177d, 33d);
-                        targetColor1 = new ModBase.MyColor(215d, 29d, 160d, 29d); // HintType.Critical
-                        break;
-                    }
+                        HintType.Finish => "lucide/circle-check",
+                        HintType.Critical => "lucide/circle-minus",
+                        _ => "lucide/info"
+                    },
+                    DisplayDuration = (800d + ModBase.MathClamp(currentHint.Text.Length, 5d, 23d) * 180d) * ModAnimation.aniSpeed
+                };
 
-                    default:
-                    {
-                        targetColor0 = new ModBase.MyColor(215d, 255d, 53d, 11d);
-                        targetColor1 = new ModBase.MyColor(215d, 255d, 43d, 0d);
-                        break;
-                    }
-                }
+                frmMain.PanHint.Children.Add(toast);
+                toast.Show();
 
-                // 根据提示方向准备参数
-                var alignRight = Config.Preference.HintAlignRight;
-                var slideSign = alignRight ? -1d : 1d;
-
-                if (doubleStack is not null)
-                {
-                    var doubleStackTag = (object[])doubleStack.Tag;
-                    // 有重复提示，且该提示的进入动画已播放
-                    if (!ModAnimation.AniIsRun($"Hint Show {doubleStackTag[1]}"))
-                    {
-                        ModAnimation.AniStop($"Hint Hide {doubleStackTag[1]}");
-                        var delay = (800d + ModBase.MathClamp(currentHint.Text!.Length, 5d, 23d) * 180d) *
-                                    ModAnimation.aniSpeed;
-                        ModAnimation.AniStart(new[]
-                            {
-                                ModAnimation.AaX(doubleStack, alignRight ? doubleStack.Margin.Right + 12 : -12 - doubleStack.Margin.Left, 50,
-                                    ease: new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 50, new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaX(doubleStack, slideSign * 8, 50, 100, new ModAnimation.AniEaseOutFluent()),
-                                ModAnimation.AaX(doubleStack, -slideSign * 8, 50, 150, new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaDouble(i =>
-                                {
-                                    percent += (double)i;
-                                    var gradient = (LinearGradientBrush)doubleStack.Background;
-                                    gradient.GradientStops[0].Color = targetColor0 * percent +
-                                                                      new ModBase.MyColor(255d, 255d, 255d) *
-                                                                      (1d - percent);
-                                    gradient.GradientStops[1].Color = targetColor1 * percent +
-                                                                      new ModBase.MyColor(255d, 255d, 255d) *
-                                                                      (1d - percent);
-                                }, 0.7d, 250),
-                                ModAnimation.AaX(doubleStack, -slideSign * 50, 200, (int)Math.Round(delay),
-                                    new ModAnimation.AniEaseInFluent()),
-                                ModAnimation.AaOpacity(doubleStack, -1, 150, (int)Math.Round(delay)),
-                                ModAnimation.AaCode(() => doubleStackTag[0] = false,
-                                    (int)Math.Round(delay)),
-                                ModAnimation.AaHeight(doubleStack, -26, 100, ease: new ModAnimation.AniEaseOutFluent(),
-                                    after: true),
-                                ModAnimation.AaCode(() => frmMain.PanHint.Children.Remove(doubleStack), after: true)
-                            },
-                            $"Hint Hide {doubleStackTag[1]}");
-                    }
-                }
-                else
-                {
-                    // 准备控件
-                    var newHintTag = new object[] { true, ModBase.GetUuid() };
-                    var newHintControl = new Border
-                    {
-                        Tag = newHintTag, Margin = alignRight ? new Thickness(20d, 0d, -70d, 0d) : new Thickness(-70, 0d, 20d, 0d),
-                        Opacity = 0d,
-                        Height = 0d, HorizontalAlignment = alignRight ? HorizontalAlignment.Right : HorizontalAlignment.Left,
-                        CornerRadius = alignRight ? new CornerRadius(6d, 0d, 0d, 6d) : new CornerRadius(0d, 6d, 6d, 0d),
-                        Background = new LinearGradientBrush(
-                            new GradientStopCollection(new List<GradientStop>
-                            {
-                                new(targetColor0 * percent + new ModBase.MyColor(255d, 255d, 255d) * (1d - percent),
-                                    0d),
-                                new(targetColor1 * percent + new ModBase.MyColor(255d, 255d, 255d) * (1d - percent), 1d)
-                            }), 90d),
-                        Child = new TextBlock
-                        {
-                            TextTrimming = TextTrimming.CharacterEllipsis, FontSize = 13d, Text = currentHint.Text,
-                            Foreground = new ModBase.MyColor(255d, 255d, 255d), Margin = alignRight ? new Thickness(8d, 5d, 33d, 5d) : new Thickness(33d, 5d, 8d, 5d)
-                        }
-                    };
-                    // AddHandler NewHintControl.MouseLeftButtonDown, AddressOf HideAllHint
-                    frmMain.PanHint.Children.Add(newHintControl);
-                    // 控件动画
-                    var animations = new List<ModAnimation.AniData>();
-                    if (frmMain.PanHint.Children.Count > 1)
-                        // 已有提示
-                        animations.Add(ModAnimation.AaHeight(newHintControl, 26d, 150,
-                            ease: new ModAnimation.AniEaseOutFluent()));
-                    else
-                        // 是唯一提示
-                        newHintControl.Height = 26d;
-                    // 开始动画
-                    animations.AddRange([
-                        ModAnimation.AaX(newHintControl, slideSign * 30d,
-                            ease: new ModAnimation.AniEaseOutElastic(ModAnimation.AniEasePower.Weak)),
-                        ModAnimation.AaX(newHintControl, slideSign * 20d, 200, ease: new ModAnimation.AniEaseOutFluent()),
-                        ModAnimation.AaOpacity(newHintControl, 1d, 100),
-                        ModAnimation.AaDouble(i =>
-                        {
-                            percent += (double)i;
-                            var gradient = (LinearGradientBrush)newHintControl.Background;
-                            gradient.GradientStops[0].Color = targetColor0 * percent +
-                                                              new ModBase.MyColor(255d, 255d, 255d) * (1d - percent);
-                            gradient.GradientStops[1].Color = targetColor1 * percent +
-                                                              new ModBase.MyColor(255d, 255d, 255d) * (1d - percent);
-                        }, 0.7d, 250, 100)
-                    ]);
-                    ModAnimation.AniStart(animations, $"Hint Show {newHintTag[1]}");
-                    // 结束动画
-                    var delay = (800d + ModBase.MathClamp(currentHint.Text!.Length, 5d, 23d) * 180d) *
-                                ModAnimation.aniSpeed;
-                    ModAnimation.AniStart(
-                        new[]
-                        {
-                            ModAnimation.AaX(newHintControl, -slideSign * 50, 200, (int)Math.Round(delay),
-                                new ModAnimation.AniEaseInFluent()),
-                            ModAnimation.AaOpacity(newHintControl, -1, 150, (int)Math.Round(delay)),
-                            ModAnimation.AaCode(() => newHintTag[0] = false, (int)Math.Round(delay)),
-                            ModAnimation.AaHeight(newHintControl, -26, 100, ease: new ModAnimation.AniEaseOutFluent(),
-                                after: true),
-                            ModAnimation.AaCode(() => frmMain.PanHint.Children.Remove(newHintControl), after: true)
-                        }, $"Hint Hide {newHintTag[1]}");
-                }
-
-                // 结束处理
                 EndHint: ;
 
                 if (currentHint.Log)
@@ -454,21 +318,8 @@ public static class ModMain
 
     private static void HideAllHint()
     {
-        var hideSign = Config.Preference.HintAlignRight ? -1d : 1d;
-        foreach (Border control in frmMain!.PanHint.Children)
-        {
-            var controlTag = (object[])control.Tag;
-            control.IsHitTestVisible = false;
-            ModAnimation.AniStart(
-                new[]
-                {
-                    ModAnimation.AaX(control, -hideSign * 50, 200, ease: new ModAnimation.AniEaseInFluent()),
-                    ModAnimation.AaOpacity(control, -1, 150, ease: new ModAnimation.AniEaseInFluent()),
-                    ModAnimation.AaCode(() => controlTag[0] = false),
-                    ModAnimation.AaHeight(control, -26, 100, ease: new ModAnimation.AniEaseOutFluent(), after: true),
-                    ModAnimation.AaCode(() => frmMain.PanHint.Children.Remove(control), after: true)
-                }, $"Hint Hide {controlTag[1]}");
-        }
+        foreach (MyToast toast in frmMain!.PanHint.Children.OfType<MyToast>().ToList())
+            toast.Dismiss();
     }
 
     #endregion
@@ -906,6 +757,38 @@ public static class ModMain
             button1Action: btnAct1, button2Action: btnAct2, button3Action: btnAct3);
     }
 
+    #endregion
+
+    #region 页面声明
+
+    // 在最后进行页面声明，避免颜色尚未加载完毕
+
+    // 窗体声明
+
+
+    // 页面声明（出于单元测试考虑，初始化页面已转入 FormMain 中）
+
+
+    // 工具页面声明
+
+
+    // 下载页面声明
+
+
+    // 设置页面声明
+
+
+    // 登录页面声明
+
+
+    // 实例设置页面声明
+
+
+    // 实例存档页面
+
+
+    // 资源信息分页声明
+    
     #endregion
 
     #region 愚人节

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -292,7 +292,7 @@ public static class ModMain
 
                 var toast = new MyToast
                 {
-                    Title = currentHint.Text,
+                    Context = currentHint.Text,
                     ToastType = currentHint.Type,
                     Icon = currentHint.Type switch
                     {

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -285,7 +285,10 @@ public static class ModMain
                 currentHint.Text = currentHint.Text.Replace("\r\n", " ").Replace("\r", " ")
                     .Replace("\n", " ");
                 if (frmMain.PanHint.Children.Count >= 5)
-                    goto EndHint;
+                {
+                    var oldest = frmMain.PanHint.Children.OfType<MyToast>().FirstOrDefault();
+                    oldest?.Dismiss();
+                }
 
                 var toast = new MyToast
                 {
@@ -302,8 +305,6 @@ public static class ModMain
 
                 frmMain.PanHint.Children.Add(toast);
                 toast.Show();
-
-                EndHint: ;
 
                 if (currentHint.Log)
                     ModBase.Log("[UI] 弹出提示：" + currentHint.Text);

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -71,9 +71,6 @@
                         <local:MyCheckBox Text="{DynamicResource Setup.Ui.Basic.ShowTriviaHint}" Margin="-1,0,0,7" Height="22"
                                            x:Name="CheckShowLaunchingHint" Tag="UiShowLaunchingHint"
                                            Change="CheckBoxChange" />
-                        <local:MyCheckBox Text="{DynamicResource Setup.Ui.Basic.HintAlignRight}" Margin="-1,0,0,7" Height="22"
-                                           x:Name="CheckHintAlignRight" Tag="UiHintAlignRight"
-                                           Change="CheckBoxChange" />
                         <StackPanel x:Name="PanelBlur" Margin="0,0,0,10">
                             <local:MyCheckBox Text="{DynamicResource Setup.Ui.Basic.AdvancedMaterial}" Height="22" x:Name="CheckBlur" Tag="UiBlur"
                                               ToolTip="{DynamicResource Setup.Ui.Basic.AdvancedMaterial.ToolTip}"

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml.cs
@@ -54,7 +54,6 @@ public partial class PageSetupUI
             ComboDarkColor.SelectedIndex = (int)Config.Preference.Theme.DarkColor;
             ComboLightColor.SelectedIndex = (int)Config.Preference.Theme.LightColor;
             CheckShowLaunchingHint.Checked = Config.Preference.ShowLaunchingHint;
-            CheckHintAlignRight.Checked = Config.Preference.HintAlignRight;
 
             // 字体设置
             ComboUiFont.SelectedFontTag = Config.Preference.Font;
@@ -232,7 +231,6 @@ public partial class PageSetupUI
 
             case "UiLauncherLogo": Config.Preference.ShowStartupLogo = (bool)value; break;
             case "UiShowLaunchingHint": Config.Preference.ShowLaunchingHint = (bool)value; break;
-            case "UiHintAlignRight": Config.Preference.HintAlignRight = (bool)value; ModMain.Hint(Lang.Text("Setup.Ui.Basic.HintAlignRight.Changed")); break;
             case "UiLockWindowSize": Config.Preference.LockWindowSize = (bool)value; break;
             case "UiBlur": Config.Preference.Blur.IsEnabled = (bool)value; break;
             case "UiAutoPauseVideo": Config.Preference.Background.AutoPauseVideo = (bool)value; break;


### PR DESCRIPTION
close #3005
<img width="199" height="171" alt="1072f34311a294426db9201379723d35" src="https://github.com/user-attachments/assets/660384d8-9fac-4b40-a490-d4803177089b" />
<img width="186" height="169" alt="PixPin_2026-06-16_23-36-50" src="https://github.com/user-attachments/assets/9617862b-853d-4b11-a5ff-8c7d0c4be0a4" />

## 由 Sourcery 提供的摘要

将旧版的窗口内提示气泡替换为新的 toast 通知组件，并简化提示位置的处理。

新功能：
- 引入可复用的 MyToast 控件，用于应用内的 toast 通知，支持按类型定制样式、图标、自动消失时间以及手动关闭。

增强内容：
- 将 ModMain 的提示逻辑接入新的 MyToast 控件，限制同时显示的 toast 数量，并将其位置统一为主窗口右下角。
- 通过移除提示对齐方式的用户偏好设置及其相关的设置界面条目，简化提示配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace legacy in-window hint bubbles with a new toast notification component and simplify hint positioning.

New Features:
- Introduce a reusable MyToast control for in-app toast notifications with type-specific styling, icons, auto-dismiss timing, and manual dismissal.

Enhancements:
- Wire ModMain hint logic to use the new MyToast control, limiting concurrent toasts and standardizing their position at the bottom-right of the main window.
- Simplify hint configuration by removing the user preference for hint alignment and its associated settings UI entries.

</details>

## Summary by Sourcery

将旧版窗口内提示气泡替换为统一的 toast 通知系统，并移除与对齐相关的配置。

新功能：
- 引入可复用的 MyToast 控件，用于应用内 toast 通知，并具备按类型区分的图标、样式以及自动消失行为。

改进：
- 将现有的 ModMain 提示逻辑接入新的 MyToast 控件，限制同时显示的 toast 数量，并将其位置统一为主窗口右下角。
- 调整 MyHint 边框样式，使其不再依赖用户可配置的提示对齐方式。

日常维护：
- 移除 UiHintAlignRight 配置选项及其在首选项页面中相关的设置界面接线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the legacy in-window hint bubbles with a unified toast notification system and remove alignment-related configuration.

New Features:
- Introduce a reusable MyToast control for in-app toast notifications with type-specific icon, style, and auto-dismiss behavior.

Enhancements:
- Wire existing ModMain hint logic to use the new MyToast control, limiting concurrent toasts and standardizing their placement at the bottom-right of the main window.
- Adjust MyHint border styling to no longer depend on user-configurable hint alignment.

Chores:
- Remove the UiHintAlignRight configuration option and its associated settings UI wiring from the preferences page.

</details>