### PR TITLE
fix(server): 修复 Ping 无 description 时服务器页 NRE 崩溃 [Composer]

### DIFF
--- a/PCL.Core/UI/Controls/MotdRenderer.xaml.cs
+++ b/PCL.Core/UI/Controls/MotdRenderer.xaml.cs
@@ -184,6 +184,8 @@ public partial class MotdRenderer {
         MotdCanvas.Children.Clear();
         _obfuscatedTextBlocks.Clear();
 
+        motd ??= string.Empty;
+
         var colorMap = isDarkMode ? _ColorMapWithBlackBackground : _ColorMapWithWhiteBackground;
         var font = Config.Preference.MotdFont;
         var fontFamily = new FontFamily(string.IsNullOrWhiteSpace(font)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceServer.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceServer.xaml.cs
@@ -431,7 +431,7 @@ public partial class PageInstanceServer : MyPageRight
                     server.Status = ServerStatus.Online;
                     server.PlayerCount = result.Players.Online;
                     server.MaxPlayers = result.Players.Max;
-                    server.Description = result.Description;
+                    server.Description = result.Description ?? string.Empty;
                     server.Version = result.Version.Name;
                     server.Ping = (int)result.Latency;
                     server.Icon = result.Favicon;


### PR DESCRIPTION
## Summary

- 在 `MotdRenderer.RenderMotd` 入口对 null MOTD 兜底为空字符串
- Ping 成功后赋值 `server.Description` 时使用 `?? string.Empty`

部分服务器（如 `server.zakozako.cc:25550`）Ping 响应 JSON 不含 `description` 字段，导致 `NullReferenceException` 未捕获并强制退出启动器。

Close #3225

## Test plan

- [x] 添加 `server.zakozako.cc:25550`，Ping 成功后不再崩溃
- [x] 服务器卡片正常显示，MOTD 为空时不报错
- [x] Debug x64 构建通过


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

防止在渲染或赋值空或缺失的 Minecraft 服务器 MOTD/描述值时发生崩溃。

Bug 修复：
- 通过将为 null 的 MOTD 字符串默认为为空字符串，避免在 MotdRenderer 中出现 NullReferenceException。
- 确保从 ping 响应中获取的服务器描述在缺失或为 null 时回退为空字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent crashes when rendering or assigning empty or missing Minecraft server MOTD/description values.

Bug Fixes:
- Avoid NullReferenceException in MotdRenderer by defaulting null MOTD strings to empty.
- Ensure server descriptions from ping responses fall back to an empty string when missing or null.

</details>