### PR TITLE
fix(download): 修复社区资源搜索页返回后收藏按钮 hover 失效 [Composer]

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
@@ -224,7 +224,7 @@ public partial class MyCompItem
     }
 
     /// <summary>
-    ///     刷新收藏状态
+    ///     刷新收藏状态（仅更新图标，不影响 hover 展示逻辑）
     /// </summary>
     public void RefreshFavoriteStatus()
     {
@@ -232,7 +232,6 @@ public partial class MyCompItem
 
         var isFavourite = ModComp.CompFavorites.IsFavourite(project.Id);
         BtnDelete.SvgIcon = isFavourite ? "lucide/heart-filled" : "lucide/heart";
-        ShowFavoriteBtn = isFavourite;
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- `MyCompItem.RefreshFavoriteStatus` 仅更新心形图标（实心/空心），不再修改 `ShowFavoriteBtn`

## 问题描述

社区资源**搜索列表页**（Mod、整合包、资源包、光影、数据包、地图等，均基于 `PageComp` + `MyCompItem`）中，列表项 hover 时应显示右侧收藏按钮。

从任意列表项进入**详情页**再返回后，**当前视窗内**已渲染的列表项 hover 不再显示收藏按钮；向下滚动后，**新进入视窗**（懒加载）的列表项 hover 仍正常。

## 根因

1. 返回列表时 `PageComp_IsVisibleChanged` 触发 `RefreshAllFavoriteStatus()`
2. `RefreshFavoriteStatus()` 将 `ShowFavoriteBtn = isFavourite`
3. 未收藏项的 `PanButtons` 被设为 `Collapsed`，hover 动画条件 `ShowFavoriteBtn == true` 不再满足
4. 视窗外尚未实例化的项由 `MyVirtualizingElement` 懒加载，未经过此次刷新，故表现不一致

## 影响范围

所有使用 `PageComp` 的社区资源下载搜索页：

- Mod
- 整合包
- 资源包
- 光影
- 数据包
- 地图

**不影响**详情页顶部卡片（该处显式 `ShowFavoriteBtn = false`）。

## Test plan

- [x] Mod 列表：首次进入 hover 正常；进入详情返回后当前视窗内 hover 正常
- [x] 整合包列表：同上
- [x] 滚动后新旧列表项 hover 行为一致
- [x] Debug x64 构建通过

Close #3230


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- 防止在从详情视图返回后，社区下载搜索页面中已渲染项目的收藏悬停按钮消失。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent favorite hover button from disappearing on already-rendered items in community download search pages after navigating back from a detail view.

</details>