### PR TITLE
feat(save): 存档页面添加跳转到下载世界页面的按钮

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml
@@ -19,6 +19,7 @@
                         <ColumnDefinition Width="1*" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="1*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Row="0" Grid.ColumnSpan="4" Margin="0,0,0,9" HorizontalAlignment="Center"
@@ -36,6 +37,11 @@
                                     Margin="10,10,10,0"
                                     Padding="13,0" ColorType="Highlight" />
                     <local:MyButton Grid.Row="3" Grid.Column="2" Height="35" HorizontalAlignment="Center"
+                                    Click="BtnDownloadNew_Click"
+                                    MinWidth="140" Text="{DynamicResource Instance.Resource.DownloadNew}"
+                                    Margin="10,10,10,0"
+                                    Padding="13,0" />
+                    <local:MyButton Grid.Row="3" Grid.Column="3" Height="35" HorizontalAlignment="Center"
                                     Click="BtnPaste_Click"
                                     MinWidth="140" Text="{DynamicResource Instance.Saves.PasteFile}"
                                     Margin="10,10,10,0"
@@ -53,12 +59,17 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="Button" />
                         </Grid.ColumnDefinitions>
                         <local:MyButton Grid.Column="0" MinWidth="140"
                                         Text="{DynamicResource Instance.Saves.OpenFolder}" Padding="13,0"
                                         Margin="0,0,20,0" Click="BtnOpenFolder_Click"
                                         HorizontalAlignment="Left" ColorType="Highlight" />
                         <local:MyButton Grid.Column="1" MinWidth="140"
+                                        Text="{DynamicResource Instance.Resource.DownloadNew}" Padding="13,0"
+                                        Margin="0,0,20,0" Click="BtnDownloadNew_Click"
+                                        HorizontalAlignment="Left" />
+                        <local:MyButton Grid.Column="2" MinWidth="140"
                                         Text="{DynamicResource Instance.Saves.PasteFile}" Padding="13,0"
                                         Margin="0,0,20,0" Click="BtnPaste_Click"
                                         HorizontalAlignment="Left" />

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
@@ -413,6 +413,7 @@ public partial class PageInstanceSaves : IRefreshable
     private void BtnDownloadNew_Click(object sender, MouseButtonEventArgs e)
     {
         ModMain.frmMain.PageChange(FormMain.PageType.Download, FormMain.PageSubType.DownloadWorld);
+        PageComp.targetVersion = PageInstanceLeft.McInstance; // 将当前实例设置为筛选器
     }
 
     #region 搜索和排序

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves.xaml.cs
@@ -410,6 +410,11 @@ public partial class PageInstanceSaves : IRefreshable
         ModMain.frmMain.BtnExtraDownload.Ribble();
     }
 
+    private void BtnDownloadNew_Click(object sender, MouseButtonEventArgs e)
+    {
+        ModMain.frmMain.PageChange(FormMain.PageType.Download, FormMain.PageSubType.DownloadWorld);
+    }
+
     #region 搜索和排序
 
     private SortMethod _currentSortMethod = SortMethod.FileName;


### PR DESCRIPTION
This PR resolves #3196.

## Summary by Sourcery

新功能：
- 在存档页面添加一个按钮，用于打开世界下载页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add a button on the saves page that opens the world download page.

</details>