### PR TITLE
feat(mymsgbox): 实现部分控件的 MVVM 设计

### DIFF
--- a/PCL.Core/Utils/Exts/EnumerableExtensions.cs
+++ b/PCL.Core/Utils/Exts/EnumerableExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PCL.Core.Utils.Exts;
+
+public static class EnumerableExtensions
+{
+    /// <summary>
+    /// 对目标集合进行枚举，并传递该元素在集合中的位置
+    /// </summary>
+    /// <param name="collection">要枚举的集合</param>
+    /// <param name="handle">处理函数</param>
+    /// <typeparam name="T">类型</typeparam>
+    public static void ForEachIndexed<T>(this IEnumerable<T> collection, Action<T, int> handle)
+    {
+        var i = 0;
+        foreach (var element in collection)
+        {
+            handle.Invoke(element ,i);
+            i++;
+        }
+    }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgBoxCommand.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgBoxCommand.cs
@@ -1,0 +1,39 @@
+﻿using System.Windows.Input;
+using PCL.Controls.MyMsg.Models;
+using PCL.Core.Utils.Exts;
+
+namespace PCL.Controls.MyMsg.Commands;
+
+public class MyMsgBoxCommand: ICommand
+{
+    public MyMsgBoxCommand(ButtonContext[] contexts)
+    {
+        contexts.ForEachIndexed((value, index) => OperateMap[index] = value);
+    }
+
+    public event Action? Exited;
+
+    public event Action<int>? Clicked;
+
+    public event EventHandler? CanExecuteChanged;
+    
+    private Dictionary<int, ButtonContext> OperateMap { get; set; } = [];
+
+    public string GetButtonTextById(int id) =>
+        OperateMap.FirstOrDefault(key => key.Key == id).Value.ButtonName;
+
+    public bool CanExecute(object? parameter) =>
+        parameter is not null && OperateMap.ContainsKey((int)parameter);
+
+    public void Execute(object? parameter)
+    {
+        
+        if(parameter is null 
+           || !OperateMap.TryGetValue((int)parameter, out var op)) return;
+        
+        Clicked?.Invoke((int)parameter);
+        
+        op.Operation.Invoke(parameter);
+        if(op.ExitWhenClick) Exited?.Invoke();
+    }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputButtonCommand.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputButtonCommand.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Input;
+
+namespace PCL.Controls.MyMsg.Commands;
+
+public class MyMsgInputButtonCommand: ICommand
+{
+    public event Action? Exited;
+    
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => true;
+
+    public void Execute(object? parameter) => Exited?.Invoke();
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputCommand.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace PCL.Controls.MyMsg.Commands;
+
+public class MyMsgInputCommand
+{
+    
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputCommand.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Commands/MyMsgInputCommand.cs
@@ -1,6 +1,30 @@
-﻿namespace PCL.Controls.MyMsg.Commands;
+﻿using System.Windows.Input;
+using FluentValidation;
 
-public class MyMsgInputCommand
+namespace PCL.Controls.MyMsg.Commands;
+
+public class MyMsgInputCommand: ICommand
 {
+    public List<IValidator<string>> ValidateRules { get; } = [];
+    public event Action<string>? Error;
+
+    public event Action? Success;
+
+    public event EventHandler? CanExecuteChanged;
+
+    public void Execute(object? parameter)
+    {
+        var userInput = parameter?.ToString()!;
+        foreach (var rule in ValidateRules)
+        {
+            var result = rule.Validate(userInput);
+            if(result.IsValid) continue;
+            Error?.Invoke(string.Join(Environment.NewLine, result.Errors.Select(e => e.ErrorMessage)));
+            return;
+        }
+        Success?.Invoke();
+    }
     
+    public bool CanExecute(object? parameter) => true;
+
 }

--- a/Plain Craft Launcher 2/Controls/MyMsg/Models/ButtonContext.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Models/ButtonContext.cs
@@ -1,0 +1,8 @@
+﻿namespace PCL.Controls.MyMsg.Models;
+
+public class ButtonContext
+{
+    public required string ButtonName { get; set; }
+    public bool ExitWhenClick { get; set; }
+    public Action<object> Operation { get; set; }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgInputData.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgInputData.cs
@@ -1,0 +1,8 @@
+﻿namespace PCL.Controls.MyMsg.Models;
+
+public class MyMsgInputData
+{
+    public string? UserInput { get; set; }
+    
+    public string? Description { get; set; }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgInputData.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgInputData.cs
@@ -1,8 +1,45 @@
-﻿namespace PCL.Controls.MyMsg.Models;
+﻿using System.Windows.Input;
+using FluentValidation;
+using PCL.Controls.MyMsg.Commands;
+
+namespace PCL.Controls.MyMsg.Models;
 
 public class MyMsgInputData
 {
+    
     public string? UserInput { get; set; }
     
     public string? Description { get; set; }
+    
+    public bool NoError { get; set; }
+
+    public ICommand Command;
+
+    public MyMsgInputData(string description)
+    {
+        Description = description;
+        var command = new MyMsgInputCommand();
+        command.Error += _ => NoError = false;
+        command.Success += () => NoError = true;
+        Command = command;
+    }
+
+    public MyMsgInputData(List<IValidator<string>> rules)
+    {
+        var command = new MyMsgInputCommand();
+        command.Error += _ => NoError = false;
+        command.Success += () => NoError = true;
+        rules.ForEach(v => command.ValidateRules.Add(v));
+        Command = command;
+    }
+
+    public MyMsgInputData(string description, List<IValidator<string>> rules)
+    {
+        Description = description;
+        var command = new MyMsgInputCommand();
+        command.Error += _ => NoError = false;
+        command.Success += () => NoError = true;
+        rules.ForEach(v => command.ValidateRules.Add(v));
+        Command = command;
+    }
 }

--- a/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgTextData.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/Models/MyMsgTextData.cs
@@ -1,0 +1,50 @@
+﻿using System.Windows.Input;
+using PCL.Controls.MyMsg.Commands;
+
+// 非常感谢龙猫送来的工作量，非常感谢！！！
+
+namespace PCL.Controls.MyMsg.Models;
+
+public class MyMsgTextData
+{
+    /// <summary>
+    /// 退出事件
+    /// </summary>
+    public event Action? Exited;
+    /// <summary>
+    /// 窗口消息
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// 标题
+    /// </summary>
+    public string Title { get; set; } = "提示";
+    
+    public MyMsgTextData(string message) : this(message,
+        new ButtonContext
+        {
+            ButtonName = "确定", ExitWhenClick = true, Operation = static _ => { }
+        },
+        new ButtonContext
+        {
+            ButtonName = "取消", ExitWhenClick = true, Operation = static _ => { }
+        }
+    ){}
+
+    public MyMsgTextData(string message, params ButtonContext[] buttons)
+    {
+        Message = message;
+        var cmd =new MyMsgBoxCommand(buttons);
+        cmd.Exited += () => Exited?.Invoke();
+        cmd.Clicked += value => Result = value;
+        Command = cmd;
+    }
+    
+    /// <summary>
+    /// 执行器
+    /// </summary>
+    public ICommand Command { get; set; }
+    
+    public int Result { get; set; }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgInput.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgInput.xaml.cs
@@ -1,7 +1,9 @@
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using PCL.Controls.MyMsg.Models;
 using PCL.Core.UI.Controls;
 
 namespace PCL;
@@ -10,7 +12,7 @@ public partial class MyMsgInput
 {
     private readonly ModMain.MyMsgBoxConverter myConverter;
     private readonly int uuid = ModBase.GetUuid();
-
+    
     public MyMsgInput(ModMain.MyMsgBoxConverter converter)
     {
         try

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgInput.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgInput.xaml.cs
@@ -3,7 +3,9 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using PCL.Controls.MyMsg.Commands;
 using PCL.Controls.MyMsg.Models;
+using PCL.Controls.MyMsg.ViewModels;
 using PCL.Core.UI.Controls;
 
 namespace PCL;
@@ -12,6 +14,15 @@ public partial class MyMsgInput
 {
     private readonly ModMain.MyMsgBoxConverter myConverter;
     private readonly int uuid = ModBase.GetUuid();
+    
+    public MyMsgInput(MyMsgInputData data)
+    {
+        var command = new MyMsgInputButtonCommand();
+        command.Exited += Close;
+        DataContext = new MyMsgInputViewModel(data, command);
+        var buttonCommand = new MyMsgInputButtonCommand();
+        
+    }
     
     public MyMsgInput(ModMain.MyMsgBoxConverter converter)
     {

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgText.xaml
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgText.xaml
@@ -24,7 +24,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" FontSize="23" TextTrimming="None" Foreground="{DynamicResource ColorBrush2}"
-                       HorizontalAlignment="Left" Name="LabTitle" Margin="7,-1,70,9" Text="测试标题文本"
+                       HorizontalAlignment="Left" Name="LabTitle" Margin="7,-1,70,9" Text="{Binding Title}"
                        VerticalAlignment="Top" SnapsToDevicePixels="False" UseLayoutRounding="False" />
             <Rectangle x:Name="ShapeLine" Grid.Row="1" Height="2" Fill="{Binding Foreground, ElementName=LabTitle}" />
             <my:MyScrollViewer Grid.Row="3" VerticalAlignment="Top" x:Name="PanCaption" Margin="0,0,0,17"

--- a/Plain Craft Launcher 2/Controls/MyMsg/MyMsgText.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/MyMsgText.xaml.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using PCL.Controls.MyMsg.Models;
+using PCL.Controls.MyMsg.ViewModels;
 using PCL.Core.UI.Controls;
 
 namespace PCL;
@@ -11,6 +14,16 @@ public partial class MyMsgText
     private readonly ModMain.MyMsgBoxConverter myConverter;
     private readonly int uuid = ModBase.GetUuid();
 
+    public MyMsgText(MyMsgTextData data)
+    {
+        data.Exited += Close;
+        
+        DataContext = new MyMsgTextViewModel(data);
+        InitializeComponent();
+        ShapeLine.StrokeThickness = ModBase.GetWPFSize(1d);
+        Loaded += Load;
+    }
+    
     public MyMsgText(ModMain.MyMsgBoxConverter converter)
     {
         try

--- a/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/MyMsgInputViewModel.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/MyMsgInputViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows.Input;
+using PCL.Controls.MyMsg.Commands;
+using PCL.Controls.MyMsg.Models;
+
+namespace PCL.Controls.MyMsg.ViewModels;
+
+public class MyMsgInputViewModel: ViewModelBase
+{
+    public string ErrorDescription
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            SetProperty(value, ref field);
+        }
+    } = "";
+    
+    public ICommand ButtonCommand { get; set; }
+    public ICommand ValidateCommand { get; set; }
+
+    public MyMsgInputViewModel(MyMsgInputData data, ICommand buttonCommand)
+    {
+        ((MyMsgInputCommand)data.Command).Error += value => ErrorDescription = value;
+        ButtonCommand = buttonCommand;
+        ValidateCommand = data.Command;
+    }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/MyMsgTextViewModel.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/MyMsgTextViewModel.cs
@@ -1,0 +1,111 @@
+﻿using System.Windows;
+using System.Windows.Input;
+using PCL.Controls.MyMsg.Commands;
+using PCL.Controls.MyMsg.Models;
+
+namespace PCL.Controls.MyMsg.ViewModels;
+
+public class MyMsgTextViewModel: ViewModelBase
+{
+    public string Title
+    {
+        get;
+        set
+        {
+            if(field == value) return;
+            SetProperty(value, ref field);
+        }
+    }
+
+    public string Message
+    {
+        get;
+        set
+        {
+            if(field == value) return;
+            SetProperty(value, ref field);
+        }
+    }
+
+    public Visibility Button1Visibility
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            SetProperty(value, ref field);
+        }
+    }
+    
+    
+    public Visibility Button2Visibility
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            SetProperty(value, ref field);
+        }
+    }
+    
+    
+    public Visibility Button3Visibility
+    {
+        get;
+        set
+        {
+            if (field == value) return;
+            SetProperty(value, ref field);
+        }
+    }
+
+    public string Button1Text
+    {
+        get;
+        set
+        {
+            if(value == field) return;
+            SetProperty(value, ref field);
+        }
+    }
+
+    public string Button2Text
+    {
+        get;
+        set
+        {
+            if(value == field) return;
+            SetProperty(value, ref field);
+        }
+    }
+    
+    public string Button3Text
+    {
+        get;
+        set
+        {
+            if(value == field) return;
+            SetProperty(value, ref field);
+        }
+    }
+
+    public ICommand Context { get; set; }
+
+    public MyMsgTextViewModel(MyMsgTextData data)
+    {
+        var cmd = (MyMsgBoxCommand)data.Command;
+        Context = data.Command;
+        Title = data.Title;
+        Message = data.Message;
+        var hasButton1 = Context.CanExecute(0);
+        var hasButton2 = Context.CanExecute(1);
+        var hasButton3 = Context.CanExecute(2);
+        if (!hasButton1) throw new InvalidOperationException("必须提供至少一个按钮");
+        Button1Visibility = hasButton1 ? Visibility.Visible : Visibility.Collapsed;
+        Button2Visibility = hasButton2 ? Visibility.Visible : Visibility.Collapsed;
+        Button3Visibility = hasButton3 ? Visibility.Visible : Visibility.Collapsed;
+        Button1Text = cmd.GetButtonTextById(0);
+        Button2Text = cmd.GetButtonTextById(1);
+        Button3Text = cmd.GetButtonTextById(2);
+    }
+}

--- a/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/ViewModelBase.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/ViewModels/ViewModelBase.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace PCL.Controls.MyMsg.ViewModels;
+
+public class ViewModelBase: INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void SetProperty<T>(T newValue, ref T value, [CallerMemberName] string propertyName = "")
+    {
+        value = newValue;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Plain Craft Launcher 2/Modules/ModMain.cs
+++ b/Plain Craft Launcher 2/Modules/ModMain.cs
@@ -11,6 +11,7 @@ using System.Windows.Threading;
 using FluentValidation;
 using Microsoft.VisualBasic;
 using Microsoft.Win32;
+using PCL.Controls.MyMsg.Models;
 using PCL.Core.App;
 using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
@@ -96,9 +97,14 @@ public static class ModMain
     private static int timer150Count;
 
     /// <summary>
-    ///     等待显示的弹窗。
+    /// 等待显示的弹窗。
     /// </summary>
     public static List<MyMsgBoxConverter> WaitingMyMsgBox { get; } = [];
+
+    /// <summary>
+    /// 等待显示的 MyMsgBox
+    /// </summary>
+    public static List<MyMsgTextData> WaitMyMsgData { get; } = [];
 
     private static void TimerMain()
     {
@@ -126,6 +132,7 @@ public static class ModMain
             try
             {
                 #region 每 250ms 执行一次的代码
+
             }
 
             #endregion
@@ -393,6 +400,11 @@ public static class ModMain
         return 1;
     }
 
+    public static int MyMsgBox(MyMsgTextData data)
+    {
+
+    }
+
     /// <summary>
     ///     显示弹窗，返回点击按钮的编号（从 1 开始）。
     /// </summary>
@@ -405,7 +417,8 @@ public static class ModMain
     /// <param name="button2Action">点击第二个按钮将执行该方法，不关闭弹窗。</param>
     /// <param name="button3Action">点击第三个按钮将执行该方法，不关闭弹窗。</param>
     /// <param name="isWarn">是否为警告弹窗，若为 True，弹窗配色和背景会变为红色。</param>
-    public static int MyMsgBoxMarkdown(string caption, string? title = null, string? button1 = null, string? button2 = "",
+    public static int MyMsgBoxMarkdown(string caption, string? title = null, string? button1 = null,
+        string? button2 = "",
         string? button3 = "", bool isWarn = false, bool highLight = true, bool forceWait = false,
         Action button1Action = null, Action button2Action = null, Action button3Action = null)
     {
@@ -566,7 +579,36 @@ public static class ModMain
         return (int?)converter.Result;
     }
 
-
+    public static void MyMsgBoxShow()
+    {
+        try
+        {
+            if (frmMain is null || frmMain.PanMsg is null || frmMain.WindowState == WindowState.Minimized)
+                return;
+            if (frmMain.PanMsg.Children.Count > 0)
+            {
+                // 弹窗中
+                frmMain.PanMsgBackground.Visibility = Visibility.Visible;
+            }
+            else if (WaitingMyMsgBox.Count != 0)
+            {
+                // 没有弹窗，显示一个等待的弹窗
+                frmMain.PanMsgBackground.Visibility = Visibility.Visible;
+                frmMain.PanMsg.Children.Add(new MyMsgText(WaitMyMsgData[0]));
+                WaitMyMsgData.RemoveAt(0);
+            }
+            // 没有弹窗，没有等待的弹窗
+            else if (!(frmMain.PanMsgBackground.Visibility == Visibility.Collapsed))
+            {
+                frmMain.PanMsgBackground.Visibility = Visibility.Collapsed;
+            }
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "处理等待中的弹窗失败", ModBase.LogLevel.Feedback);
+        }
+    }
+    
     public static void MyMsgBoxTick()
     {
         try
@@ -578,7 +620,7 @@ public static class ModMain
                 // 弹窗中
                 frmMain.PanMsgBackground.Visibility = Visibility.Visible;
             }
-            else if (WaitingMyMsgBox.Any())
+            else if (WaitingMyMsgBox.Count != 0)
             {
                 // 没有弹窗，显示一个等待的弹窗
                 frmMain.PanMsgBackground.Visibility = Visibility.Visible;


### PR DESCRIPTION
将部分控件转换为 MVVM 设计模式，以便实现控件解耦合

Work In Progress

## Summary by Sourcery

为消息框控件引入 MVVM 风格的基础设施，并开始将其集成到现有的消息系统中。

新功能：
- 添加 `MyMsgTextData` 和 `ButtonContext` 模型以及 `MyMsgBoxCommand`，以解耦的、基于命令的方式描述消息内容和按钮行为。
- 添加 `MyMsgTextViewModel` 和 `ViewModelBase`，以支持消息框文本对话框的 MVVM 绑定，包括按钮可见性和标签。
- 添加可枚举扩展 `ForEachIndexed`，以简化在整个代码库中需要索引的迭代逻辑。

增强内容：
- 新增一个接受基于 MVVM 的 `MyMsgTextData` 的 `MyMsgText` 构造函数，并将其绑定到新的视图模型。
- 在 `ModMain` 中为待处理的 `MyMsgTextData` 实例添加存储和显示逻辑，与现有基于 `MyMsgBoxConverter` 的队列机制并行工作。
- 优化 `MyMsgBoxTick` 逻辑，改用显式的 `Count` 检查来处理待显示的消息框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MVVM-style infrastructure for message box controls and begin integrating it into the existing message system.

New Features:
- Add MyMsgTextData and ButtonContext models plus MyMsgBoxCommand to describe message content and button behavior in a decoupled, command-based way.
- Add MyMsgTextViewModel and ViewModelBase to support MVVM binding for message box text dialogs, including button visibility and labels.
- Add enumerable extension ForEachIndexed to simplify index-aware iteration across the codebase.

Enhancements:
- Add a new MyMsgText constructor that accepts MVVM-based MyMsgTextData and bind it to the new view model.
- Add storage and display logic for pending MyMsgTextData instances in ModMain, alongside existing MyMsgBoxConverter-based queueing.
- Refine MyMsgBoxTick logic to use explicit Count checks for pending message boxes.

</details>