### PR TITLE
feat: add http client definition

### DIFF
--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -7,12 +7,9 @@ using PCL.Core.IO.Storage.Cache;
 using PCL.Core.Logging;
 using Polly;
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace PCL.Core.IO.Net;
 
@@ -184,7 +181,7 @@ public partial class NetworkService
             .WaitAndRetryAsync(
                 retry,
                 attempt => retryPolicy.Invoke(attempt),
-                onRetry: (exception, timeSpan, retryAttempt, context) =>
+                onRetry: (exception, timeSpan, retryAttempt, _) =>
                 {
                     LogWrapper.Debug(
                         exception,

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -7,9 +7,12 @@ using PCL.Core.IO.Storage.Cache;
 using PCL.Core.Logging;
 using Polly;
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PCL.Core.IO.Net;
 
@@ -22,17 +25,17 @@ public partial class NetworkService
 
     #region AddressDefinition
 
-    private const string MicrosoftEntraIdServer = "https://login.microsoftonline.com";
+    private const string MicrosoftEntraIdServer = "https://login.microsoftonline.com/";
 
-    private const string MojangPistonMetaServer = "https://piston-meta.mojang.com";
+    private const string MojangPistonMetaServer = "https://piston-meta.mojang.com/";
     
-    private const string MojangSessionServer = "https://sessionserver.mojang.com";
+    private const string MojangSessionServer = "https://sessionserver.mojang.com/";
 
-    private const string CurseForgeApiServer = "https://api.curseforge.com/v1";
+    private const string CurseForgeApiServer = "https://api.curseforge.com/";
 
-    private const string ModrinthApiServer = "https://api.modrinth.com/v2";
+    private const string ModrinthApiServer = "https://api.modrinth.com/";
 
-    private const string MinecraftServiceServer = "https://api.minecraftservices.com";
+    private const string MinecraftServiceServer = "https://api.minecraftservices.com/";
 
     #endregion
 
@@ -65,21 +68,11 @@ public partial class NetworkService
     {
         
         var services = new ServiceCollection();
-        services.ConfigureHttpClientDefaults(b => b.ConfigurePrimaryHttpMessageHandler(static () =>
-            new SocketsHttpHandler
-            {
-                UseProxy = true,
-                AutomaticDecompression = DecompressionMethods.All,
-                Proxy = HttpProxyManager.Instance,
-                AllowAutoRedirect = true,
-                MaxAutomaticRedirections = 20,
-                UseCookies = false,
-                ConnectCallback = Config.Network.EnableDoH
-                    ? HostConnectionHandler.Instance.GetConnectionAsync
-                    : null
-            }).ConfigureHttpClient( c=> c.DefaultRequestHeaders
-            .UserAgent.Add(new ProductInfoHeaderValue("PCL-CE", Basics.VersionName)
-            )).SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime)));
+        services.ConfigureHttpClientDefaults(b => b
+            .ConfigurePrimaryHttpMessageHandler(_GetSocketsHttpHandler)
+            .ConfigureHttpClient(c => c.DefaultRequestHeaders
+                .UserAgent.Add(new ProductInfoHeaderValue("PCL-CE", Basics.VersionName)))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime)));
         
         // 默认的 HTTP Client
         
@@ -90,6 +83,7 @@ public partial class NetworkService
         services.AddHttpClient(CurseForgeApi).ConfigureHttpClient(c =>
         {
             c.DefaultRequestHeaders.Add("x-api-key", Secrets.CurseForgeAPIKey);
+            c.BaseAddress = new Uri(CurseForgeApiServer);
         });
         
         // Modrinth
@@ -130,18 +124,8 @@ public partial class NetworkService
         // Cache
         services.AddHttpClient(Cache)
             .ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
-            new SocketsHttpHandler
-            {
-                UseProxy = true,
-                UseCookies = false,
-                AutomaticDecompression = DecompressionMethods.All,
-                Proxy = HttpProxyManager.Instance,
-                AllowAutoRedirect = true,
-                MaxAutomaticRedirections = 20,
-                ConnectCallback = Config.Network.EnableDoH
-                    ? HostConnectionHandler.Instance.GetConnectionAsync
-                    : null
-            }, CacheServiceManager.Current)).SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime));
+            _GetSocketsHttpHandler(),CacheServiceManager.Current
+            )).SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime));
 
         _provider?.Dispose();
         _provider = services.BuildServiceProvider();
@@ -153,6 +137,17 @@ public partial class NetworkService
     {
         _provider?.Dispose();
     }
+
+    private static SocketsHttpHandler _GetSocketsHttpHandler() => new SocketsHttpHandler
+    {
+        UseProxy = true,
+        AutomaticDecompression = DecompressionMethods.All,
+        Proxy = HttpProxyManager.Instance,
+        AllowAutoRedirect = true,
+        MaxAutomaticRedirections = 20,
+        UseCookies = false,
+        ConnectCallback = Config.Network.EnableDoH ? HostConnectionHandler.Instance.GetConnectionAsync : null
+    };
 
     /// <summary>
     /// 获取 HttpClient

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -31,9 +31,9 @@ public partial class NetworkService
     
     private const string MojangSessionServer = "https://sessionserver.mojang.com/";
 
-    private const string CurseForgeApiServer = "https://api.curseforge.com/";
+    private const string CurseForgeApiServer = "https://api.curseforge.com/v1/";
 
-    private const string ModrinthApiServer = "https://api.modrinth.com/";
+    private const string ModrinthApiServer = "https://api.modrinth.com/v2/";
 
     private const string MinecraftServiceServer = "https://api.minecraftservices.com/";
 

--- a/PCL.Core/IO/Net/NetworkService.cs
+++ b/PCL.Core/IO/Net/NetworkService.cs
@@ -9,6 +9,7 @@ using Polly;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace PCL.Core.IO.Net;
 
@@ -16,16 +17,56 @@ namespace PCL.Core.IO.Net;
 [LifecycleScope("network", "网络服务")]
 public partial class NetworkService
 {
+
+    private const int LifeTime = 15;
+
+    #region AddressDefinition
+
+    private const string MicrosoftEntraIdServer = "https://login.microsoftonline.com";
+
+    private const string MojangPistonMetaServer = "https://piston-meta.mojang.com";
+    
+    private const string MojangSessionServer = "https://sessionserver.mojang.com";
+
+    private const string CurseForgeApiServer = "https://api.curseforge.com/v1";
+
+    private const string ModrinthApiServer = "https://api.modrinth.com/v2";
+
+    private const string MinecraftServiceServer = "https://api.minecraftservices.com";
+
+    #endregion
+
+    #region HttpClientName
+
+    public const string Default = "default";
+
+    public const string MicrosoftEntraId = "microsoft_id";
+
+    public const string MinecraftService = "minecraft_service";
+
+    public const string Cache = "cache";
+
+    public const string MojangPistonMeta = "mojang_piston";
+
+    public const string MojangSession = "mojang_session";
+
+    public const string CurseForgeApi = "curseforge_api";
+
+    public const string ModrinthApi = "modrinth_api";
+
+
+    #endregion
+    
     private static ServiceProvider? _provider;
     private static IHttpClientFactory? _factory;
 
     [LifecycleStart]
     private static void _Start()
     {
-        // 重新构建服务提供者，添加带缓存的 HTTP 客户端
+        
         var services = new ServiceCollection();
-        services.AddHttpClient("default")
-            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+        services.ConfigureHttpClientDefaults(b => b.ConfigurePrimaryHttpMessageHandler(static () =>
+            new SocketsHttpHandler
             {
                 UseProxy = true,
                 AutomaticDecompression = DecompressionMethods.All,
@@ -34,11 +75,60 @@ public partial class NetworkService
                 MaxAutomaticRedirections = 20,
                 UseCookies = false,
                 ConnectCallback = Config.Network.EnableDoH
-                        ? HostConnectionHandler.Instance.GetConnectionAsync
-                        : null
-            }
-            );
-        services.AddHttpClient("cache")
+                    ? HostConnectionHandler.Instance.GetConnectionAsync
+                    : null
+            }).ConfigureHttpClient( c=> c.DefaultRequestHeaders
+            .UserAgent.Add(new ProductInfoHeaderValue("PCL-CE", Basics.VersionName)
+            )).SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime)));
+        
+        // 默认的 HTTP Client
+        
+        services.AddHttpClient(Default);
+        
+        // CurseForge
+
+        services.AddHttpClient(CurseForgeApi).ConfigureHttpClient(c =>
+        {
+            c.DefaultRequestHeaders.Add("x-api-key", Secrets.CurseForgeAPIKey);
+        });
+        
+        // Modrinth
+
+        services.AddHttpClient(ModrinthApi).ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri(ModrinthApiServer);
+        });
+        
+        // Microsoft Entra ID
+        
+        services.AddHttpClient(MicrosoftEntraId).ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri(MicrosoftEntraIdServer);
+        });
+        
+        // Minecraft Service API
+
+        services.AddHttpClient(MinecraftService).ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri(MinecraftServiceServer);
+        });
+        
+        // Mojang Piston Manifest
+
+        services.AddHttpClient(MojangPistonMeta).ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri(MojangPistonMetaServer);
+        });
+        
+        // Mojang Session Server
+
+        services.AddHttpClient(MojangSession).ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri(MojangSessionServer);
+        });
+        
+        // Cache
+        services.AddHttpClient(Cache)
             .ConfigurePrimaryHttpMessageHandler(() => new HttpCacheHandler(
             new SocketsHttpHandler
             {
@@ -51,7 +141,7 @@ public partial class NetworkService
                 ConnectCallback = Config.Network.EnableDoH
                     ? HostConnectionHandler.Instance.GetConnectionAsync
                     : null
-            }, CacheServiceManager.Current));
+            }, CacheServiceManager.Current)).SetHandlerLifetime(TimeSpan.FromMinutes(LifeTime));
 
         _provider?.Dispose();
         _provider = services.BuildServiceProvider();


### PR DESCRIPTION
添加了多个适用于不同端点的 HttpClient

## Summary by Sourcery

在 NetworkService 中为常见的外部服务定义并注册带类型的 HTTP 客户端，统一配置和生命周期管理。

新功能：
- 为默认、缓存、Microsoft Entra ID、Minecraft Services、Mojang Piston meta、Mojang session、CurseForge API 和 Modrinth API 等端点引入具名 HTTP 客户端。
- 为各服务配置特定的默认设置，例如基础地址（base address）、认证头（authentication header），以及用于所有向外 HTTP 请求的共享 User-Agent 头。

增强：
- 通过 `ConfigureHttpClientDefaults` 集中管理 HTTP 处理程序（handler）配置，并为所有 HTTP 客户端（包括缓存客户端）应用一致的处理程序生命周期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define and register typed HTTP clients for common external services within NetworkService, standardizing configuration and lifetimes.

New Features:
- Introduce named HTTP clients for default, cache, Microsoft Entra ID, Minecraft Services, Mojang Piston meta, Mojang session, CurseForge API, and Modrinth API endpoints.
- Configure service-specific defaults such as base addresses, authentication headers, and a shared User-Agent header for outbound HTTP requests.

Enhancements:
- Centralize HTTP handler configuration via ConfigureHttpClientDefaults and apply a consistent handler lifetime for all HTTP clients, including the cached client.

</details>