### PR TITLE
fix(mod-path): Validate Minecraft library artifact paths

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
@@ -267,8 +267,8 @@ public static class ModLibrary
                             init.Url = (string)(rootUrl ?? library["downloads"]["artifact"]["url"]),
                             init.LocalPath = library["downloads"]["artifact"]["path"] is null
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
-                                : Path.Combine(customMcFolder, "libraries", library["downloads"]["artifact"]["path"].ToString()
-                                    .Replace("/", @"\")),
+                                : McLibGetByArtifactPath(library["downloads"]["artifact"]["path"].ToString(),
+                                    customMcFolder),
                             init.size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["artifact"]["size"].ToString())),
                             init.IsNatives = false, init.Sha1 = library["downloads"]["artifact"]["sha1"]?.ToString(),
@@ -307,9 +307,9 @@ public static class ModLibrary
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
                                     .Replace(".jar", "-" + library["natives"]["windows"] + ".jar")
                                     .Replace("${arch}", Environment.Is64BitOperatingSystem ? "64" : "32")
-                                : Path.Combine(customMcFolder, "libraries",
-                                  library["downloads"]["classifiers"]["natives-windows"]["path"].ToString()
-                                      .Replace("/", @"\")),
+                                : McLibGetByArtifactPath(
+                                    library["downloads"]["classifiers"]["natives-windows"]["path"].ToString(),
+                                    customMcFolder),
                             size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["classifiers"]["natives-windows"]["size"].ToString())),
                             IsNatives = true,
@@ -641,6 +641,29 @@ public static class ModLibrary
         }
 
         return mcLibGetRet;
+    }
+
+    /// <summary>
+    ///     根据 JSON 中的 downloads.artifact.path 获取支持库文件地址。
+    /// </summary>
+    private static string McLibGetByArtifactPath(string artifactPath, string customMcFolder = null)
+    {
+        customMcFolder = customMcFolder ?? ModFolder.mcFolderSelected;
+        if (string.IsNullOrWhiteSpace(artifactPath))
+            throw new ArgumentException("支持库下载路径无效", nameof(artifactPath));
+
+        var librariesRoot = Path.GetFullPath(Path.Combine(customMcFolder, "libraries"));
+        var normalizedArtifactPath = artifactPath.Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(normalizedArtifactPath))
+            throw new IOException("支持库下载路径不能为绝对路径: " + artifactPath);
+
+        var localPath = Path.GetFullPath(Path.Combine(librariesRoot, normalizedArtifactPath));
+        var librariesRootWithSeparator = librariesRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                                         Path.DirectorySeparatorChar;
+        if (!localPath.StartsWith(librariesRootWithSeparator, StringComparison.OrdinalIgnoreCase))
+            throw new IOException("支持库下载路径不能位于 libraries 文件夹外: " + artifactPath);
+
+        return localPath;
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLibrary.cs
@@ -258,6 +258,9 @@ public static class ModLibrary
                                 library["name"].ToString().AfterFirst(":").Replace(":", "-") + ".jar";
                 else
                     localPath = McLibGet((string)library["name"], customMcFolder: customMcFolder);
+                var artifactPath = library["downloads"] is not null && library["downloads"]["artifact"] is not null
+                    ? library["downloads"]["artifact"]["path"]
+                    : null;
                 try
                 {
                     if (library["downloads"] is not null && library["downloads"]["artifact"] is not null)
@@ -265,10 +268,9 @@ public static class ModLibrary
                         var init = new McLibToken();
                         basicArray.Add((init.OriginalName = (string)library["name"],
                             init.Url = (string)(rootUrl ?? library["downloads"]["artifact"]["url"]),
-                            init.LocalPath = library["downloads"]["artifact"]["path"] is null
+                            init.LocalPath = artifactPath is null
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
-                                : McLibGetByArtifactPath(library["downloads"]["artifact"]["path"].ToString(),
-                                    customMcFolder),
+                                : McLibGetByArtifactPath(artifactPath.ToString(), customMcFolder),
                             init.size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["artifact"]["size"].ToString())),
                             init.IsNatives = false, init.Sha1 = library["downloads"]["artifact"]["sha1"]?.ToString(),
@@ -283,6 +285,11 @@ public static class ModLibrary
                         });
                     }
                 }
+                catch (Exception ex) when (artifactPath is not null && (ex is ArgumentException || ex is IOException))
+                {
+                    ModBase.Log(ex, "支持库下载路径非法，已跳过（无 Natives，" + (library["name"] ?? "Nothing") + "）");
+                    continue;
+                }
                 catch (Exception ex)
                 {
                     ModBase.Log(ex, "处理实际支持库列表失败（无 Natives，" + (library["name"] ?? "Nothing") + "）");
@@ -295,6 +302,10 @@ public static class ModLibrary
             }
             else if (library["natives"]["windows"] is not null) // 有 Windows Natives
             {
+                var nativePath = library["downloads"] is not null && library["downloads"]["classifiers"] is not null &&
+                                 library["downloads"]["classifiers"]["natives-windows"] is not null
+                    ? library["downloads"]["classifiers"]["natives-windows"]["path"]
+                    : null;
                 try
                 {
                     if (library["downloads"] is not null && library["downloads"]["classifiers"] is not null &&
@@ -303,13 +314,11 @@ public static class ModLibrary
                         {
                             OriginalName = (string)library["name"],
                             Url = (string)(rootUrl ?? library["downloads"]["classifiers"]["natives-windows"]["url"]),
-                            LocalPath = library["downloads"]["classifiers"]["natives-windows"]["path"] is null
+                            LocalPath = nativePath is null
                                 ? McLibGet((string)library["name"], customMcFolder: customMcFolder)
                                     .Replace(".jar", "-" + library["natives"]["windows"] + ".jar")
                                     .Replace("${arch}", Environment.Is64BitOperatingSystem ? "64" : "32")
-                                : McLibGetByArtifactPath(
-                                    library["downloads"]["classifiers"]["natives-windows"]["path"].ToString(),
-                                    customMcFolder),
+                                : McLibGetByArtifactPath(nativePath.ToString(), customMcFolder),
                             size = (long)Math.Round(
                                 ModBase.Val(library["downloads"]["classifiers"]["natives-windows"]["size"].ToString())),
                             IsNatives = true,
@@ -325,6 +334,11 @@ public static class ModLibrary
                                 .Replace("${arch}", Environment.Is64BitOperatingSystem ? "64" : "32"),
                             size = 0L, IsNatives = true, Sha1 = null, IsLocal = isLocal
                         });
+                }
+                catch (Exception ex) when (nativePath is not null && (ex is ArgumentException || ex is IOException))
+                {
+                    ModBase.Log(ex, "支持库下载路径非法，已跳过（有 Natives，" + (library["name"] ?? "Nothing") + "）");
+                    continue;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
### Motivation
- Prevent untrusted `downloads.artifact.path` values from escaping the intended Minecraft `libraries` directory and enabling arbitrary file writes during library downloads.
- Close a path traversal/absolute-path attack vector introduced when remote LabyMod manifest entries are deep-cloned into the combined version JSON.

### Description
- Route manifest-provided artifact paths through a new helper `McLibGetByArtifactPath` instead of directly combining strings with `Path.Combine` when creating `LocalPath` for downloads.
- Apply the same validation for native classifier paths so both regular artifacts and natives cannot escape the `libraries` folder.
- Implement `McLibGetByArtifactPath` to canonicalize paths with `Path.GetFullPath`, reject absolute (`Path.IsPathRooted`) and blank values, and enforce containment by ensuring the resolved path starts with the `libraries` root.

### Testing
- Ran a `python3` static check that asserts the new `McLibGetByArtifactPath` call sites and containment logic are present, which succeeded.
- Ran `git diff --check` to validate the working tree for whitespace/errors, which produced no issues.
- `dotnet --info` could not be executed in the environment so full runtime build/tests were not run in this container.

------

## Summary by Sourcery

验证 Minecraft 库下载构件的路径，防止在 libraries 目录之外写入文件。

错误修复（Bug Fixes）:
- 确保清单（manifest）中提供的库构件和本地化（native classifier）的路径无法通过绝对路径或路径遍历（traversal paths）逃离 Minecraft 的 libraries 文件夹。

增强功能（Enhancements）:
- 引入一个辅助工具，在构建本地库路径之前，对 `downloads.artifact.path` 的值进行规范化（canonicalize）和校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate Minecraft library download artifact paths to prevent writing files outside the libraries directory.

Bug Fixes:
- Ensure manifest-provided library artifact and native classifier paths cannot escape the Minecraft libraries folder via absolute or traversal paths.

Enhancements:
- Introduce a helper to canonicalize and validate downloads.artifact.path values before constructing local library paths.

</details>