### PR TITLE
fix(minecraft): 修复中文环境下 Minecraft 更新日志 Wiki 链接无效 [Composer]

### DIFF
--- a/PCL.Core/Minecraft/McFormatter.cs
+++ b/PCL.Core/Minecraft/McFormatter.cs
@@ -51,9 +51,9 @@ public static class McFormatter
         if (!langCode.StartsWith("zh", StringComparison.Ordinal))
             return $"/w/Special:Search?search={Uri.EscapeDataString($"Java Edition {formattedVersion}")}";
 
-        if (gameVersion.Contains('w')) return formattedVersion;
+        if (gameVersion.Contains('w', StringComparison.Ordinal)) return $"/w/{formattedVersion}";
 
-        return "Java版" + formattedVersion;
+        return $"/w/Java版{formattedVersion}";
     }
 
     public static string FormatVersion(string gameVersion)


### PR DESCRIPTION
## Summary
- 修复中文 UI 下点击「更新日志」时浏览器打开但不跳转的问题
- 为 `GetWikiUrlSuffix` 的中文路径补上 `/w/` 前缀，使 URL 与 `GetWikiBaseUrl()` 正确拼接

## Root cause
- #3074 引入多语言 Wiki 支持后，`McUpdateLogShow` 改为 `GetWikiBaseUrl() + GetWikiUrlSuffix()` 拼接
- 非中文后缀以 `/w/...` 开头，中文后缀却返回 `Java版{version}`（无 `/w/`）
- 拼接结果如 `https://zh.minecraft.wikiJava版1.21.1` 为无效 URL，Shell 仅启动浏览器进程而不导航

## Reproduction (before fix)
1. 使用 Debug 编译的 PCL CE（dev 分支，中文 UI）
2. 进入「下载」→ 任意 Minecraft 版本 → 点击右侧「更新日志」按钮
3. Chrome 打开但不跳转，且每次弹出账号选择（像全新实例）

## Verification (after fix)
- [x] 浏览器正确跳转到 `https://zh.minecraft.wiki/w/Java版…`
- [x] Chrome 复用已有 Profile，不再重复询问账号
- [x] Debug 构建通过

## Test plan
- [x] 本地 Debug 构建
- [x] 点击更新日志按钮，确认 Wiki 页面正常打开

Close #3223

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 确保中文 Minecraft Wiki 的 URL 后缀包含 `/w/` 前缀，以便更新日志链接在浏览器中打开正确的页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure Chinese Minecraft Wiki URL suffixes include the /w/ prefix so update log links open the correct page in browsers.

</details>