### PR TITLE
fix(network): 临时禁用 HTTP/3 以缓解 dotnet/runtime#114128

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyImage.cs
+++ b/Plain Craft Launcher 2/Controls/MyImage.cs
@@ -144,7 +144,6 @@ public class MyImage : Image
             using (var fs = new FileStream(tempDownloadingPath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read))
             {
                 using (var response = await HttpRequest.Create(url)
-                           .WithHttpVersionOption(HttpVersion.Version30)
                            .SendAsync(addMetedata: false))
                 {
                     response.EnsureSuccessStatusCode();


### PR DESCRIPTION
This resolves #3226.
根据本人探索，此问题是由 dotnet/runtime#114128 引起的。.NET 的 HTTP/3 实现在 stream abort 时会把 `QuicException` 挂到内部 Task，无法从请求调用点 catch，导致这个异常没有经过任何 try catch，而是直接走到了 `TaskScheduler.UnobservedTaskException`。

此问题在 .NET 10 被修复，主项目版本却仍为 .NET 8，因此，此问题应当在升级至 .NET 10 之后解决。

综上所述，解决此问题只有两个方法：
1. 升级至 .NET 10
2. 禁用强制 HTTP/3

由于仍有一部分用户的系统版本较低，因此升级至 .NET 10 还需要一定时间。所以此问题的最佳修复方案是**禁用强制 HTTP/3**，在有条件升级至 .NET 10 之后回退此更改

## Summary by Sourcery

Bug Fixes:
- 通过不再对这些请求强制使用 HTTP/3，避免在图片下载过程中因未处理的 HTTP/3 QUIC 异常而导致的崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid crashes caused by unhandled HTTP/3 QUIC exceptions during image downloads by no longer forcing HTTP/3 for these requests.

</details>