### PR TITLE
fix: 更新主页预设 Minecraft 新闻主页的 URL 链接

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -125,7 +125,7 @@ public partial class PageLaunchRight : IRefreshable
 
                 case 2:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 新闻");
-                    url = "https://pcl.mcnews.thestack.top";
+                    url = "https://news.bugjump.net";
                     content = LoadFromNetwork(url);
                     break;
 


### PR DESCRIPTION
close #3260

## Summary by Sourcery

错误修复：
- 更正 Minecraft 新闻主页预设链接，使其指向更新后的官方网站 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the Minecraft news homepage preset link to point to the updated official URL.

</details>