### PR TITLE
feat(download): 快速下载资源

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -91,6 +91,10 @@ public static partial class Config
             [ConfigItem<bool>("ToolDownloadClipboard", false)] public partial bool ReadClipboard { get; set; }
             [ConfigItem<int>("ToolDownloadMod", 1)] public partial int CompSourceSolution { get; set; }
             [ConfigItem<int>("ToolModLocalNameStyle", 0)] public partial int UiCompNameSolution { get; set; }
+            /// <summary>
+            /// 资源卡片快速下载行为：0=总是询问，1=下载到当前选中实例，2=询问并下载到选择的实例，3=询问并下载到一个路径。
+            /// </summary>
+            [ConfigItem<int>("ToolDownloadQuickBehavior", 0)] public partial int QuickDownloadBehavior { get; set; }
         }
     }
 

--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -91,9 +91,6 @@ public static partial class Config
             [ConfigItem<bool>("ToolDownloadClipboard", false)] public partial bool ReadClipboard { get; set; }
             [ConfigItem<int>("ToolDownloadMod", 1)] public partial int CompSourceSolution { get; set; }
             [ConfigItem<int>("ToolModLocalNameStyle", 0)] public partial int UiCompNameSolution { get; set; }
-            /// <summary>
-            /// 资源卡片快速下载行为：0=总是询问，1=下载到当前选中实例，2=询问并下载到选择的实例，3=询问并下载到一个路径。
-            /// </summary>
             [ConfigItem<int>("ToolDownloadQuickBehavior", 0)] public partial int QuickDownloadBehavior { get; set; }
         }
     }

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1133,19 +1133,19 @@
 
     <!-- Download.Comp.QuickDownload -->
 
-    <sys:String x:Key="Download.Comp.QuickDownload.Btn.ToolTip">Quick download the latest version</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.Loading">Fetching resource version info, please wait…</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoFile">No downloadable file found</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoInstance">No Minecraft instance is currently selected</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleInstance">No Minecraft instance is compatible with this resource</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleFile">No version found for this instance</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.SelectFolder">Please choose where to save</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.Hint.DownloadStarted">Download started: {0}</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.Title">Choose how to download</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.CurrentInstance">Download to the currently selected instance</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskInstance">Choose an instance…</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskPath">Choose a folder…</sys:String>
-    <sys:String x:Key="Download.Comp.QuickDownload.ChooseInstance.Title">Choose the Minecraft instance to download to</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Btn.ToolTip">Download the latest version</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.Loading">Getting resource version info, please wait…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoFile">No downloadable files found</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoInstance">No Minecraft instance selected!</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleInstance">No compatible Minecraft instances found</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleFile">No compatible version found for this instance</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.SelectFolder">Select a folder to save the file</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.DownloadStarted">Started downloading: {0}</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.Title">Select a download destination</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.CurrentInstance">Download to the current instance</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskInstance">Select an instance…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskPath">Select a folder…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseInstance.Title">Select a target Minecraft instance</sys:String>
 
     <!-- Download.Source / Tag -->
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1131,6 +1131,22 @@
     <sys:String x:Key="Download.Comp.Favorites.LoaderName.BatchDownloadSuitable">Batch download applicable resources</sys:String>
     <sys:String x:Key="Download.Comp.Favorites.LoaderName.BatchDownload">Batch download resources ({0})</sys:String>
 
+    <!-- Download.Comp.QuickDownload -->
+
+    <sys:String x:Key="Download.Comp.QuickDownload.Btn.ToolTip">Quick download the latest version</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.Loading">Fetching resource version info, please wait…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoFile">No downloadable file found</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoInstance">No Minecraft instance is currently selected</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleInstance">No Minecraft instance is compatible with this resource</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleFile">No version found for this instance</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.SelectFolder">Please choose where to save</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.DownloadStarted">Download started: {0}</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.Title">Choose how to download</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.CurrentInstance">Download to the currently selected instance</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskInstance">Choose an instance…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskPath">Choose a folder…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseInstance.Title">Choose the Minecraft instance to download to</sys:String>
+
     <!-- Download.Source / Tag -->
 
     <sys:String x:Key="Download.Source.CleanroomOfficial">Cleanroom official source</sys:String>
@@ -1713,6 +1729,12 @@
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.ToolTip">Display style of mod items on the Mod management page</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleTranslation">Title shows translated name, details show file name</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleFilename">Title shows file name, details show translated name</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload">Quick download behavior</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.ToolTip">Behavior when clicking the quick download button on a resource search result card.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AlwaysAsk">Always ask</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.CurrentInstance">Download to the currently selected instance</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskInstance">Ask and download to a chosen instance</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskPath">Ask and download to a folder</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt">Hide Quilt loader</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt.ToolTip">Hide Quilt from the community resource loader display.</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies">Auto-check and install required dependencies when downloading mods</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1730,11 +1730,11 @@
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleTranslation">Title shows translated name, details show file name</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleFilename">Title shows file name, details show translated name</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.QuickDownload">Quick download behavior</sys:String>
-    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.ToolTip">Behavior when clicking the quick download button on a resource search result card.</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.ToolTip">Choose what happens when you click the quick download button on a resource card</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AlwaysAsk">Always ask</sys:String>
-    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.CurrentInstance">Download to the currently selected instance</sys:String>
-    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskInstance">Ask and download to a chosen instance</sys:String>
-    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskPath">Ask and download to a folder</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.CurrentInstance">Download to the current instance</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskInstance">Ask which instance to use</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskPath">Ask where to save</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt">Hide Quilt loader</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt.ToolTip">Hide Quilt from the community resource loader display.</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies">Auto-check and install required dependencies when downloading mods</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1131,6 +1131,22 @@
     <sys:String x:Key="Download.Comp.Favorites.LoaderName.BatchDownloadSuitable">批量下载合适资源</sys:String>
     <sys:String x:Key="Download.Comp.Favorites.LoaderName.BatchDownload">批量下载资源（{0}）</sys:String>
 
+    <!-- Download.Comp.QuickDownload -->
+
+    <sys:String x:Key="Download.Comp.QuickDownload.Btn.ToolTip">快速下载最新版本</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.Loading">正在获取资源版本信息，请稍候……</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoFile">未找到可下载的文件</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoInstance">当前未选中任何 Minecraft 实例</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleInstance">没有与该资源兼容的 Minecraft 实例</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.NoCompatibleFile">未找到适用于该实例的版本</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.SelectFolder">请选择保存位置</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.Hint.DownloadStarted">已开始下载：{0}</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.Title">选择下载方式</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.CurrentInstance">下载到当前选中实例</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskInstance">选择一个实例…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseMethod.AskPath">选择一个文件夹…</sys:String>
+    <sys:String x:Key="Download.Comp.QuickDownload.ChooseInstance.Title">选择要下载到的 Minecraft 实例</sys:String>
+
     <!-- Download.Source / Tag -->
 
     <sys:String x:Key="Download.Source.CleanroomOfficial">Cleanroom 官方源</sys:String>
@@ -1713,6 +1729,12 @@
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.ToolTip">在模组管理页面中，模组项的显示方式</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleTranslation">标题显示译名，详情显示文件名</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.ModManageStyle.TitleFilename">标题显示文件名，详情显示译名</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload">快速下载行为</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.ToolTip">点击资源搜索结果卡片上的快速下载按钮时的行为。</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AlwaysAsk">总是询问</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.CurrentInstance">下载到当前选中实例</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskInstance">询问并下载到选择的实例</sys:String>
+    <sys:String x:Key="Setup.GameManage.Community.QuickDownload.AskPath">询问并下载到一个路径</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt">不显示 Quilt 加载器</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.HideQuilt.ToolTip">不在社区资源的加载器展示中显示 Quilt 加载器</sys:String>
     <sys:String x:Key="Setup.GameManage.Community.AutoInstallDependencies">下载模组时自动检查并安装必需前置</sys:String>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3537,6 +3537,20 @@ public static class ModComp
                 block = true
             }
         };
+        if (file.Type == CompType.World)
+        {
+            var extractDir = Path.GetDirectoryName(target);
+            loaders.Add(new ModLoader.LoaderTask<int, int>(
+                Lang.Text("Download.Comp.Detail.InstallWorld"),
+                _ => ModBase.ExtractFile(target, extractDir, Encoding.UTF8))
+            {
+                ProgressWeight = 0.1d,
+                block = true
+            });
+            loaders.Add(new ModLoader.LoaderTask<int, int>(
+                Lang.Text("Download.Comp.Detail.CleanCache"),
+                _ => System.IO.File.Delete(target)));
+        }
         var loader = new ModLoader.LoaderCombo<int>(loaderName, loaders)
         {
             OnStateChanged = ModDownloadLib.LoaderStateChangedHintOnly

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3562,7 +3562,7 @@ public static class ModComp
     private static List<CompLoaderType> ResolveLoaders(CompFile file, CompProject project)
         => file.ModLoaders.Count > 0 ? file.ModLoaders : project.ModLoaders;
 
-    /// <summary>判断某实例是否兼容该文件（镜像 Save_Click 的 isVersionSuitable）。</summary>
+    /// <summary>判断某实例是否兼容该文件（基于 Save_Click 的 isVersionSuitable，补全了 Quilt 判定）。</summary>
     public static bool IsInstanceSuitableForFile(McInstance? version, CompFile file, List<CompLoaderType> allowedLoaders)
     {
         if (version is null) return false;
@@ -3580,6 +3580,7 @@ public static class ModComp
         if (allowedLoaders.Contains(CompLoaderType.Fabric) &&
             (version.Info.HasFabric || version.Info.HasLegacyFabric)) return true;
         if (allowedLoaders.Contains(CompLoaderType.NeoForge) && version.Info.HasNeoForge) return true;
+        if (allowedLoaders.Contains(CompLoaderType.Quilt) && version.Info.HasQuilt) return true;
         if (allowedLoaders.Contains(CompLoaderType.LiteLoader) && version.Info.HasLiteLoader) return true;
         return false;
     }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -19,6 +19,7 @@ using PCL.Core.Logging;
 using PCL.Core.Utils;
 using PCL.Core.Utils.Hash;
 using PCL.Network;
+using PCL.Network.Loaders;
 using ProtoBuf;
 using PCL.Core.App.Localization;
 using PCL.Core.UI;
@@ -1509,7 +1510,9 @@ public static class ModComp
         /// <summary>
         ///     将当前工程信息实例化为控件。
         /// </summary>
-        public MyVirtualizingElement<MyCompItem> ToCompItem(bool showMcVersionDesc, bool showLoaderDesc)
+        /// <param name="showQuickDownload">是否在卡片右侧显示快速下载按钮（仅搜索结果页应传 true）。</param>
+        public MyVirtualizingElement<MyCompItem> ToCompItem(bool showMcVersionDesc, bool showLoaderDesc,
+            bool showQuickDownload = false)
         {
             // --- 1. 获取版本描述 (核心算法优化) ---
             string gameVersionDescription;
@@ -1620,6 +1623,7 @@ public static class ModComp
 
                     newItem.Tags = Tags;
                     newItem.Description = Description.Replace("\r", "").Replace("\n", "");
+                    newItem.ShowDownloadBtn = showQuickDownload;
 
                     // 下边栏逻辑切换
                     newItem.LabVersion.Text = (showMcVersionDesc, showLoaderDesc) switch
@@ -3359,6 +3363,239 @@ public static class ModComp
         var result = sanitized.ToString().Trim();
         return result is "" or "." or ".." ? "download" : result;
     }
+
+    #region 快速下载（资源卡片下载按钮）
+
+    /// <summary>
+    /// 资源卡片的快速下载入口：按 <see cref="Config.Download.Comp.QuickDownloadBehavior"/> 指定的行为，
+    /// 下载该资源最新（优先 Release、其次最新发布）的兼容版本到目标实例或文件夹。
+    /// 由 <see cref="MyCompItem"/> 上的快速下载按钮调用。快速下载不会自动安装前置。
+    /// </summary>
+    public static void QuickDownload(CompProject project)
+    {
+        ModBase.RunInNewThread(() =>
+        {
+            try
+            {
+                HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.Loading"), HintType.Info);
+                var files = CompFilesGet(project.Id, project.FromCurseForge)
+                    .Where(f => f.Available)
+                    .ToList();
+                if (files.Count == 0)
+                {
+                    HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoFile"), HintType.Info);
+                    return;
+                }
+
+                var behavior = Config.Download.Comp.QuickDownloadBehavior;
+                if (behavior == 0)
+                {
+                    // 总是询问：弹「方式选择」
+                    int? choice = ModBase.RunInUiWait(() =>
+                    {
+                        var options = new List<IMyRadio>
+                        {
+                            new MyRadioBox { Text = Lang.Text("Download.Comp.QuickDownload.ChooseMethod.CurrentInstance") },
+                            new MyRadioBox { Text = Lang.Text("Download.Comp.QuickDownload.ChooseMethod.AskInstance") },
+                            new MyRadioBox { Text = Lang.Text("Download.Comp.QuickDownload.ChooseMethod.AskPath") }
+                        };
+                        return ModMain.MyMsgBoxSelect(options,
+                            Lang.Text("Download.Comp.QuickDownload.ChooseMethod.Title"),
+                            button1: Lang.Text("Common.Action.Continue"),
+                            button2: Lang.Text("Common.Action.Cancel"));
+                    });
+                    if (choice is null) return; // 用户取消
+                    behavior = choice.Value + 1; // 0→1 当前实例, 1→2 选实例, 2→3 选路径
+                }
+
+                switch (behavior)
+                {
+                    case 1: // 下载到当前选中实例
+                        QuickDownloadToInstance(project, files, ModInstanceList.McMcInstanceSelected);
+                        break;
+                    case 2: // 询问并下载到选择的实例
+                    {
+                        var instance = QuickDownloadPickInstance(project, files);
+                        if (instance is null) return;
+                        QuickDownloadToInstance(project, files, instance);
+                        break;
+                    }
+                    case 3: // 询问并下载到一个路径
+                        QuickDownloadToFolder(project, files);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                ModBase.Log(ex, "[Comp] 快速下载失败", ModBase.LogLevel.Feedback);
+            }
+        }, "Comp QuickDownload");
+    }
+
+    /// <summary>下载到指定实例的最新兼容版本。</summary>
+    private static void QuickDownloadToInstance(CompProject project, List<CompFile> files, McInstance? instance)
+    {
+        if (instance is null)
+        {
+            HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoInstance"), HintType.Info);
+            return;
+        }
+        if (!instance.IsLoaded) instance.Load();
+        var compatible = files
+            .Where(f => IsInstanceSuitableForFile(instance, f, ResolveLoaders(f, project)))
+            .ToList();
+        var file = PickLatestFile(compatible);
+        if (file is null)
+        {
+            HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoCompatibleFile"), HintType.Info);
+            return;
+        }
+        var folder = instance.PathIndie + GetSubFolder(project.Type);
+        Directory.CreateDirectory(folder);
+        var target = Path.Combine(folder, CompFileNameGet(project, file));
+        StartQuickDownload(file, target);
+        HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.DownloadStarted", project.RawName), HintType.Success);
+    }
+
+    /// <summary>弹实例列表让用户选择，返回选中的实例（兼容者优先、当前选中实例居首）；取消或无兼容实例返回 null。</summary>
+    private static McInstance? QuickDownloadPickInstance(CompProject project, List<CompFile> files)
+    {
+        var needLoad = ModInstanceList.mcInstanceListLoader.State != ModBase.LoadState.Finished;
+        if (needLoad)
+        {
+            HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.Loading"), HintType.Info);
+            ModLoader.LoaderFolderRun(ModInstanceList.mcInstanceListLoader, ModFolder.mcFolderSelected,
+                ModLoader.LoaderFolderRunType.ForceRun, 1, "versions\\", true);
+        }
+        var compatible = ModInstanceList.mcInstanceList.Values
+            .SelectMany(l => l)
+            .Where(v => v is not null && files.Any(f => IsInstanceSuitableForFile(v, f, ResolveLoaders(f, project))))
+            .ToList();
+        if (compatible.Count == 0)
+        {
+            HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoCompatibleInstance"), HintType.Info);
+            return null;
+        }
+        // 当前选中实例排首位（呼应 issue「第一行应为当前所选实例」）
+        var current = ModInstanceList.McMcInstanceSelected;
+        if (current is not null)
+            compatible = compatible
+                .OrderBy(v => v == current ? 0 : 1)
+                .ThenBy(v => v.Name)
+                .ToList();
+        int? idx = ModBase.RunInUiWait(() =>
+        {
+            var options = compatible
+                .Select(v => (IMyRadio)new MyRadioBox { Text = v.Name })
+                .ToList();
+            return ModMain.MyMsgBoxSelect(options,
+                Lang.Text("Download.Comp.QuickDownload.ChooseInstance.Title"),
+                button1: Lang.Text("Common.Action.Continue"),
+                button2: Lang.Text("Common.Action.Cancel"));
+        });
+        if (idx is null) return null;
+        return compatible[idx.Value];
+    }
+
+    /// <summary>下载最新版本到用户选择的文件夹。</summary>
+    private static void QuickDownloadToFolder(CompProject project, List<CompFile> files)
+    {
+        var file = PickLatestFile(files);
+        if (file is null)
+        {
+            HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoFile"), HintType.Info);
+            return;
+        }
+        var saveFolder = ModBase.RunInUiWait(() =>
+            SystemDialogs.SelectFolder(Lang.Text("Download.Comp.QuickDownload.Hint.SelectFolder")));
+        if (string.IsNullOrWhiteSpace(saveFolder)) return; // 取消
+        var target = Path.Combine(saveFolder, CompFileNameGet(project, file));
+        StartQuickDownload(file, target);
+        HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.DownloadStarted", project.RawName), HintType.Success);
+    }
+
+    /// <summary>构造并启动单文件下载任务（与详情页 Save_Click 末段一致）。</summary>
+    private static void StartQuickDownload(CompFile file, string target)
+    {
+        var desc = file.Type switch
+        {
+            CompType.Mod => Lang.Text("Download.Comp.Type.Mod"),
+            CompType.ResourcePack => Lang.Text("Download.Comp.Type.ResourcePack"),
+            CompType.Shader => Lang.Text("Download.Comp.Type.Shader"),
+            CompType.DataPack => Lang.Text("Download.Comp.Type.DataPack"),
+            CompType.World => Lang.Text("Download.Comp.Type.World"),
+            _ => Lang.Text("Download.Comp.Type.Mod")
+        };
+        var loaderName = Lang.Text("Download.Comp.Detail.DownloadResource", desc,
+            ModBase.GetFileNameWithoutExtentionFromPath(target));
+        var loaders = new List<ModLoader.LoaderBase>
+        {
+            new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadFile"),
+                new List<DownloadFile> { file.ToNetFile(target) })
+            {
+                ProgressWeight = 6,
+                block = true
+            }
+        };
+        var loader = new ModLoader.LoaderCombo<int>(loaderName, loaders)
+        {
+            OnStateChanged = ModDownloadLib.LoaderStateChangedHintOnly
+        };
+        loader.Start(1);
+        ModLoader.LoaderTaskbarAdd(loader);
+        ModMain.frmMain.BtnExtraDownload.ShowRefresh();
+        ModMain.frmMain.BtnExtraDownload.Ribble();
+    }
+
+    /// <summary>根据资源类型返回实例内的目标子文件夹（与 Save_Click 一致）。</summary>
+    private static string GetSubFolder(CompType type) => type switch
+    {
+        CompType.Mod => "mods\\",
+        CompType.ResourcePack => "resourcepacks\\",
+        CompType.Shader => "shaderpacks\\",
+        CompType.World => "saves\\",
+        CompType.DataPack => "", // 导航到版本根目录
+        _ => ""
+    };
+
+    /// <summary>取文件自身声明的加载器，缺失时回退到工程的加载器。</summary>
+    private static List<CompLoaderType> ResolveLoaders(CompFile file, CompProject project)
+        => file.ModLoaders.Count > 0 ? file.ModLoaders : project.ModLoaders;
+
+    /// <summary>判断某实例是否兼容该文件（镜像 Save_Click 的 isVersionSuitable）。</summary>
+    public static bool IsInstanceSuitableForFile(McInstance? version, CompFile file, List<CompLoaderType> allowedLoaders)
+    {
+        if (version is null) return false;
+        if (!version.IsLoaded) version.Load();
+
+        // 只对 Mod 和数据包进行版本检测
+        if (file.Type == CompType.Mod || file.Type == CompType.DataPack)
+            if (file.GameVersions.Any(v => v.Contains(".")) &&
+                !file.GameVersions.Any(v => v.Contains(".") && v == version.Info.VanillaName))
+                return false;
+
+        // 加载器判定
+        if (allowedLoaders.Count == 0) return true; // 无要求
+        if (allowedLoaders.Contains(CompLoaderType.Forge) && version.Info.HasForge) return true;
+        if (allowedLoaders.Contains(CompLoaderType.Fabric) &&
+            (version.Info.HasFabric || version.Info.HasLegacyFabric)) return true;
+        if (allowedLoaders.Contains(CompLoaderType.NeoForge) && version.Info.HasNeoForge) return true;
+        if (allowedLoaders.Contains(CompLoaderType.LiteLoader) && version.Info.HasLiteLoader) return true;
+        return false;
+    }
+
+    /// <summary>挑选最新文件：优先 Release，其次按发布日期最新。compatFilter 为空时不做兼容过滤。</summary>
+    private static CompFile? PickLatestFile(List<CompFile> files, Func<CompFile, bool>? compatFilter = null)
+    {
+        var candidates = (compatFilter is null ? files : files.Where(compatFilter)).ToList();
+        if (candidates.Count == 0) return null;
+        return candidates
+            .OrderByDescending(f => f.Status == CompFileStatus.Release)
+            .ThenByDescending(f => f.ReleaseDate)
+            .First();
+    }
+
+    #endregion
 
     /// <summary>
     /// 预载包含大量 CompFile 的卡片，添加必要的元素和前置列表。

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3378,9 +3378,9 @@ public static class ModComp
             try
             {
                 HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.Loading"), HintType.Info);
-                var files = CompFilesGet(project.Id, project.FromCurseForge)
-                    .Where(f => f.Available)
-                    .ToList();
+                var files = FilterFilesByType(
+                    CompFilesGet(project.Id, project.FromCurseForge).Where(f => f.Available).ToList(),
+                    project.Type);
                 if (files.Count == 0)
                 {
                     HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoFile"), HintType.Info);
@@ -3575,6 +3575,17 @@ public static class ModComp
     /// <summary>取文件自身声明的加载器，缺失时回退到工程的加载器。</summary>
     private static List<CompLoaderType> _ResolveLoaders(CompFile file, CompProject project)
         => file.ModLoaders.Count > 0 ? file.ModLoaders : project.ModLoaders;
+
+    /// <summary>
+    /// 按资源类型筛选文件，与详情页 GetResults 一致：Modrinth 会返回 Mod / 服务端插件 / 数据包混合的列表，
+    /// 需过滤回当前类型，避免快速下载到另一种产物。光影与资源包不筛（原版光影以资源包格式发布）。
+    /// </summary>
+    private static List<CompFile> FilterFilesByType(List<CompFile> files, CompType type)
+    {
+        if (type == CompType.Shader || type == CompType.ResourcePack)
+            return files;
+        return files.Where(f => f.Type == type).ToList();
+    }
 
     /// <summary>判断某实例是否兼容该文件（基于 Save_Click 的 isVersionSuitable，补全了 Quilt 判定）。</summary>
     public static bool IsInstanceSuitableForFile(McInstance? version, CompFile file, List<CompLoaderType> allowedLoaders)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3411,17 +3411,17 @@ public static class ModComp
                 switch (behavior)
                 {
                     case 1: // 下载到当前选中实例
-                        QuickDownloadToInstance(project, files, ModInstanceList.McMcInstanceSelected);
+                        _QuickDownloadToInstance(project, files, ModInstanceList.McMcInstanceSelected);
                         break;
                     case 2: // 询问并下载到选择的实例
                     {
-                        var instance = QuickDownloadPickInstance(project, files);
+                        var instance = _QuickDownloadPickInstance(project, files);
                         if (instance is null) return;
-                        QuickDownloadToInstance(project, files, instance);
+                        _QuickDownloadToInstance(project, files, instance);
                         break;
                     }
                     case 3: // 询问并下载到一个路径
-                        QuickDownloadToFolder(project, files);
+                        _QuickDownloadToFolder(project, files);
                         break;
                 }
             }
@@ -3433,7 +3433,7 @@ public static class ModComp
     }
 
     /// <summary>下载到指定实例的最新兼容版本。</summary>
-    private static void QuickDownloadToInstance(CompProject project, List<CompFile> files, McInstance? instance)
+    private static void _QuickDownloadToInstance(CompProject project, List<CompFile> files, McInstance? instance)
     {
         if (instance is null)
         {
@@ -3442,23 +3442,23 @@ public static class ModComp
         }
         if (!instance.IsLoaded) instance.Load();
         var compatible = files
-            .Where(f => IsInstanceSuitableForFile(instance, f, ResolveLoaders(f, project)))
+            .Where(f => IsInstanceSuitableForFile(instance, f, _ResolveLoaders(f, project)))
             .ToList();
-        var file = PickLatestFile(compatible);
+        var file = _PickLatestFile(compatible);
         if (file is null)
         {
             HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoCompatibleFile"), HintType.Info);
             return;
         }
-        var folder = instance.PathIndie + GetSubFolder(project.Type);
+        var folder = instance.PathIndie + _GetSubFolder(project.Type);
         Directory.CreateDirectory(folder);
         var target = Path.Combine(folder, CompFileNameGet(project, file));
-        StartQuickDownload(file, target);
+        _StartQuickDownload(file, target);
         HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.DownloadStarted", project.RawName), HintType.Success);
     }
 
     /// <summary>弹实例列表让用户选择，返回选中的实例（兼容者优先、当前选中实例居首）；取消或无兼容实例返回 null。</summary>
-    private static McInstance? QuickDownloadPickInstance(CompProject project, List<CompFile> files)
+    private static McInstance? _QuickDownloadPickInstance(CompProject project, List<CompFile> files)
     {
         var needLoad = ModInstanceList.mcInstanceListLoader.State != ModBase.LoadState.Finished;
         if (needLoad)
@@ -3469,7 +3469,7 @@ public static class ModComp
         }
         var compatible = ModInstanceList.mcInstanceList.Values
             .SelectMany(l => l)
-            .Where(v => v is not null && files.Any(f => IsInstanceSuitableForFile(v, f, ResolveLoaders(f, project))))
+            .Where(v => v is not null && files.Any(f => IsInstanceSuitableForFile(v, f, _ResolveLoaders(f, project))))
             .ToList();
         if (compatible.Count == 0)
         {
@@ -3498,9 +3498,9 @@ public static class ModComp
     }
 
     /// <summary>下载最新版本到用户选择的文件夹。</summary>
-    private static void QuickDownloadToFolder(CompProject project, List<CompFile> files)
+    private static void _QuickDownloadToFolder(CompProject project, List<CompFile> files)
     {
-        var file = PickLatestFile(files);
+        var file = _PickLatestFile(files);
         if (file is null)
         {
             HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.NoFile"), HintType.Info);
@@ -3510,12 +3510,12 @@ public static class ModComp
             SystemDialogs.SelectFolder(Lang.Text("Download.Comp.QuickDownload.Hint.SelectFolder")));
         if (string.IsNullOrWhiteSpace(saveFolder)) return; // 取消
         var target = Path.Combine(saveFolder, CompFileNameGet(project, file));
-        StartQuickDownload(file, target);
+        _StartQuickDownload(file, target);
         HintService.Hint(Lang.Text("Download.Comp.QuickDownload.Hint.DownloadStarted", project.RawName), HintType.Success);
     }
 
     /// <summary>构造并启动单文件下载任务（与详情页 Save_Click 末段一致）。</summary>
-    private static void StartQuickDownload(CompFile file, string target)
+    private static void _StartQuickDownload(CompFile file, string target)
     {
         var desc = file.Type switch
         {
@@ -3548,7 +3548,7 @@ public static class ModComp
     }
 
     /// <summary>根据资源类型返回实例内的目标子文件夹（与 Save_Click 一致）。</summary>
-    private static string GetSubFolder(CompType type) => type switch
+    private static string _GetSubFolder(CompType type) => type switch
     {
         CompType.Mod => "mods\\",
         CompType.ResourcePack => "resourcepacks\\",
@@ -3559,7 +3559,7 @@ public static class ModComp
     };
 
     /// <summary>取文件自身声明的加载器，缺失时回退到工程的加载器。</summary>
-    private static List<CompLoaderType> ResolveLoaders(CompFile file, CompProject project)
+    private static List<CompLoaderType> _ResolveLoaders(CompFile file, CompProject project)
         => file.ModLoaders.Count > 0 ? file.ModLoaders : project.ModLoaders;
 
     /// <summary>判断某实例是否兼容该文件（基于 Save_Click 的 isVersionSuitable，补全了 Quilt 判定）。</summary>
@@ -3586,7 +3586,7 @@ public static class ModComp
     }
 
     /// <summary>挑选最新文件：优先 Release，其次按发布日期最新。compatFilter 为空时不做兼容过滤。</summary>
-    private static CompFile? PickLatestFile(List<CompFile> files, Func<CompFile, bool>? compatFilter = null)
+    private static CompFile? _PickLatestFile(List<CompFile> files, Func<CompFile, bool>? compatFilter = null)
     {
         var candidates = (compatFilter is null ? files : files.Where(compatFilter)).ToList();
         if (candidates.Count == 0) return null;

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml
@@ -12,7 +12,7 @@
         <ColumnDefinition Width="8" />
         <ColumnDefinition Width="Auto" />
         <ColumnDefinition Width="1*" />
-        <ColumnDefinition Width="30" />
+        <ColumnDefinition Width="Auto" />
     </Grid.ColumnDefinitions>
     <Grid.RowDefinitions>
         <RowDefinition Height="1*" />
@@ -132,6 +132,11 @@
     <StackPanel x:Name="PanButtons" Grid.Column="5" Grid.Row="0" Grid.RowSpan="5"
                 Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center"
                 Margin="0,0,5,0" SnapsToDevicePixels="False" UseLayoutRounding="False" Opacity="0">
+
+        <!-- 快速下载按钮 -->
+        <local:MyIconButton x:Name="BtnDownload" Height="25" Width="25" SvgIcon="lucide/download"
+                            Margin="0,0,4,0" Visibility="Collapsed"
+                            ToolTip="{DynamicResource Download.Comp.QuickDownload.Btn.ToolTip}" />
 
         <!-- 删除收藏按钮 -->
         <local:MyIconButton x:Name="BtnDelete" Height="25" Width="25" SvgIcon="lucide/heart" />

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
@@ -50,7 +50,7 @@ public partial class MyCompItem
             var ani = new List<ModAnimation.AniData>();
             if (IsMouseOver)
             {
-                if (PanButtons is not null && ShowFavoriteBtn)
+                if (PanButtons is not null && HasActionButtons)
                     ani.Add(ModAnimation.AaOpacity(PanButtons, 1d - PanButtons.Opacity, (int)Math.Round(time * 0.35d),
                         (int)Math.Round(time * 0.15d)));
                 ani.AddRange(new[]
@@ -71,7 +71,7 @@ public partial class MyCompItem
             }
             else
             {
-                if (PanButtons is not null && ShowFavoriteBtn)
+                if (PanButtons is not null && HasActionButtons)
                     ani.Add(ModAnimation.AaOpacity(PanButtons, -PanButtons.Opacity, (int)Math.Round(time * 0.4d)));
                 ani.AddRange(new[]
                 {
@@ -160,6 +160,7 @@ public partial class MyCompItem
         // Handles
         LabInfo.MouseEnter += LabInfo_MouseEnter;
         BtnDelete.Click += BtnDelete_Click;
+        BtnDownload.Click += BtnDownload_Click;
     }
 
     // 指向时扩展描述
@@ -219,8 +220,32 @@ public partial class MyCompItem
     // ‘收藏按钮
     public bool ShowFavoriteBtn
     {
-        set => PanButtons.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
-        get => PanButtons.Visibility == Visibility.Visible;
+        get => BtnDelete.Visibility == Visibility.Visible;
+        set
+        {
+            BtnDelete.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            UpdatePanButtons();
+        }
+    }
+
+    // 快速下载按钮
+    public bool ShowDownloadBtn
+    {
+        get => BtnDownload.Visibility == Visibility.Visible;
+        set
+        {
+            BtnDownload.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            UpdatePanButtons();
+        }
+    }
+
+    /// <summary>右侧是否存在任意可见的操作按钮（收藏 / 下载），用于决定悬停时是否淡入按钮区。</summary>
+    private bool HasActionButtons => ShowFavoriteBtn || ShowDownloadBtn;
+
+    private void UpdatePanButtons()
+    {
+        if (PanButtons is null) return;
+        PanButtons.Visibility = HasActionButtons ? Visibility.Visible : Visibility.Collapsed;
     }
 
     /// <summary>
@@ -250,6 +275,12 @@ public partial class MyCompItem
             var project = (ModComp.CompProject)Tag;
             ModComp.CompFavorites.ShowMenu(project, (UIElement)sender, () => RefreshFavoriteStatus());
         }
+    }
+
+    private void BtnDownload_Click(object sender, EventArgs e)
+    {
+        if (PanButtons.Opacity > 0d && Tag is ModComp.CompProject project)
+            ModComp.QuickDownload(project);
     }
 
     private void MyCompItem_Click(MyCompItem sender, EventArgs e)
@@ -363,10 +394,8 @@ public partial class MyCompItem
         var isClickOnButton = false;
 
         if (PanButtons.Visibility == Visibility.Visible)
-        {
-            var buttonBounds = new Rect(BtnDelete.TranslatePoint(new Point(0d, 0d), this), BtnDelete.RenderSize);
-            isClickOnButton = buttonBounds.Contains(clickPosition);
-        }
+            isClickOnButton = IsClickOnActionButton(BtnDelete, clickPosition) ||
+                              IsClickOnActionButton(BtnDownload, clickPosition);
 
         // 如果点击在按钮上，不处理主项目点击事件
         if (isClickOnButton) return;
@@ -386,6 +415,14 @@ public partial class MyCompItem
     private void Button_MouseLeave(object sender, object e)
     {
         isMouseDown = false;
+    }
+
+    // 判断点击是否落在某个操作按钮（收藏 / 下载）上
+    private bool IsClickOnActionButton(FrameworkElement button, Point clickPosition)
+    {
+        if (button is null || button.Visibility != Visibility.Visible) return false;
+        var bounds = new Rect(button.TranslatePoint(new Point(0d, 0d), this), button.RenderSize);
+        return bounds.Contains(clickPosition);
     }
 
     #endregion

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml.cs
@@ -50,7 +50,7 @@ public partial class MyCompItem
             var ani = new List<ModAnimation.AniData>();
             if (IsMouseOver)
             {
-                if (PanButtons is not null && HasActionButtons)
+                if (PanButtons is not null && _HasActionButtons)
                     ani.Add(ModAnimation.AaOpacity(PanButtons, 1d - PanButtons.Opacity, (int)Math.Round(time * 0.35d),
                         (int)Math.Round(time * 0.15d)));
                 ani.AddRange(new[]
@@ -71,7 +71,7 @@ public partial class MyCompItem
             }
             else
             {
-                if (PanButtons is not null && HasActionButtons)
+                if (PanButtons is not null && _HasActionButtons)
                     ani.Add(ModAnimation.AaOpacity(PanButtons, -PanButtons.Opacity, (int)Math.Round(time * 0.4d)));
                 ani.AddRange(new[]
                 {
@@ -160,7 +160,7 @@ public partial class MyCompItem
         // Handles
         LabInfo.MouseEnter += LabInfo_MouseEnter;
         BtnDelete.Click += BtnDelete_Click;
-        BtnDownload.Click += BtnDownload_Click;
+        BtnDownload.Click += _BtnDownload_Click;
     }
 
     // 指向时扩展描述
@@ -224,7 +224,7 @@ public partial class MyCompItem
         set
         {
             BtnDelete.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
-            UpdatePanButtons();
+            _UpdatePanButtons();
         }
     }
 
@@ -235,17 +235,17 @@ public partial class MyCompItem
         set
         {
             BtnDownload.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
-            UpdatePanButtons();
+            _UpdatePanButtons();
         }
     }
 
     /// <summary>右侧是否存在任意可见的操作按钮（收藏 / 下载），用于决定悬停时是否淡入按钮区。</summary>
-    private bool HasActionButtons => ShowFavoriteBtn || ShowDownloadBtn;
+    private bool _HasActionButtons => ShowFavoriteBtn || ShowDownloadBtn;
 
-    private void UpdatePanButtons()
+    private void _UpdatePanButtons()
     {
         if (PanButtons is null) return;
-        PanButtons.Visibility = HasActionButtons ? Visibility.Visible : Visibility.Collapsed;
+        PanButtons.Visibility = _HasActionButtons ? Visibility.Visible : Visibility.Collapsed;
     }
 
     /// <summary>
@@ -277,7 +277,7 @@ public partial class MyCompItem
         }
     }
 
-    private void BtnDownload_Click(object sender, EventArgs e)
+    private void _BtnDownload_Click(object sender, EventArgs e)
     {
         if (PanButtons.Opacity > 0d && Tag is ModComp.CompProject project)
             ModComp.QuickDownload(project);
@@ -394,8 +394,8 @@ public partial class MyCompItem
         var isClickOnButton = false;
 
         if (PanButtons.Visibility == Visibility.Visible)
-            isClickOnButton = IsClickOnActionButton(BtnDelete, clickPosition) ||
-                              IsClickOnActionButton(BtnDownload, clickPosition);
+            isClickOnButton = _IsClickOnActionButton(BtnDelete, clickPosition) ||
+                              _IsClickOnActionButton(BtnDownload, clickPosition);
 
         // 如果点击在按钮上，不处理主项目点击事件
         if (isClickOnButton) return;
@@ -418,7 +418,7 @@ public partial class MyCompItem
     }
 
     // 判断点击是否落在某个操作按钮（收藏 / 下载）上
-    private bool IsClickOnActionButton(FrameworkElement button, Point clickPosition)
+    private bool _IsClickOnActionButton(FrameworkElement button, Point clickPosition)
     {
         if (button is null || button.Visibility != Visibility.Visible) return false;
         var bounds = new Rect(button.TranslatePoint(new Point(0d, 0d), this), button.RenderSize);

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
@@ -27,10 +27,13 @@ public partial class PageComp
             // 列表项
             PanProjects.Children.Clear();
             var index = Math.Min(page * pageSize, storage.results.Count - 1);
+            // 整合包需要安装而非直接下载，不显示快速下载按钮
+            var showQuickDownload = PageType != ModComp.CompType.ModPack;
             foreach (var result in storage.results.GetRange(index, Math.Min(storage.results.Count - index, pageSize)))
                 PanProjects.Children.Add(result.ToCompItem(loader.input.gameVersion is null,
                     loader.input.modLoader == ModComp.CompLoaderType.Any &&
-                    (PageType == ModComp.CompType.Mod || PageType == ModComp.CompType.ModPack)));
+                    (PageType == ModComp.CompType.Mod || PageType == ModComp.CompType.ModPack),
+                    showQuickDownload));
             // 页码
             CardPages.Visibility =
                 storage.results.Count > 40 || storage.curseForgeOffset < storage.curseForgeTotal ||

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml
@@ -85,6 +85,8 @@
                             <RowDefinition Height="7" x:Name="RowFilenameFormatGap" />
                             <RowDefinition Height="28" x:Name="RowModManageStyle" />
                             <RowDefinition Height="7" x:Name="RowModManageStyleGap" />
+                            <RowDefinition Height="28" x:Name="RowQuickDownload" />
+                            <RowDefinition Height="7" x:Name="RowQuickDownloadGap" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.Source}"
@@ -113,6 +115,16 @@
                                           ToolTip="{DynamicResource Setup.GameManage.Community.ModManageStyle.ToolTip}">
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.ModManageStyle.TitleTranslation}" IsSelected="True" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.ModManageStyle.TitleFilename}" />
+                        </local:MyComboBox>
+                        <TextBlock Grid.Row="6" VerticalAlignment="Center" HorizontalAlignment="Left" Text="{DynamicResource Setup.GameManage.Community.QuickDownload}"
+                                   Margin="0,0,25,0" />
+                        <local:MyComboBox Grid.Row="6" x:Name="ComboDownloadQuickBehavior" Grid.ColumnSpan="2"
+                                          Tag="ToolDownloadQuickBehavior" Grid.Column="1" SelectionChanged="ComboChange"
+                                          ToolTip="{DynamicResource Setup.GameManage.Community.QuickDownload.ToolTip}">
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.QuickDownload.AlwaysAsk}" IsSelected="True" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.QuickDownload.CurrentInstance}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.QuickDownload.AskInstance}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.GameManage.Community.QuickDownload.AskPath}" />
                         </local:MyComboBox>
                     </Grid>
                     <Grid>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -61,6 +61,7 @@ public partial class PageSetupGameManage
         ComboDownloadTranslateV2.SelectedIndex = Config.Download.Comp.NameFormatV2;
         ComboDownloadMod.SelectedIndex = Config.Download.Comp.CompSourceSolution;
         ComboModLocalNameStyle.SelectedIndex = Config.Download.Comp.UiCompNameSolution;
+        ComboDownloadQuickBehavior.SelectedIndex = Config.Download.Comp.QuickDownloadBehavior;
         CheckDownloadIgnoreQuilt.Checked = Config.Download.Comp.IgnoreQuilt;
         CheckDownloadAutoInstallDependencies.Checked = Config.Download.Comp.AutoInstallDependencies;
         CheckDownloadClipboard.Checked = Config.Download.Comp.ReadClipboard;


### PR DESCRIPTION
This PR closes #3221.
本 PR 在模组存档、数据包等页面的卡片信息右侧添加一个快捷下载按钮，允许通过点击此按钮快速下载资源。

<img width="1123" height="686" alt="image" src="https://github.com/user-attachments/assets/396bcf30-3c5b-41fe-8d40-4f930f30ba83" />
<img width="1123" height="686" alt="image" src="https://github.com/user-attachments/assets/2514a311-9177-4dc6-b64e-74593cdf525c" />

## Summary by Sourcery

为组件搜索结果卡片新增可配置的快速下载支持，包括实例/文件夹目标选择以及基于兼容性的集中式文件选取。

New Features:
- 在搜索结果中兼容的资源卡片上显示快速下载按钮，用于获取最新的兼容文件。
- 引入可配置的快速下载行为，可在当前实例、已选择的实例或用户自选文件夹之间选择下载目标。

Enhancements:
- 将兼容性检查和最新文件选取逻辑集中化，以便在快速下载流程和实例选择中复用。
- 统一资源卡片操作按钮的处理逻辑，使收藏和快速下载按钮在悬停、可见性及点击行为上保持一致。
- 将快速下载偏好设置接入游戏管理设置页面和本地化资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable quick-download support for component search result cards, including instance/folder targeting and centralized compatibility-based file selection.

New Features:
- Expose a quick-download button on compatible resource cards in search results to fetch the latest compatible file.
- Introduce a configurable quick-download behavior to choose between current instance, selected instance, or a user-chosen folder as the download target.

Enhancements:
- Centralize compatibility checks and latest-file selection logic for reuse across quick-download flows and instance selection.
- Unify resource card action button handling so favorite and quick-download buttons share consistent hover, visibility, and click behavior.
- Wire quick-download preferences into the game management settings page and localization resources.

</details>

新功能：
- 在下载搜索结果中的资源卡片上添加“快速下载”按钮，用于获取项目的最新兼容文件。
- 引入可配置的快速下载行为，用于控制资源是保存到当前实例、指定实例，还是指定文件夹。

增强改进：
- 将兼容性检查和最新文件选择逻辑集中化，以支持跨实例的快速下载。
- 改进资源卡片操作按钮的处理方式，使多个操作（收藏和快速下载）在悬停和点击时拥有一致的体验。
- 将快速下载选项接入游戏管理设置页面和本地化资源中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为组件搜索结果卡片新增可配置的快速下载支持，包括实例/文件夹目标选择以及基于兼容性的集中式文件选取。

New Features:
- 在搜索结果中兼容的资源卡片上显示快速下载按钮，用于获取最新的兼容文件。
- 引入可配置的快速下载行为，可在当前实例、已选择的实例或用户自选文件夹之间选择下载目标。

Enhancements:
- 将兼容性检查和最新文件选取逻辑集中化，以便在快速下载流程和实例选择中复用。
- 统一资源卡片操作按钮的处理逻辑，使收藏和快速下载按钮在悬停、可见性及点击行为上保持一致。
- 将快速下载偏好设置接入游戏管理设置页面和本地化资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable quick-download support for component search result cards, including instance/folder targeting and centralized compatibility-based file selection.

New Features:
- Expose a quick-download button on compatible resource cards in search results to fetch the latest compatible file.
- Introduce a configurable quick-download behavior to choose between current instance, selected instance, or a user-chosen folder as the download target.

Enhancements:
- Centralize compatibility checks and latest-file selection logic for reuse across quick-download flows and instance selection.
- Unify resource card action button handling so favorite and quick-download buttons share consistent hover, visibility, and click behavior.
- Wire quick-download preferences into the game management settings page and localization resources.

</details>

</details>