### PR TITLE
fix: 修复在集合枚举内操作集合导致 InvalidOperationException

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1320,25 +1320,14 @@ public static class ModModpack
                         }
 
                     var components = (JsonArray)packJson["components"];
-                    foreach (var Patch in patches)
-                    {
-                        // 检查 Patch 是否在 mmc-pack.json 中
-                        var isContainedInPackJson = false;
-                        foreach (var Component in components)
-                            if ((Component["uid"].ToString() ?? "") == (Patch.Key["uid"].ToString() ?? ""))
-                            {
-                                isContainedInPackJson = true;
-                                break;
-                            }
-
-                        if (!isContainedInPackJson)
-                        {
-                            ModBase.Log($"[ModPack] JSON-Patch {Patch.Key["uid"]} 未包含于 mmc-pack.json, 跳过该 Patch");
-                            patches.Remove(Patch);
-                        }
-                    }
-
-                    patches.Sort((x, y) => x.Value.CompareTo(y.Value));
+                    var componentUids = components
+                        .Select(c => c["uid"]?.ToString())
+                        .ToHashSet();
+                    
+                    patches = patches
+                        .Where(p => componentUids.Contains(p.Key["uid"]?.ToString() ?? ""))
+                        .OrderBy(p => p.Value)
+                        .ToList();
                     // 应用 Patches
                     packInfo = new MMCPackInfo();
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1325,7 +1325,7 @@ public static class ModModpack
                         .ToHashSet();
                     
                     patches = patches
-                        .Where(p => componentUids.Contains(p.Key["uid"]?.ToString() ?? ""))
+                        .Where(p => componentUids.Contains(p.Key["uid"]?.ToString()))
                         .OrderBy(p => p.Value)
                         .ToList();
                     // 应用 Patches


### PR DESCRIPTION
This pull request fixes a bug caused by modifying a collection during a foreach iteration.

Qodana 扫出来的一个 bug，顺手修了

~快把鸽子炖了罢~

## Summary by Sourcery

Bug Fixes:
- 通过在枚举过程中避免对补丁集合进行就地删除操作，而是重建一个已过滤并排序的补丁列表，防止出现 `InvalidOperationException`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent InvalidOperationException by avoiding in-place removal from the patches collection during enumeration and instead rebuilding a filtered, ordered list of patches.

</details>