### PR TITLE
fix(mytoast): 修复 `MyToast` 控件字体和边框缝隙的问题

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -27,7 +27,8 @@
                              Margin="0,0,6,0" UseOriginalColor="False" />
 
             <TextBlock x:Name="TitleText" Grid.Column="1" VerticalAlignment="Center"
-                       FontSize="13" FontWeight="Bold"/>
+                       FontSize="13" FontWeight="Bold"
+                       TextTrimming="CharacterEllipsis" />
 
             <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
                                 Margin="8,0,0,0" SvgIcon="lucide/x" Theme="Custom" />

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -5,7 +5,7 @@
         xmlns:local="clr-namespace:PCL"
         x:Name="Root"
         HorizontalAlignment="Right"
-        CornerRadius="8" BorderThickness="1"
+        CornerRadius="8" BorderThickness="0"
         UseLayoutRounding="True" SnapsToDevicePixels="True">
     <Border.Effect>
         <DropShadowEffect BlurRadius="16" Opacity="0.2" ShadowDepth="4" Direction="270" Color="#000000" />

--- a/Plain Craft Launcher 2/Controls/MyToast.xaml
+++ b/Plain Craft Launcher 2/Controls/MyToast.xaml
@@ -6,8 +6,7 @@
         x:Name="Root"
         HorizontalAlignment="Right"
         CornerRadius="8" BorderThickness="1"
-        UseLayoutRounding="True" SnapsToDevicePixels="True"
-        RenderOptions.BitmapScalingMode="NearestNeighbor">
+        UseLayoutRounding="True" SnapsToDevicePixels="True">
     <Border.Effect>
         <DropShadowEffect BlurRadius="16" Opacity="0.2" ShadowDepth="4" Direction="270" Color="#000000" />
     </Border.Effect>
@@ -28,8 +27,7 @@
                              Margin="0,0,6,0" UseOriginalColor="False" />
 
             <TextBlock x:Name="TitleText" Grid.Column="1" VerticalAlignment="Center"
-                       FontSize="13" FontWeight="SemiBold"
-                       TextTrimming="CharacterEllipsis" />
+                       FontSize="13" FontWeight="Bold"/>
 
             <local:MyIconButton Grid.Column="2" x:Name="BtnClose" Width="20" Height="20"
                                 Margin="8,0,0,0" SvgIcon="lucide/x" Theme="Custom" />


### PR DESCRIPTION
<img width="819" height="257" alt="PixPin_2026-07-01_21-08-59" src="https://github.com/user-attachments/assets/4df9f352-4e78-41cd-a11a-e354087bdcb3" />

## Summary by Sourcery

Bug Fixes:
- 修正 MyToast 控件的字体配置，使通知消息能够使用预期的字体进行显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct MyToast control font configuration so toast messages display with the intended font.

</details>