### PR TITLE
fix(download): 移除数据包的快速下载功能

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3568,7 +3568,6 @@ public static class ModComp
         CompType.ResourcePack => "resourcepacks\\",
         CompType.Shader => "shaderpacks\\",
         CompType.World => "saves\\",
-        CompType.DataPack => "", // 导航到版本根目录
         _ => ""
     };
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
@@ -27,14 +27,15 @@ public partial class PageComp
             // 列表项
             PanProjects.Children.Clear();
             var index = Math.Min(page * pageSize, storage.results.Count - 1);
-            // 整合包需要安装、数据包需放入具体存档，均不显示快速下载按钮
-            var showQuickDownload = PageType != ModComp.CompType.ModPack &&
-                                    PageType != ModComp.CompType.DataPack;
             foreach (var result in storage.results.GetRange(index, Math.Min(storage.results.Count - index, pageSize)))
+            {
+                var showQuickDownload = result.Type != ModComp.CompType.ModPack &&
+                                        result.Type != ModComp.CompType.DataPack;
                 PanProjects.Children.Add(result.ToCompItem(loader.input.gameVersion is null,
                     loader.input.modLoader == ModComp.CompLoaderType.Any &&
                     (PageType == ModComp.CompType.Mod || PageType == ModComp.CompType.ModPack),
                     showQuickDownload));
+            }
             // 页码
             CardPages.Visibility =
                 storage.results.Count > 40 || storage.curseForgeOffset < storage.curseForgeTotal ||

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.cs
@@ -27,8 +27,9 @@ public partial class PageComp
             // 列表项
             PanProjects.Children.Clear();
             var index = Math.Min(page * pageSize, storage.results.Count - 1);
-            // 整合包需要安装而非直接下载，不显示快速下载按钮
-            var showQuickDownload = PageType != ModComp.CompType.ModPack;
+            // 整合包需要安装、数据包需放入具体存档，均不显示快速下载按钮
+            var showQuickDownload = PageType != ModComp.CompType.ModPack &&
+                                    PageType != ModComp.CompType.DataPack;
             foreach (var result in storage.results.GetRange(index, Math.Min(storage.results.Count - index, pageSize)))
                 PanProjects.Children.Add(result.ToCompItem(loader.input.gameVersion is null,
                     loader.input.modLoader == ModComp.CompLoaderType.Any &&


### PR DESCRIPTION
由于数据包一般需要放置到存档的 `datapacks` 文件夹内，因此快速下载功能需要选择存档，会增加耦合性

## 由 Sourcery 提供的摘要

禁用数据包的快速下载支持，以减少与特定存档目录的耦合。

错误修复：
- 在下载页面中隐藏数据包条目的快速下载按钮。
- 从快速下载目标路径映射中移除对数据包的处理，以防止错误下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable quick download support for datapacks to reduce coupling with specific save directories.

Bug Fixes:
- Hide the quick download button for datapack items in the download page.
- Remove datapack handling from the quick download target path mapping to prevent incorrect downloads.

</details>