### PR TITLE
fix(download-lib): 补全 mods 临时路径分隔符

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -4036,7 +4036,7 @@ public static class ModDownloadLib
         var modable = request.fabricVersion is not null || request.legacyFabricVersion is not null ||
                       request.forgeEntry is not null || request.neoForgeEntry is not null ||
                       request.liteLoaderEntry is not null;
-        var modsTempFolder = Path.Combine(tempMcFolder, "mods");
+        var modsTempFolder = Path.Combine(tempMcFolder, "mods") + @"\";
         var optiFineAsMod = request.optiFineEntry is not null && modable; // 选择了 OptiFine 与任意 Mod 加载器
         if (optiFineAsMod)
         {


### PR DESCRIPTION
close #3301

## Summary by Sourcery

Bug Fixes:
- 修复错误的模组临时文件夹路径问题，该问题可能会在下载或处理过程中破坏对模组的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect mods temporary folder path that could break handling of mods during download or processing.

</details>