### PR TITLE
fix(lang): 移除未使用的 i18n 条目

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -291,24 +291,6 @@
     <sys:String x:Key="Launch.Account.Profile.Uuid.Hint">32 characters, no hyphens</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Uuid.InvalidChars">UUID should only contain letters and numbers!</sys:String>
 
-    <!-- Launch.Account.Profile.Migration -->
-
-    <sys:String x:Key="Launch.Account.Profile.Migration.Title">Profile migration</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Message">PCL CE supports two-way profile synchronization with HMCL.&#x0a;Select an operation:</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportOnlyMessage">Since the current profile list is empty, only importing from HMCL is supported.</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Import">Import</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Export">Export</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Importing">Importing from HMCL...</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.HmclConfigNotFound">HMCL configuration file not found.</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.MsRequired">You must complete Microsoft login at least once before importing these profiles!</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.NoNewProfiles">No new profiles to import.</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportSuccess">Successfully imported {0} profile(s)!</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Exporting">Exporting to HMCL...</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ExportSuccess">Successfully synchronized {0} profile(s).</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportFailed">Import error. Please check the file format.</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ExportFailed">Export failed.</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.AutoMigrate">{0} profile(s) have been automatically migrated from legacy configuration files.</sys:String>
-
     <!-- Launch.Account.Profile.Validation -->
 
     <sys:String x:Key="Launch.Account.Profile.Validation.EmptyUsername">Username cannot be empty!</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -291,24 +291,6 @@
     <sys:String x:Key="Launch.Account.Profile.Uuid.Hint">32 位，不含连字符</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Uuid.InvalidChars">UUID 只应该包括英文字母和数字！</sys:String>
 
-    <!-- Launch.Account.Profile.Migration -->
-
-    <sys:String x:Key="Launch.Account.Profile.Migration.Title">档案迁移</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Message">PCL CE 支持与 HMCL 相互同步全局档案列表。&#x0a;请选择操作：</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportOnlyMessage">由于当前档案列表为空，仅支持从 HMCL 导入档案。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Import">导入</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Export">导出</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Importing">正在从 HMCL 导入...</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.HmclConfigNotFound">未找到 HMCL 的配置文件。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.MsRequired">你必须先进行一次正版验证才能导入这些档案！</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.NoNewProfiles">没有新档案可供导入。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportSuccess">成功导入 {0} 个档案！</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.Exporting">正在导出至 HMCL...</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ExportSuccess">已成功同步 {0} 个档案。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ImportFailed">导入出错，请检查文件格式。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.ExportFailed">导出失败。</sys:String>
-    <sys:String x:Key="Launch.Account.Profile.Migration.AutoMigrate">已自动从旧版配置文件迁移档案，共迁移了 {0} 个档案</sys:String>
-
     <!-- Launch.Account.Profile.Validation -->
 
     <sys:String x:Key="Launch.Account.Profile.Validation.EmptyUsername">玩家名不能为空！</sys:String>


### PR DESCRIPTION
## Summary by Sourcery

从英文和中文资源字典中移除未使用的本地化键。

Enhancements:
- 通过删除未使用的条目清理 en-US 本地化资源。
- 通过删除未使用的条目清理 zh-CN 本地化资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused localization keys from the English and Chinese resource dictionaries.

Enhancements:
- Clean up en-US localization resources by deleting unused entries.
- Clean up zh-CN localization resources by deleting unused entries.

</details>
- 清理 en-US 和 zh-CN 资源字典中未使用的本地化键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

从英文和中文资源字典中移除未使用的本地化键。

Enhancements:
- 通过删除未使用的条目清理 en-US 本地化资源。
- 通过删除未使用的条目清理 zh-CN 本地化资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused localization keys from the English and Chinese resource dictionaries.

Enhancements:
- Clean up en-US localization resources by deleting unused entries.
- Clean up zh-CN localization resources by deleting unused entries.

</details>

</details>