### PR TITLE
chore: modify suffix

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModSkin.cs
@@ -149,7 +149,7 @@ public static class ModSkin
         {
             if (!File.Exists(fileAddress))
             {
-                FileDownloader.Download(address, fileAddress + ModNet.netDownloadEnd).GetAwaiter().GetResult();
+                FileDownloader.DownloadAsync(address, fileAddress + ModNet.netDownloadEnd).GetAwaiter().GetResult();
                 File.Delete(fileAddress);
                 FileSystem.Rename(fileAddress + ModNet.netDownloadEnd, fileAddress);
                 ModBase.Log("[Minecraft] 皮肤下载成功：" + fileAddress);

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -1,40 +1,38 @@
 using System.IO;
-using System.Net.Http;
-using System.Threading;
 using Downloader;
 using PCL.Core.IO.Net;
-using PCL.Core.Utils;
+
 
 namespace PCL.Network;
 
 public static class FileDownloader
 {
-    public static Task Download(string url, string localPath, bool useBrowserUserAgent = false,
+    public static async Task DownloadAsync(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
         bool enableParallelChunks = true, DownloadFile? trackedFile = null)
     {
-        return DownloadCoreAsync(new[] { url }, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
+        await DownloadCoreAsync([url], localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
             enableParallelChunks, trackedFile);
     }
 
-    public static Task Download(IEnumerable<string> urls, string localPath, bool useBrowserUserAgent = false,
+    public static async Task DownloadAsync(IEnumerable<string> urls, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "", CancellationToken cancellationToken = default,
         bool enableParallelChunks = true, DownloadFile? trackedFile = null)
     {
-        return DownloadCoreAsync(urls, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
+        await DownloadCoreAsync(urls, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
             enableParallelChunks, trackedFile);
     }
 
     public static void DownloadByLoader(string url, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "")
     {
-        Download(url, localPath, useBrowserUserAgent, customUserAgent).GetAwaiter().GetResult();
+        DownloadAsync(url, localPath, useBrowserUserAgent, customUserAgent).GetAwaiter().GetResult();
     }
 
     public static void DownloadByLoader(IEnumerable<string> urls, string localPath, bool useBrowserUserAgent = false,
         string customUserAgent = "")
     {
-        Download(urls, localPath, useBrowserUserAgent, customUserAgent).GetAwaiter().GetResult();
+        DownloadAsync(urls, localPath, useBrowserUserAgent, customUserAgent).GetAwaiter().GetResult();
     }
 
     private static async Task DownloadCoreAsync(IEnumerable<string> urls, string localPath, bool useBrowserUserAgent,

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -12,7 +12,7 @@ public static class FileDownloader
         bool enableParallelChunks = true, DownloadFile? trackedFile = null)
     {
         await DownloadCoreAsync([url], localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-            enableParallelChunks, trackedFile);
+            enableParallelChunks, trackedFile).ConfigureAwait(false);
     }
 
     public static async Task DownloadAsync(IEnumerable<string> urls, string localPath, bool useBrowserUserAgent = false,
@@ -20,7 +20,7 @@ public static class FileDownloader
         bool enableParallelChunks = true, DownloadFile? trackedFile = null)
     {
         await DownloadCoreAsync(urls, localPath, useBrowserUserAgent, customUserAgent, cancellationToken,
-            enableParallelChunks, trackedFile);
+            enableParallelChunks, trackedFile).ConfigureAwait(false);
     }
 
     public static void DownloadByLoader(string url, string localPath, bool useBrowserUserAgent = false,

--- a/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Facade/ModNet.cs
@@ -101,20 +101,20 @@ public static class ModNet
 
     public static Task NetDownloadByClient(string url, string localFile, bool useBrowserUserAgent = false)
     {
-        return FileDownloader.Download(url, localFile, useBrowserUserAgent);
+        return FileDownloader.DownloadAsync(url, localFile, useBrowserUserAgent);
     }
 
     public static void NetDownloadByLoader(string url, string localFile, ModLoader.LoaderBase? loaderToSyncProgress = null,
         ModBase.FileChecker? check = null, bool useBrowserUserAgent = false)
     {
-        FileDownloader.Download(url, localFile, useBrowserUserAgent).GetAwaiter().GetResult();
+        FileDownloader.DownloadAsync(url, localFile, useBrowserUserAgent).GetAwaiter().GetResult();
     }
 
     public static void NetDownloadByLoader(IEnumerable<string> urls, string localFile,
         ModLoader.LoaderBase? loaderToSyncProgress = null, ModBase.FileChecker? check = null,
         bool useBrowserUserAgent = false)
     {
-        FileDownloader.Download(urls, localFile, useBrowserUserAgent).GetAwaiter().GetResult();
+        FileDownloader.DownloadAsync(urls, localFile, useBrowserUserAgent).GetAwaiter().GetResult();
     }
 
     public static bool HasDownloadingTask(bool ignoreCustomDownload = false)

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -135,12 +135,12 @@ public static class Requester
 
     public static async Task DownloadFileAsync(string url, string filePath)
     {
-        await FileDownloader.Download(url, filePath).ConfigureAwait(false);
+        await FileDownloader.DownloadAsync(url, filePath).ConfigureAwait(false);
     }
 
     public static async Task DownloadFileOnceAsync(string url, string filePath)
     {
-        await FileDownloader.Download(url, filePath).ConfigureAwait(false);
+        await FileDownloader.DownloadAsync(url, filePath).ConfigureAwait(false);
     }
 
     public static DownloadService CreateDownloadService(string url, bool useBrowserUserAgent = false)

--- a/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Loaders/LoaderDownload.cs
@@ -137,7 +137,7 @@ public class LoaderDownload : ModLoader.LoaderBase
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await FileDownloader.Download(file.Urls, file.LocalPath, file.UseBrowserUserAgent, file.CustomUserAgent,
+                await FileDownloader.DownloadAsync(file.Urls, file.LocalPath, file.UseBrowserUserAgent, file.CustomUserAgent,
                     cancellationToken, enableParallelChunks, file).ConfigureAwait(false);
                 break;
             }


### PR DESCRIPTION
将名称改为 DownloadAsync 以符合 C# 方法命名规范

## Summary by Sourcery

将文件下载 API 重命名，在异步操作中使用 Async 后缀。

增强内容：
- 将 `FileDownloader.Download` 方法重命名为 `FileDownloader.DownloadAsync`，并更新所有调用方以体现异步语义和命名规范。
- 从下载模块中移除未使用的 using 指令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename file download APIs to use Async suffix for asynchronous operations.

Enhancements:
- Rename FileDownloader.Download methods to FileDownloader.DownloadAsync and update all callers to reflect asynchronous semantics and naming conventions.
- Remove unused using directives from the downloader module.

</details>