### PR TITLE
fix(download-install): 修复 Minecraft 下载页面`返回顶部`按钮不显示

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -18,10 +18,10 @@ public partial class PageDownloadInstall
 
     public PageDownloadInstall()
     {
-        PanScroll = PanBack;
         Initialized += (_, _) => LoaderInit();
         Loaded += (_, _) => Init();
         InitializeComponent();
+        PanScroll = PanBack;
         LoadMinecraft.Text = Lang.Text("Download.Version.LoadingList");
         BtnBack.Click += (_, _) => ExitSelectPage();
         CardOptiFine.Swap += (_, _) => ReloadSelected();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复由于初始化顺序不正确导致 Minecraft 下载页面的“回到顶部”按钮未显示的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the Minecraft download page 'Back to Top' button not appearing due to incorrect initialization order.

</details>