### PR TITLE
feat(download): 下载详情页显示自动下载的前置

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -175,13 +175,13 @@ public static class ModCompDependency
             ?.File;
     }
 
-    public static List<DownloadFile> BuildDependencyDownloads(
+    public static List<(string, DownloadFile)> BuildDependencyDownloads(
         ModDependencyResolutionResult result,
         string targetModsFolder)
     {
         ArgumentNullException.ThrowIfNull(result);
 
-        var downloads = new List<DownloadFile>();
+        var downloads = new List<(string, DownloadFile)>();
         foreach (var install in result.ToInstall.AsEnumerable().Reverse())
         {
             if (!ModComp.compProjectCache.TryGetValue(install.ProjectId, out var depProject))
@@ -203,7 +203,7 @@ public static class ModCompDependency
             }
 
             var targetPath = Path.Combine(targetModsFolder ?? string.Empty, ModComp.CompFileNameGet(depProject, depCompFile));
-            downloads.Add(depCompFile.ToNetFile(targetPath));
+            downloads.Add((depCompFile.FileName, depCompFile.ToNetFile(targetPath)));
         }
 
         return downloads;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -175,7 +175,7 @@ public static class ModCompDependency
             ?.File;
     }
 
-    public static List<(string, DownloadFile)> BuildDependencyDownloads(
+    public static List<(string Filename, DownloadFile File)> BuildDependencyDownloads(
         ModDependencyResolutionResult result,
         string targetModsFolder)
     {

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -387,7 +387,6 @@ public partial class PageDownloadCompDetail
                             cachedFolder.Add(file.Type, targetDir);
                     }
 
-                    var downloadFiles = new List<DownloadFile> { file.ToNetFile(target) };
                     if (file.Type == ModComp.CompType.Mod && Config.Download.Comp.AutoInstallDependencies &&
                         file.Dependencies.Any())
                     {
@@ -449,7 +448,26 @@ public partial class PageDownloadCompDetail
 
                                 ModBase.Log($"[CompDeps] 准备下载: {result.ToInstall.Count} 个前置");
                                 var depDownloads = ModCompDependency.BuildDependencyDownloads(result, targetDir);
-                                downloadFiles = depDownloads.Concat(downloadFiles).ToList();
+                                foreach (var (depFilename, downloadFile) in depDownloads)
+                                {
+                                    var depLoaderName = Lang.Text("Download.Comp.Detail.DownloadResource", desc,
+                                        ModBase.GetFileNameWithoutExtentionFromPath(depFilename));
+                                    var depLoaders = new List<ModLoader.LoaderBase>
+                                    {
+                                        new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadFile"),
+                                            new List<DownloadFile> { downloadFile })
+                                        {
+                                            ProgressWeight = 6,
+                                            block = true
+                                        }
+                                    };
+
+                                    // 启动加载器
+                                    var depLoader = new ModLoader.LoaderCombo<int>(depLoaderName, depLoaders);
+                                    depLoader.OnStateChanged = ModDownloadLib.LoaderStateChangedHintOnly;
+                                    depLoader.Start(1);
+                                    ModLoader.LoaderTaskbarAdd(depLoader);
+                                }
                             }
                             else
                             {
@@ -470,7 +488,7 @@ public partial class PageDownloadCompDetail
                     var loaders = new List<ModLoader.LoaderBase>
                     {
                         new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadFile"),
-                            downloadFiles)
+                            new List<DownloadFile> { file.ToNetFile(target) })
                         {
                             ProgressWeight = 6,
                             block = true


### PR DESCRIPTION
This issue resolves #3190.

本 PR 为被依赖而自动下载的模组的下载任务单独创建 `LoaderDownload`，使得用户可以在下载管理器看到被依赖的模组的下载状况。

## 由 Sourcery 提供的摘要

将自动依赖模组下载拆分为可在下载管理器中看到的独立加载任务。

新功能：
- 在下载管理器中，将自动下载的依赖模组显示为单独的下载任务。

增强改进：
- 调整依赖下载的构建逻辑，使其返回文件名和下载描述符，以便为每个模组的任务提供更清晰的标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate automatic dependency mod downloads into individual loader tasks visible in the download manager.

New Features:
- Show automatically downloaded dependency mods as separate download tasks in the download manager.

Enhancements:
- Adjust dependency download building to return both the file name and download descriptor for better per-mod task labeling.

</details>