### PR TITLE
fix(Hint): 修复提示条方向

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyHint.xaml.cs
@@ -59,9 +59,9 @@ public partial class MyHint
         set
         {
             if (value)
-                BorderThickness = new Thickness(ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d), 3d, ModBase.GetWPFSize(1d));
+                BorderThickness = new Thickness(3d, ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d), ModBase.GetWPFSize(1d));
             else
-                BorderThickness = new Thickness(0d, 0d, 3d, 0d);
+                BorderThickness = new Thickness(3d, 0d, 0d, 0d);
         }
     }
 


### PR DESCRIPTION
从
<img width="654" height="107" alt="PixPin_2026-06-29_00-13-34" src="https://github.com/user-attachments/assets/774f847d-888b-4e72-9e26-6a23f81a2228" />
改回
<img width="650" height="99" alt="PixPin_2026-06-29_00-12-43" src="https://github.com/user-attachments/assets/0e0b6f32-a7b5-4550-8399-f70ed88ec8d9" />

## Summary by Sourcery

Bug Fixes:
- 修复提示组件边框的位置，使其出现在预期的一侧，而不是相反的一侧。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix hint component border so it appears on the intended side instead of the opposite side.

</details>