### PR TITLE
fix: 修复 LiteLoader 安装实例 Json 时间解析格式

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -16,8 +16,6 @@ using PCL.Core.UI;
 using PCL.Core.Utils;
 using PCL.Network;
 using PCL.Network.Loaders;
-using PCL.Core.IO.Net.Http;
-using PCL.Core.App.Localization;
 
 namespace PCL;
 
@@ -1476,10 +1474,9 @@ public static class ModDownloadLib
                 Directory.CreateDirectory(versionFolder);
                 var versionJson = new JsonObject();
                 versionJson.Add("id", versionName);
-                versionJson.Add("time",
-                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd H:mm", CultureInfo.InvariantCulture));
-                versionJson.Add("releaseTime",
-                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd H:mm", CultureInfo.InvariantCulture));
+                var releaseDate = DateTime.Parse(downloadInfo.ReleaseTime, Lang.Culture);
+                versionJson.Add("time", releaseDate);
+                versionJson.Add("releaseTime", releaseDate);
                 versionJson.Add("type", "release");
                 versionJson.Add("arguments",
                     (JsonNode)ModBase.GetJson("{\"game\":[\"--tweakClass\",\"" + downloadInfo.jsonToken["tweakClass"] +

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -1477,9 +1477,9 @@ public static class ModDownloadLib
                 var versionJson = new JsonObject();
                 versionJson.Add("id", versionName);
                 versionJson.Add("time",
-                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd HH:mm", CultureInfo.InvariantCulture));
+                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd H:mm", CultureInfo.InvariantCulture));
                 versionJson.Add("releaseTime",
-                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd HH:mm", CultureInfo.InvariantCulture));
+                    DateTime.ParseExact(downloadInfo.ReleaseTime, "yyyy/MM/dd H:mm", CultureInfo.InvariantCulture));
                 versionJson.Add("type", "release");
                 versionJson.Add("arguments",
                     (JsonNode)ModBase.GetJson("{\"game\":[\"--tweakClass\",\"" + downloadInfo.jsonToken["tweakClass"] +


### PR DESCRIPTION
close #3299

## Summary by Sourcery

Bug Fixes:
- 通过调整预期的日期时间格式，修复 LiteLoader 安装 JSON 中 `time` 和 `releaseTime` 的解析问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix LiteLoader installation JSON time and releaseTime parsing by adjusting the expected date-time format.

</details>