### PR TITLE
fix: 实例修改页无法正常显示已安装的cleanroom

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1156,6 +1156,7 @@ public partial class PageInstanceInstall
             };
         if (currentInstance.HasCleanroom)
         {
+            selectedLoaderName = "Cleanroom";
             selectedAPIName = "Cleanroom";
             selectedCleanroomVersion = currentInstance.Cleanroom;
             selectedCleanroom = new ModDownload.DlCleanroomListEntry(selectedCleanroomVersion);

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1158,6 +1158,7 @@ public partial class PageInstanceInstall
         {
             selectedAPIName = "Cleanroom";
             selectedCleanroomVersion = currentInstance.Cleanroom;
+            selectedCleanroom = new ModDownload.DlCleanroomListEntry(selectedCleanroomVersion);
         }
         else if (currentInstance.HasForge)
         {

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1901,6 +1901,7 @@ public partial class PageInstanceInstall
     private void Cleanroom_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedCleanroom = null;
+        selectedCleanroomVersion = null;
         selectedLoaderName = null;
         CardCleanroom.IsSwapped = true;
         e.Handled = true;

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1903,6 +1903,7 @@ public partial class PageInstanceInstall
         selectedCleanroom = null;
         selectedCleanroomVersion = null;
         selectedLoaderName = null;
+        selectedAPIName = null;
         CardCleanroom.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();


### PR DESCRIPTION
~仅需一行更改！（雾~现在不是了

## Summary by Sourcery

Bug Fixes:
- 确保在加载带有 Cleanroom 的实例时初始化选定的 Cleanroom 条目，以便已安装的版本能够正确显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the selected Cleanroom entry is initialized when an instance with Cleanroom is loaded so the installed version displays properly.

</details>

## Summary by Sourcery

修复实例中已选 Cleanroom 配置的初始化和清除逻辑，确保已安装的 Cleanroom 版本显示正确，并在清除时完全重置状态。

Bug 修复：
- 在加载已安装 Cleanroom 的实例时初始化已选 Cleanroom 条目，以便正确显示其版本。
- 在清除 Cleanroom 选择时，同时重置已选的 Cleanroom 版本和 API 名称，避免遗留过期的加载器状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix initialization and clearing of the selected Cleanroom configuration for instances so installed Cleanroom versions display correctly and state is fully reset when clearing.

Bug Fixes:
- Initialize the selected Cleanroom entry when loading an instance that already has Cleanroom installed so its version is shown correctly.
- Reset both the selected Cleanroom version and API name when clearing Cleanroom selection to avoid leaving stale loader state.

</details>