### PR TITLE
fix(download-lib): 修复 Wiki 链接拼接缺少斜杠

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -585,7 +585,7 @@ public static class ModDownloadLib
     public static void McUpdateLogShow(JsonNode versionJson)
     {
         var wikiName = McFormatter.GetWikiUrlSuffix(versionJson["id"].ToString());
-        var wikiUrl = McFormatter.GetWikiBaseUrl() + "/" + wikiName.TrimStart('/');;
+        var wikiUrl = $"{McFormatter.GetWikiBaseUrl()}/{wikiName.TrimStart('/')}";
         ModBase.OpenWebsite(wikiUrl);
     }
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -585,7 +585,7 @@ public static class ModDownloadLib
     public static void McUpdateLogShow(JsonNode versionJson)
     {
         var wikiName = McFormatter.GetWikiUrlSuffix(versionJson["id"].ToString());
-        var wikiUrl = McFormatter.GetWikiBaseUrl() + "/" + wikiName;
+        var wikiUrl = McFormatter.GetWikiBaseUrl() + "/" + wikiName.TrimStart('/');;
         ModBase.OpenWebsite(wikiUrl);
     }
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -585,7 +585,7 @@ public static class ModDownloadLib
     public static void McUpdateLogShow(JsonNode versionJson)
     {
         var wikiName = McFormatter.GetWikiUrlSuffix(versionJson["id"].ToString());
-        var wikiUrl = McFormatter.GetWikiBaseUrl() + wikiName;
+        var wikiUrl = McFormatter.GetWikiBaseUrl() + "/" + wikiName;
         ModBase.OpenWebsite(wikiUrl);
     }
 


### PR DESCRIPTION
close #3223

## Summary by Sourcery

Bug Fixes:
- 修复在拼接 Wiki 基础 URL 和用于更新日志链接的路径后缀时缺少斜杠的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix missing slash when concatenating the Wiki base URL and path suffix for update log links.

</details>