### PR TITLE
i18n(zh-CN): 完善 Minecraft 披风名称翻译（新增工匠披风、Moonlight Trail 披风）

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -394,6 +394,8 @@
     <sys:String x:Key="Launch.Skin.Cape.Name.Copper">Copper</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.ZombieHorse">Zombie Horse</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.Builder">Builder</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.Crafter">Crafter</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.MoonlightTrail">Moonlight Trail</sys:String>
 
     <!-- Launch.Skin.Cape -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -394,6 +394,8 @@
     <sys:String x:Key="Launch.Skin.Cape.Name.Copper">铜披风</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.ZombieHorse">僵尸马披风</sys:String>
     <sys:String x:Key="Launch.Skin.Cape.Name.Builder">建造者披风</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.Crafter">工匠披风</sys:String>
+    <sys:String x:Key="Launch.Skin.Cape.Name.MoonlightTrail">Moonlight Trail 披风</sys:String>
 
     <!-- Launch.Skin.Cape -->
 


### PR DESCRIPTION
## Summary by Sourcery

改进 Minecraft 披风名称的简体中文本地化。

改进内容：
- 更新 zh-CN 本地化中的现有 Minecraft 披风名称翻译。
- 为新的 Artisan 披风和 Moonlight Trail 披风条目添加 zh-CN 翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Simplified Chinese localization for Minecraft cape names.

Enhancements:
- Update existing Minecraft cape name translations in zh-CN localization.
- Add zh-CN translations for new Artisan cape and Moonlight Trail cape entries.

</details>