### PR TITLE
fix: 修复 `MyIconButton` 颜色偏浅

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyIconButton.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyIconButton.xaml.cs
@@ -334,7 +334,7 @@ public partial class MyIconButton
         switch (Theme)
         {
             case Themes.Color:
-                SetActiveIconResource("ColorBrush5");
+                SetActiveIconResource("ColorBrush4");
                 break;
             case Themes.White:
                 SetActiveIconBrush(new ModBase.MyColor(234d, 242d, 254d));


### PR DESCRIPTION
close #3162
前：
<img width="140" height="52" alt="PixPin_2026-06-19_14-33-09" src="https://github.com/user-attachments/assets/96a11dcf-94de-48c8-ad72-eb66643aaaa5" />
后：
<img width="135" height="56" alt="PixPin_2026-06-19_14-33-45" src="https://github.com/user-attachments/assets/a80642f7-4ede-4e07-892e-67746f2db580" />

## Summary by Sourcery

Bug Fixes:
- 修正配色主题中 `MyIconButton` 激活状态图标的颜色，避免显示得过于浅淡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct MyIconButton active icon color in color theme to avoid appearing too light.

</details>