### PR TITLE
fix: 验证登录失败导致无法进行第三方登录

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1381,7 +1381,8 @@ public static class ModLaunch
             catch (WebException ex)
             {
                 HandleHttpWebException(ex, "验证登录失败");
-            }catch (HttpResponseException ex){
+            }
+            catch (HttpResponseException ex){
                 ModProfile.ProfileLog($"验证登录失败: {ex}");
             }
             catch (Exception ex)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1382,7 +1382,7 @@ public static class ModLaunch
             {
                 HandleHttpWebException(ex, "验证登录失败");
             }catch (HttpResponseException ex){
-                ModProfile.ProfileLog("验证登录失败", ex)
+                ModProfile.ProfileLog($"验证登录失败: {ex}");
             }
             catch (Exception ex)
             {

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1381,6 +1381,8 @@ public static class ModLaunch
             catch (WebException ex)
             {
                 HandleHttpWebException(ex, "验证登录失败");
+            }catch (HttpResponseException ex){
+                ModProfile.ProfileLog("验证登录失败", ex)
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Resolved #3274

@Pigeon0v0 发一版新的吧

## Summary by Sourcery

错误修复：
- 在登录验证过程中单独处理 `HttpResponseException`，以便当出现此特定错误时，第三方登录功能仍然保持可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle HttpResponseException separately during login verification so third‑party login remains functional when this specific error occurs.

</details>
