### PR TITLE
imp(java): 增加基于 MFT 的 Java 查找 [Deepseek v4 flash]

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1631,6 +1631,7 @@
     <sys:String x:Key="Setup.Launch.Java.Added">Java added!</sys:String>
     <sys:String x:Key="Setup.Launch.Java.AddFailed">Failed to add Java to the list.</sys:String>
     <sys:String x:Key="Setup.Launch.Java.EnableFailed">Failed to change Java enabled state</sys:String>
+    <sys:String x:Key="Setup.Launch.Java.Hint.MftJavaScanner">Non-administrator mode, MFT quick search disabled.</sys:String>
 
     <!-- Setup.Launch.Advanced -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1631,6 +1631,7 @@
     <sys:String x:Key="Setup.Launch.Java.Added">已添加 Java！</sys:String>
     <sys:String x:Key="Setup.Launch.Java.AddFailed">未能成功将 Java 加入列表中</sys:String>
     <sys:String x:Key="Setup.Launch.Java.EnableFailed">调整 Java 启用状态失败</sys:String>
+    <sys:String x:Key="Setup.Launch.Java.Hint.MftJavaScanner">非管理员模式，已禁用 MFT 快速搜索</sys:String>
 
     <!-- Setup.Launch.Advanced -->
 

--- a/PCL.Core/Minecraft/Java/JavaService.cs
+++ b/PCL.Core/Minecraft/Java/JavaService.cs
@@ -27,6 +27,7 @@ public sealed partial class JavaService
             new DefaultPathsScanner(),
             new PathEnvironmentScanner(),
             new MicrosoftStoreJavaScanner(),
+            new MftJavaScanner(),
             new WhereCommandScanner()
         ]);
         _javaManager.ReadConfig();

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using PCL.Core.App.Localization;
 
 namespace PCL.Core.Minecraft.Java.Scanner;
 
@@ -31,7 +32,7 @@ internal class MftJavaScanner : IJavaScanner
             _ = Task.Run(async () =>
             {
                 await Lifecycle.WaitForStateAsync(LifecycleState.WindowCreated);
-                HintWrapper.Show("非管理员模式，已禁用 MFT 快速搜索", HintTheme.Info);
+                HintWrapper.Show(Lang.Text("Setup.Launch.Java.Hint.MftJavaScanner"), HintTheme.Info);
             });
             return;
         }

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -5,6 +5,7 @@ using PCL.Core.Utils.OS;
 using PCL.Core.App.IoC;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -65,11 +66,16 @@ internal class MftJavaScanner : IJavaScanner
     {
         var drives = DriveInfo.GetDrives()
             .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
-            .Select(d => d.Name.TrimEnd('\\'));
+            .Select(d => d.Name.TrimEnd('\\'))
+            .Where(d => d.Length > 0)
+            .ToList();
 
-        foreach (var drive in drives)
+        if (drives.Count == 0) return;
+
+        var parallelResults = new ConcurrentBag<string>();
+
+        Parallel.ForEach(drives, drive =>
         {
-            if (drive.Length == 0) continue;
 
             var driveLetter = drive[..1];
             try
@@ -90,14 +96,18 @@ internal class MftJavaScanner : IJavaScanner
                     if (!fullPath.EndsWith(Path.Combine("bin", "java.exe"), StringComparison.OrdinalIgnoreCase)) continue;
                     if (!File.Exists(fullPath)) continue;
 
-                    results.Add(fullPath);
+                    parallelResults.Add(fullPath);
                 }
             }
             catch (Exception ex)
             {
                 LogWrapper.Warn(ex, "Java", $"MFT 扫描跳过驱动器 {driveLetter}");
-                continue;
             }
+        });
+
+        foreach (var path in parallelResults)
+        {
+            results.Add(path);
         }
     }
 }

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -14,13 +14,20 @@ namespace PCL.Core.Minecraft.Java.Scanner;
 
 internal class MftJavaScanner : IJavaScanner
 {
-    private static readonly string[] _SkipDirectoryNames =
-    [
-        "$Recycle.Bin", "$RECYCLE.BIN",
-        "Temp", "tmp",
-        "Cache", "caches",
-        "chrome", "chromium", "edge", "firefox", "opera",
-    ];
+    private static readonly HashSet<string> _SkipDirectoryNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "$Recycle.Bin",
+        "$RECYCLE.BIN",
+        "Temp",
+        "tmp",
+        "Cache",
+        "caches",
+        "chrome",
+        "chromium",
+        "edge",
+        "firefox",
+        "opera",
+    };
 
     public void Scan(ICollection<string> results)
     {
@@ -31,8 +38,15 @@ internal class MftJavaScanner : IJavaScanner
             LogWrapper.Info("[Java] 非管理员模式，跳过基于 MFT 的 Java 扫描");
             _ = Task.Run(async () =>
             {
-                await Lifecycle.WaitForStateAsync(LifecycleState.WindowCreated);
-                HintWrapper.Show(Lang.Text("Setup.Launch.Java.Hint.MftJavaScanner"), HintTheme.Info);
+                try
+                {
+                    await Lifecycle.WaitForStateAsync(LifecycleState.WindowCreated);
+                    HintWrapper.Show(Lang.Text("Setup.Launch.Java.Hint.MftJavaScanner"), HintTheme.Info);
+                }
+                catch (Exception ex)
+                {
+                    LogWrapper.Warn(ex, "Java", "非管理员提示任务失败");
+                }
             });
             return;
         }
@@ -55,7 +69,9 @@ internal class MftJavaScanner : IJavaScanner
 
         foreach (var drive in drives)
         {
-            var driveLetter = drive[0].ToString();
+            if (drive.Length == 0) continue;
+
+            var driveLetter = drive[..1];
             try
             {
                 using var volume = MftVolume.Open(driveLetter);
@@ -70,7 +86,7 @@ internal class MftJavaScanner : IJavaScanner
 
                     var fullPath = record.FullPath;
                     if (string.IsNullOrEmpty(fullPath)) continue;
-                    if (_IsSkippedPath(fullPath)) continue;
+                    if (_SkipDirectoryNames.Overlaps(fullPath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))) continue;
                     if (!fullPath.Contains(Path.Combine("bin", "java.exe"), StringComparison.OrdinalIgnoreCase)) continue;
                     if (!File.Exists(fullPath)) continue;
 
@@ -79,15 +95,9 @@ internal class MftJavaScanner : IJavaScanner
             }
             catch (Exception ex)
             {
-                LogWrapper.Warn(ex, "Java", $"MFT 扫描跳过驱动器 {driveLetter}: {ex.Message}");
+                LogWrapper.Warn(ex, "Java", $"MFT 扫描跳过驱动器 {driveLetter}");
                 continue;
             }
         }
-    }
-
-    private static bool _IsSkippedPath(string path)
-    {
-        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return parts.Any(part => _SkipDirectoryNames.Contains(part, StringComparer.OrdinalIgnoreCase));
     }
 }

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -54,9 +54,9 @@ internal class MftJavaScanner : IJavaScanner
 
         foreach (var drive in drives)
         {
+            var driveLetter = drive[0].ToString();
             try
             {
-                var driveLetter = drive[0].ToString();
                 using var volume = MftVolume.Open(driveLetter);
                 var records = volume.FindByName(
                     "java.exe",
@@ -76,8 +76,9 @@ internal class MftJavaScanner : IJavaScanner
                     results.Add(fullPath);
                 }
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex)
             {
+                LogWrapper.Warn(ex, "Java", $"MFT 扫描跳过驱动器 {driveLetter}: {ex.Message}");
                 continue;
             }
         }

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -87,7 +87,7 @@ internal class MftJavaScanner : IJavaScanner
                     var fullPath = record.FullPath;
                     if (string.IsNullOrEmpty(fullPath)) continue;
                     if (_SkipDirectoryNames.Overlaps(fullPath.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))) continue;
-                    if (!fullPath.Contains(Path.Combine("bin", "java.exe"), StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!fullPath.EndsWith(Path.Combine("bin", "java.exe"), StringComparison.OrdinalIgnoreCase)) continue;
                     if (!File.Exists(fullPath)) continue;
 
                     results.Add(fullPath);

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -1,0 +1,91 @@
+using MFTLib;
+using PCL.Core.Logging;
+using PCL.Core.UI;
+using PCL.Core.Utils.OS;
+using PCL.Core.App.IoC;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PCL.Core.Minecraft.Java.Scanner;
+
+internal class MftJavaScanner : IJavaScanner
+{
+    private static readonly string[] _SkipDirectoryNames =
+    [
+        "$Recycle.Bin", "$RECYCLE.BIN",
+        "Temp", "tmp",
+        "Cache", "caches",
+        "chrome", "chromium", "edge", "firefox", "opera",
+    ];
+
+    public void Scan(ICollection<string> results)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        if (!ProcessInterop.IsAdmin())
+        {
+            LogWrapper.Info("[Java] 非管理员模式，跳过基于 MFT 的 Java 扫描");
+            _ = Task.Run(async () =>
+            {
+                await Lifecycle.WaitForStateAsync(LifecycleState.WindowCreated);
+                HintWrapper.Show("非管理员模式，已禁用 MFT 快速搜索", HintTheme.Info);
+            });
+            return;
+        }
+
+        try
+        {
+            _ScanViaMft(results);
+        }
+        catch (Exception ex)
+        {
+            LogWrapper.Error(ex, "Java", "MFT 扫描失败");
+        }
+    }
+
+    private static void _ScanViaMft(ICollection<string> results)
+    {
+        var drives = DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
+            .Select(d => d.Name.TrimEnd('\\'));
+
+        foreach (var drive in drives)
+        {
+            try
+            {
+                var driveLetter = drive[0].ToString();
+                using var volume = MftVolume.Open(driveLetter);
+                var records = volume.FindByName(
+                    "java.exe",
+                    MatchFlags.Contains | MatchFlags.ResolvePaths,
+                    out _);
+
+                foreach (var record in records)
+                {
+                    if (record.IsDirectory) continue;
+
+                    var fullPath = record.FullPath;
+                    if (string.IsNullOrEmpty(fullPath)) continue;
+                    if (_IsSkippedPath(fullPath)) continue;
+                    if (!fullPath.Contains(Path.Combine("bin", "java.exe"), StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!File.Exists(fullPath)) continue;
+
+                    results.Add(fullPath);
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+        }
+    }
+
+    private static bool _IsSkippedPath(string path)
+    {
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return parts.Any(part => _SkipDirectoryNames.Contains(part, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
+++ b/PCL.Core/Minecraft/Java/Scanner/MftJavaScanner.cs
@@ -83,7 +83,7 @@ internal class MftJavaScanner : IJavaScanner
                 using var volume = MftVolume.Open(driveLetter);
                 var records = volume.FindByName(
                     "java.exe",
-                    MatchFlags.Contains | MatchFlags.ResolvePaths,
+                    MatchFlags.ExactMatch | MatchFlags.ResolvePaths,
                     out _);
 
                 foreach (var record in records)

--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -47,6 +47,7 @@
     <ItemGroup>
         <!-- UI -->
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="MFTLib" Version="0.2.0" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
         <PackageReference Include="Wacton.Unicolour" Version="6.4.0" />
         <!-- 语言和系统特性 -->


### PR DESCRIPTION
为 java 查找引入了基于 NTFS 主文件表（MFT）的搜索方式。
由deepseek v4 flash 辅助。

## 来自 Sourcery 的摘要

添加基于 NTFS MFT 的 Java 运行时发现路径，并向用户展示非管理员权限下的限制。

新增功能：
- 引入一个基于 MFT 的 Java 扫描器，用于在固定 NTFS 卷中搜索 `java.exe` 的位置。
- 当应用程序未以管理员权限运行时，在应用内显示一条信息提示，并跳过基于 MFT 的扫描。

增强改进：
- 将新的基于 MFT 的 Java 扫描器接入现有的 Java 发现管线，与其他扫描器协同工作。
- 更新本地化资源，以支持与基于 MFT 的 Java 扫描相关的用户提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将基于 NTFS MFT 的 Java 运行时扫描器集成到现有的 Java 发现流水线中，并向用户展示与权限相关的限制。

New Features:
- 添加一个基于 MFT 的 Java 扫描器，用于在固定 NTFS 卷中搜索 `java.exe` 位置，并将结果贡献给 Java 发现流程。
- 当由于应用程序未以管理员权限运行而跳过基于 MFT 的扫描时，在应用内显示信息提示。

Enhancements:
- 将新的基于 MFT 的 Java 扫描器与现有的发现扫描器一起接入 Java 服务。
- 更新本地化资源，以支持与基于 MFT 的 Java 扫描和管理员权限限制相关的消息。

Build:
- 更新核心项目配置，以引用新 Java 扫描器使用的 MFTLib 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an NTFS MFT-based Java runtime scanner into the existing Java discovery pipeline and surface permission-related limitations to users.

New Features:
- Add an MFT-based Java scanner that searches fixed NTFS volumes for java.exe locations and contributes results to Java discovery.
- Show an in-app informational hint when MFT-based scanning is skipped due to the application not running with administrator privileges.

Enhancements:
- Wire the new MFT-based Java scanner into the Java service alongside existing discovery scanners.
- Update localization resources to support messages related to MFT-based Java scanning and admin-permission limitations.

Build:
- Update the core project configuration to reference the MFTLib dependency used by the new Java scanner.

</details>

</details>

新功能：
- 引入一个基于 MFT 的 Java 扫描器，在固定 NTFS 卷中搜索 `java.exe` 的位置。
- 当程序未以管理员权限运行时，在应用内显示提示并跳过 MFT 扫描。

<details>
<summary>Original summary in English</summary>

## 来自 Sourcery 的摘要

添加基于 NTFS MFT 的 Java 运行时发现路径，并向用户展示非管理员权限下的限制。

新增功能：
- 引入一个基于 MFT 的 Java 扫描器，用于在固定 NTFS 卷中搜索 `java.exe` 的位置。
- 当应用程序未以管理员权限运行时，在应用内显示一条信息提示，并跳过基于 MFT 的扫描。

增强改进：
- 将新的基于 MFT 的 Java 扫描器接入现有的 Java 发现管线，与其他扫描器协同工作。
- 更新本地化资源，以支持与基于 MFT 的 Java 扫描相关的用户提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将基于 NTFS MFT 的 Java 运行时扫描器集成到现有的 Java 发现流水线中，并向用户展示与权限相关的限制。

New Features:
- 添加一个基于 MFT 的 Java 扫描器，用于在固定 NTFS 卷中搜索 `java.exe` 位置，并将结果贡献给 Java 发现流程。
- 当由于应用程序未以管理员权限运行而跳过基于 MFT 的扫描时，在应用内显示信息提示。

Enhancements:
- 将新的基于 MFT 的 Java 扫描器与现有的发现扫描器一起接入 Java 服务。
- 更新本地化资源，以支持与基于 MFT 的 Java 扫描和管理员权限限制相关的消息。

Build:
- 更新核心项目配置，以引用新 Java 扫描器使用的 MFTLib 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an NTFS MFT-based Java runtime scanner into the existing Java discovery pipeline and surface permission-related limitations to users.

New Features:
- Add an MFT-based Java scanner that searches fixed NTFS volumes for java.exe locations and contributes results to Java discovery.
- Show an in-app informational hint when MFT-based scanning is skipped due to the application not running with administrator privileges.

Enhancements:
- Wire the new MFT-based Java scanner into the Java service alongside existing discovery scanners.
- Update localization resources to support messages related to MFT-based Java scanning and admin-permission limitations.

Build:
- Update the core project configuration to reference the MFTLib dependency used by the new Java scanner.

</details>

</details>

</details>