### PR TITLE
refactor: 重构版本信息为 Tag 样式并在无前置时隐藏分区

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyMsg/ModDependencyMsgBox.xaml
+++ b/Plain Craft Launcher 2/Controls/MyMsg/ModDependencyMsgBox.xaml
@@ -32,7 +32,16 @@
                                VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
                                DeltaMult="0.7">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock Name="LabVersionInfo" FontSize="13" TextWrapping="Wrap" Margin="2,0,2,12" Opacity="0.8" />
+                    <StackPanel Margin="2,0,2,12">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Name="LabVersionInfo"
+                                       TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                                       VerticalAlignment="Center" />
+                            <StackPanel Orientation="Horizontal"
+                                        Name="PanVersionTags" VerticalAlignment="Center" Margin="4,0,0,0" />
+                        </StackPanel>
+                        <TextBlock Name="LabDateInfo" TextWrapping="Wrap" Margin="0,4,0,0"/>
+                    </StackPanel>
                     <TextBlock Name="LabReqTitle" FontSize="14" FontWeight="Bold" Margin="2,8,0,4" />
                     <StackPanel Name="PanReqDeps" Orientation="Vertical" />
                     <TextBlock Name="LabOptTitle" FontSize="14" FontWeight="Bold" Margin="2,8,0,4" />

--- a/Plain Craft Launcher 2/Controls/MyMsg/ModDependencyMsgBox.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MyMsg/ModDependencyMsgBox.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 using PCL.Core.App.Localization;
 using PCL.Core.UI.Controls;
 
@@ -59,23 +60,37 @@ public partial class ModDependencyMsgBox
     private void Populate(ModComp.CompFile file)
     {
         // 1. 版本信息
-        var info = new List<string>();
-        if (!string.IsNullOrEmpty(file.FileName))
-            info.Add(file.FileName);
-        if (file.GameVersions.Any())
-            info.Add(Lang.Text("Download.Comp.Detail.FileList.GameVersion", string.Join("、", file.GameVersions)));
-        if (file.ModLoaders.Any())
-            info.Add(string.Join(" / ", file.ModLoaders));
-        info.Add(Lang.Text("Download.Comp.Detail.FileList.Updated", Lang.TimeSpan(file.ReleaseDate - DateTime.Now)));
-        if (file.Status != ModComp.CompFileStatus.Release)
-            info.Add(file.StatusDescription);
-        LabVersionInfo.Text = string.Join("  |  ", info);
+        LabVersionInfo.Text = file.DisplayName;
+        _AddTag(file.StatusDescription);
+        foreach (var loader in file.ModLoaders)
+            _AddTag(loader.ToString());
+        LabDateInfo.Text = Lang.Text("Download.Comp.Detail.FileList.Updated", file.ReleaseDate.ToString("G"));
 
         // 2. 必要前置 / 可选前置
         FillDependencySection(LabReqTitle, PanReqDeps, file.Dependencies,
             Lang.Text("Download.Comp.Detail.FileList.RequiredDependencies"));
         FillDependencySection(LabOptTitle, PanOptDeps, file.OptionalDependencies,
             Lang.Text("Download.Comp.Detail.FileList.OptionalDependencies"));
+    }
+
+    private void _AddTag(string text)
+    {
+        var tag = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(17, 0, 0, 0)),
+            Padding = new Thickness(3d, 1d, 3d, 1d),
+            CornerRadius = new CornerRadius(3d),
+            Margin = new Thickness(0d, 0d, 3d, 0d),
+            SnapsToDevicePixels = true,
+            UseLayoutRounding = false
+        };
+        tag.Child = new TextBlock
+        {
+            Text = text,
+            Foreground = new SolidColorBrush(Color.FromRgb(134, 134, 134)),
+            FontSize = 11d
+        };
+        PanVersionTags.Children.Add(tag);
     }
 
     /// <summary>
@@ -92,13 +107,8 @@ public partial class ModDependencyMsgBox
 
         if (!projects.Any())
         {
-            panel.Children.Add(new TextBlock
-            {
-                Text = Lang.Text("Download.Comp.Detail.VersionPopup.NoDeps"),
-                FontSize = 13d,
-                Margin = new Thickness(14d, 0d, 0d, 4d),
-                Opacity = 0.6d
-            });
+            header.Visibility = Visibility.Collapsed;
+            panel.Visibility = Visibility.Collapsed;
             return;
         }
 


### PR DESCRIPTION
<img width="1397" height="508" alt="86b0972c61d8854a45a5c60b8e1bae41" src="https://github.com/user-attachments/assets/34ed7f0c-6e31-43b1-be6e-d45b9ac60e6e" />
<img width="1446" height="508" alt="b52b725130af80d45a0602b2b04c9e1e" src="https://github.com/user-attachments/assets/a68073a4-941f-495b-abec-91c2257e713a" />

## Summary by Sourcery

优化模组依赖弹窗布局，将版本详情以标签形式展示，并隐藏空的依赖部分。

改进内容：
- 使用文件显示名称展示模组文件版本信息，并通过标签样式的标记来体现状态和模组加载器。
- 以格式化日期字符串显示文件发布时间，而不是相对时间描述。
- 在没有依赖项时隐藏依赖部分的标题和内容，以减少视觉杂乱。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the mod dependency popup layout to present version details as tags and hide empty dependency sections.

Enhancements:
- Display mod file version information using the file display name with tag-style labels for status and mod loaders.
- Show the file release time in a formatted date string instead of a relative time description.
- Hide dependency section headers and content when no dependencies are present to reduce visual clutter.

</details>