### PR TITLE
feat(toast): 支持滑动关闭 Hint 通知

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -295,7 +295,7 @@ public partial class MyToast
             ReleaseMouseCapture();
 
         var currentX = (RenderTransform as TranslateTransform)?.X ?? 0d;
-        if (currentX >= GetDismissThreshold())
+        if (currentX - _dragStartTranslateX >= GetDismissThreshold())
         {
             Dismiss();
             return;

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using PCL.Core.App;
@@ -11,10 +12,43 @@ public partial class MyToast
 {
     public int Uuid = ModBase.GetUuid();
 
+    /// <summary>判定为拖动而非点击的最小水平位移（像素）。</summary>
+    private const double DragDeadzone = 4d;
+
+    /// <summary>拖动时透明度下限，确保控件始终可见。</summary>
+    private const double DragOpacityFloor = 0.35d;
+
+    /// <summary>触发关闭的位移占控件宽度的比例。</summary>
+    private const double DismissThresholdRatio = 0.12d;
+
+    /// <summary>触发关闭的最小绝对位移（像素）。</summary>
+    private const double DismissThresholdMin = 24d;
+
+    /// <summary>拖动释放后，若剩余显示时间不足此值则直接关闭。</summary>
+    private const double MinRemainingMs = 300d;
+
+    /// <summary>拖动释放后回到原位的动画时长（毫秒）。</summary>
+    private const int ReturnAnimationMs = 150;
+
+    // 拖动状态
+    private bool _dragPending;
+    private bool _isDragging;
+    private Point _dragStartPoint;
+    private double _dragStartTranslateX;
+    private FrameworkElement? _dragReference;
+
+    // 进度条状态
+    private double _progressStartWidth;
+    private double _progressTotalMs;
+
     public MyToast()
     {
         InitializeComponent();
         BtnClose.Click += (_, _) => Dismiss();
+        PreviewMouseLeftButtonDown += Toast_PreviewMouseLeftButtonDown;
+        PreviewMouseMove += Toast_PreviewMouseMove;
+        PreviewMouseLeftButtonUp += Toast_PreviewMouseLeftButtonUp;
+        LostMouseCapture += Toast_LostMouseCapture;
         Loaded += (_, _) =>
         {
             UpdateColors();
@@ -29,6 +63,7 @@ public partial class MyToast
             ModAnimation.AniStop($"Toast Hide {Uuid}");
             ModAnimation.AniStop($"Toast Dismiss {Uuid}");
             ModAnimation.AniStop($"Toast Emphasize {Uuid}");
+            ModAnimation.AniStop($"Toast Drag Return {Uuid}");
             ProgressBar.BeginAnimation(WidthProperty, null);
         };
     }
@@ -68,6 +103,7 @@ public partial class MyToast
 
         RenderTransform = new TranslateTransform(60, 0);
 
+        ModAnimation.AniStop($"Toast Drag Return {Uuid}");
         var enterAnimations = new List<ModAnimation.AniData>
         {
             ModAnimation.AaTranslateX(this, -60, 400, ease: new ModAnimation.AniEaseOutFluent()),
@@ -84,6 +120,7 @@ public partial class MyToast
         ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
         ModAnimation.AniStop($"Toast Emphasize {Uuid}");
+        ModAnimation.AniStop($"Toast Drag Return {Uuid}");
         ProgressBar.BeginAnimation(WidthProperty, null);
         if (RenderTransform is TranslateTransform tt) tt.X = 0;
         Opacity = 1;
@@ -99,7 +136,13 @@ public partial class MyToast
 
     private void RestartHideAnimation()
     {
-        var delay = (int)Math.Round(DisplayDuration);
+        StartHideAnimation(DisplayDuration);
+        StartProgressAnimation(DisplayDuration);
+    }
+
+    private void StartHideAnimation(double delayMs)
+    {
+        var delay = (int)Math.Round(delayMs);
         ModAnimation.AniStart(new List<ModAnimation.AniData>
         {
             ModAnimation.AaTranslateX(this, 60, 200, delay, new ModAnimation.AniEaseInFluent()),
@@ -111,16 +154,19 @@ public partial class MyToast
                     p.Children.Remove(this);
             }, after: true)
         }, $"Toast Hide {Uuid}");
-        StartProgressAnimation(DisplayDuration);
     }
 
     public void Dismiss()
     {
         if (IsDismissing) return;
         IsDismissing = true;
+        _isDragging = false;
+        _dragPending = false;
+        if (IsMouseCaptured) ReleaseMouseCapture();
         ModAnimation.AniStop($"Toast Show {Uuid}");
         ModAnimation.AniStop($"Toast Hide {Uuid}");
         ModAnimation.AniStop($"Toast Emphasize {Uuid}");
+        ModAnimation.AniStop($"Toast Drag Return {Uuid}");
         ProgressBar.BeginAnimation(WidthProperty, null);
         ModAnimation.AniStart(new List<ModAnimation.AniData>
         {
@@ -143,6 +189,8 @@ public partial class MyToast
         if (w <= 0) w = 300;
         ProgressBar.HorizontalAlignment = HorizontalAlignment.Left;
         ProgressBar.Width = w;
+        _progressStartWidth = w;
+        _progressTotalMs = totalMs;
         var anim = new DoubleAnimation(w, 0d, TimeSpan.FromMilliseconds(totalMs));
         ProgressBar.BeginAnimation(WidthProperty, anim);
     }
@@ -178,4 +226,192 @@ public partial class MyToast
         ToastIcon.IconBrush = accentBrush;
         ToastIcon.StrokeThickness = 0;
     }
+
+    #region 拖动关闭
+
+    private void Toast_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (IsDismissing)
+            return;
+        _dragReference = Parent as FrameworkElement;
+        if (_dragReference is null)
+            return;
+        _dragPending = true;
+        _isDragging = false;
+        _dragStartPoint = e.GetPosition(_dragReference);
+    }
+
+    private void Toast_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (_isDragging)
+        {
+            if (Mouse.LeftButton != MouseButtonState.Pressed || _dragReference is null)
+            {
+                _isDragging = false;
+                _dragPending = false;
+                if (IsMouseCaptured) ReleaseMouseCapture();
+                ReturnFromDrag();
+                return;
+            }
+            var dragCurrent = e.GetPosition(_dragReference);
+            UpdateDragPosition(dragCurrent.X - _dragStartPoint.X);
+            e.Handled = true;
+            return;
+        }
+
+        if (!_dragPending)
+            return;
+        if (Mouse.LeftButton != MouseButtonState.Pressed || _dragReference is null)
+        {
+            _dragPending = false;
+            return;
+        }
+
+        var current = e.GetPosition(_dragReference);
+        var delta = current.X - _dragStartPoint.X;
+
+        if (Math.Abs(delta) < DragDeadzone)
+            return;
+
+        BeginDrag(delta);
+    }
+
+    private void Toast_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (_dragPending && !_isDragging)
+        {
+            _dragPending = false;
+            return;
+        }
+
+        if (!_isDragging)
+            return;
+
+        _isDragging = false;
+        _dragPending = false;
+        e.Handled = true;
+
+        if (IsMouseCaptured)
+            ReleaseMouseCapture();
+
+        var currentX = (RenderTransform as TranslateTransform)?.X ?? 0d;
+        if (currentX >= GetDismissThreshold())
+        {
+            Dismiss();
+            return;
+        }
+
+        ReturnFromDrag();
+    }
+
+    private void Toast_LostMouseCapture(object sender, MouseEventArgs e)
+    {
+        if (!_isDragging)
+            return;
+        _isDragging = false;
+        _dragPending = false;
+        ReturnFromDrag();
+    }
+
+    private void BeginDrag(double initialDelta)
+    {
+        _isDragging = true;
+        _dragPending = false;
+
+        ModAnimation.AniStop($"Toast Show {Uuid}");
+        ModAnimation.AniStop($"Toast Hide {Uuid}");
+        ModAnimation.AniStop($"Toast Emphasize {Uuid}");
+        ModAnimation.AniStop($"Toast Drag Return {Uuid}");
+
+        PauseProgress();
+
+        Height = _targetHeight;
+        _dragStartTranslateX = (RenderTransform as TranslateTransform)?.X ?? 0d;
+
+        CaptureMouse();
+
+        UpdateDragPosition(initialDelta);
+    }
+
+    private void UpdateDragPosition(double delta)
+    {
+        var newX = _dragStartTranslateX + ApplyDragResistance(delta);
+        if (RenderTransform is TranslateTransform tt)
+            tt.X = newX;
+        Opacity = GetDragOpacity(newX);
+    }
+
+    private void ReturnFromDrag()
+    {
+        if (Parent is null || IsDismissing)
+            return;
+        var currentX = (RenderTransform as TranslateTransform)?.X ?? 0d;
+        var currentOpacity = Opacity;
+
+        var remaining = GetProgressRemainingMs();
+        if (remaining < MinRemainingMs)
+        {
+            Dismiss();
+            return;
+        }
+
+        ResumeProgress(remaining);
+
+        ModAnimation.AniStart(new List<ModAnimation.AniData>
+        {
+            ModAnimation.AaTranslateX(this, -currentX, ReturnAnimationMs, ease: new ModAnimation.AniEaseOutFluent()),
+            ModAnimation.AaOpacity(this, 1d - currentOpacity, ReturnAnimationMs),
+            ModAnimation.AaCode(() => StartHideAnimation(GetProgressRemainingMs()), after: true)
+        }, $"Toast Drag Return {Uuid}");
+    }
+
+    private static double ApplyDragResistance(double delta)
+    {
+        return Math.Max(0d, delta);
+    }
+
+    private double GetDragOpacity(double translateX)
+    {
+        if (translateX <= 0d)
+            return 1d;
+        var width = ActualWidth > 0 ? ActualWidth : 1d;
+        return Math.Max(DragOpacityFloor, 1d - (translateX / width) * (1d - DragOpacityFloor));
+    }
+
+    private double GetDismissThreshold()
+    {
+        return Math.Max(DismissThresholdMin, ActualWidth * DismissThresholdRatio);
+    }
+
+    #endregion
+
+    #region 进度条暂停与恢复
+
+    private void PauseProgress()
+    {
+        var currentWidth = ProgressBar.Width;
+        ProgressBar.BeginAnimation(WidthProperty, null);
+        ProgressBar.Width = currentWidth;
+    }
+
+    private void ResumeProgress(double remainingMs)
+    {
+        if (remainingMs <= 0)
+            return;
+        var currentWidth = ProgressBar.Width;
+        if (currentWidth <= 0)
+            return;
+        var anim = new DoubleAnimation(currentWidth, 0d, TimeSpan.FromMilliseconds(remainingMs));
+        ProgressBar.BeginAnimation(WidthProperty, anim);
+    }
+
+    private double GetProgressRemainingMs()
+    {
+        if (_progressStartWidth <= 0)
+            return 0d;
+        var currentWidth = ProgressBar.Width;
+        return _progressTotalMs * (currentWidth / _progressStartWidth);
+    }
+
+    #endregion
 }

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -233,6 +233,8 @@ public partial class MyToast
     {
         if (IsDismissing)
             return;
+        if (IsDescendantOf(e.OriginalSource as DependencyObject, BtnClose))
+            return;
         _dragReference = Parent as FrameworkElement;
         if (_dragReference is null)
             return;
@@ -381,6 +383,17 @@ public partial class MyToast
     private double GetDismissThreshold()
     {
         return Math.Max(DismissThresholdMin, ActualWidth * DismissThresholdRatio);
+    }
+
+    private static bool IsDescendantOf(DependencyObject? descendant, DependencyObject ancestor)
+    {
+        while (descendant is not null)
+        {
+            if (ReferenceEquals(descendant, ancestor))
+                return true;
+            descendant = VisualTreeHelper.GetParent(descendant);
+        }
+        return false;
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -231,6 +231,7 @@ public partial class MyToast
 
     private void Toast_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
+        _dragPending = false;
         if (IsDismissing)
             return;
         if (IsDescendantOf(e.OriginalSource as DependencyObject, BtnClose))

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml.cs
@@ -270,7 +270,7 @@ public partial class MyToast
         var current = e.GetPosition(_dragReference);
         var delta = current.X - _dragStartPoint.X;
 
-        if (Math.Abs(delta) < DragDeadzone)
+        if (delta < DragDeadzone)
             return;
 
         BeginDrag(delta);


### PR DESCRIPTION


https://github.com/user-attachments/assets/a0f3c381-5fe3-406a-9db7-0cd68cd2dcfe


> Partly Generated By GLM-5.2
## Summary by Sourcery

为吐司通知添加滑动关闭交互，包含拖拽动画以及进度条的暂停/恢复行为。

New Features:
- 允许通过水平拖拽手势关闭吐司通知，并在拖拽过程中提供透明度反馈和设置关闭阈值。

Enhancements:
- 当用户拖拽吐司时，暂停和恢复吐司的自动隐藏计时器及可视化进度条，以确保剩余显示时间保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add swipe-to-dismiss interaction for toast notifications with drag animations and progress bar pause/resume behavior.

New Features:
- Allow toast notifications to be dismissed by horizontal drag gestures with opacity feedback and a dismissal threshold.

Enhancements:
- Pause and resume the toast auto-hide timer and visual progress bar when the user drags the toast, ensuring consistent remaining display time.

</details>