### PR TITLE
fix: 资源搜索存在 use-after-free 问题

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -2801,23 +2801,24 @@ public partial class PageInstanceCompResource : IRefreshable
     {
         var curToken = new CancellationTokenSource();
         var oldToken = Interlocked.Exchange(ref _cancelToken, curToken);
-        oldToken?.Cancel();
-        oldToken?.Dispose();
+        oldToken.Cancel();
+        oldToken.Dispose();
 
         // this exception is ignored
         Dispatcher.BeginInvoke(new Func<Task>(async () =>
         {
             try
             {
-                await Task.Delay(350, curToken.Token);
+                var token = curToken.Token;
+                await Task.Delay(350, token);
                 if (curToken.IsCancellationRequested) return;
                 if (IsSearching)
                 {
                     var searchText = SearchBox.Text;
-                    searchResult = await Task.Run(() => GetSearchResult(searchText), curToken.Token);
+                    searchResult = await Task.Run(() => GetSearchResult(searchText), token);
                 }
 
-                if (curToken.IsCancellationRequested) return;
+                if (token.IsCancellationRequested) return;
                 RefreshUI();
             }
             catch (TaskCanceledException ignore)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -2801,8 +2801,8 @@ public partial class PageInstanceCompResource : IRefreshable
     {
         var curToken = new CancellationTokenSource();
         var oldToken = Interlocked.Exchange(ref _cancelToken, curToken);
-        oldToken.Cancel();
-        oldToken.Dispose();
+        oldToken?.Cancel();
+        oldToken?.Dispose();
 
         // this exception is ignored
         Dispatcher.BeginInvoke(new Func<Task>(async () =>
@@ -2811,7 +2811,7 @@ public partial class PageInstanceCompResource : IRefreshable
             {
                 var token = curToken.Token;
                 await Task.Delay(350, token);
-                if (curToken.IsCancellationRequested) return;
+                if (token.IsCancellationRequested) return;
                 if (IsSearching)
                 {
                     var searchText = SearchBox.Text;


### PR DESCRIPTION
Resolved #2880

## Summary by Sourcery

错误修复：
- 修复资源搜索中的潜在 use-after-free 竞态条件：在异步操作期间，避免直接使用可能已被替换的取消令牌，以防止此类问题发生。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a potential use-after-free race condition in resource search by avoiding direct use of a potentially replaced cancellation token during async operations.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 修复资源搜索中的潜在 use-after-free 竞态条件：在异步操作期间，避免直接使用可能已被替换的取消令牌，以防止此类问题发生。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a potential use-after-free race condition in resource search by avoiding direct use of a potentially replaced cancellation token during async operations.

</details>

</details>