### PR TITLE
chore: 移除`版本隔离设置迁移`相关代码

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -550,11 +550,6 @@ public static partial class Config
         [ConfigItem<string>("LaunchArgumentJavaSelect", "")] public partial string SelectedJava { get; set; }
 
         /// <summary>
-        /// 版本隔离 V1。
-        /// </summary>
-        [ConfigItem<int>("LaunchArgumentIndie", 0, ConfigSource.Local)] public partial int IndieSolutionV1 { get; set; }
-
-        /// <summary>
         /// 版本隔离 V2。
         /// </summary>
         [ConfigItem<int>("LaunchArgumentIndieV2", 4, ConfigSource.Local)] public partial int IndieSolutionV2 { get; set; }

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -86,20 +86,6 @@ public partial class FormMain
         else if (lastVersion > ModBase.versionCode)
             // 触发降级
             DowngradeSub(lastVersion);
-        // 版本隔离设置迁移
-        if (Config.Launch.IndieSolutionV2Config.IsDefault())
-        {
-            if (!Config.Launch.IndieSolutionV1Config.IsDefault())
-            {
-                ModBase.Log("[Start] 从老 PCL 迁移版本隔离");
-                Config.Launch.IndieSolutionV2 = Config.Launch.IndieSolutionV1;
-            }
-            else
-            {
-                ModBase.Log("[Start] 全新的 PCL，使用新的版本隔离默认值");
-                Config.Launch.IndieSolutionV2Config.Reset(Config.Launch.IndieSolutionV2Config.DefaultValue);
-            }
-        }
 
         _ = Config.Preference.Theme.ThemeSelected;
         // 注册拖拽事件（不能直接加 Handles，否则没用；#6340）


### PR DESCRIPTION
2025 年 3 月加的，已经一年多了，没必要再留着了

## Summary by Sourcery

移除旧版版本隔离（version-isolation）迁移逻辑及其已废弃的配置字段。

Chores:
- 移除针对旧版版本隔离设置的过时代码迁移逻辑。
- 从启动配置中删除未使用的 V1 版本隔离配置属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove legacy version-isolation migration logic and its obsolete configuration field.

Chores:
- Remove outdated migration code for legacy version-isolation settings.
- Drop unused V1 version-isolation configuration property from launch config.

</details>