### PR TITLE
fix: 修复部分操作意外抛出 XamlParseException 的问题

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -121,9 +121,7 @@
     <sys:String x:Key="Crash.Export.Failed.Message">The crash report could not be exported.&#xA;&#xA;Target path: {0}</sys:String>
     <sys:String x:Key="Crash.Export.Failed.MessageWithoutPath">The crash report could not be exported, and the target path is unavailable.</sys:String>
     <sys:String x:Key="Crash.Export.Failed.Title">Failed to export crash report</sys:String>
-    <sys:String x:Key="Crash.Presentation.LineSeparator">&#xA;</sys:String>
     <sys:String x:Key="Crash.Presentation.ListItem"> - {0}</sys:String>
-    <sys:String x:Key="Crash.Presentation.ParagraphSeparator">&#xA;&#xA;</sys:String>
     <sys:String x:Key="Crash.Presentation.ReasonOnly">Cause&#xA;{0}</sys:String>
     <sys:String x:Key="Crash.Presentation.WithFollowUps">{0}&#xA;&#xA;{1}</sys:String>
     <sys:String x:Key="Crash.Presentation.WithSuggestion">Cause&#xA;{0}&#xA;&#xA;What you can try&#xA;{1}</sys:String>
@@ -388,7 +386,6 @@
     <sys:String x:Key="Download.Comp.Dependency.Install.Title">Install mod dependencies</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.Install.WithDependencies">Install mod and dependencies</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.Install.WithoutDependencies">Download mod only (not recommended)</sys:String>
-    <sys:String x:Key="Download.Comp.Dependency.ListSeparator">&#xA;</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Continue">Continue download</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Message">Failed to resolve the mod dependencies. Only the main mod will be downloaded.</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Title">Failed to resolve dependencies</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -121,9 +121,7 @@
     <sys:String x:Key="Crash.Export.Failed.Message">无法导出错误报告。&#xA;&#xA;目标路径：{0}</sys:String>
     <sys:String x:Key="Crash.Export.Failed.MessageWithoutPath">无法导出错误报告，且未能获取目标路径。</sys:String>
     <sys:String x:Key="Crash.Export.Failed.Title">导出错误报告失败</sys:String>
-    <sys:String x:Key="Crash.Presentation.LineSeparator">&#xA;</sys:String>
     <sys:String x:Key="Crash.Presentation.ListItem"> - {0}</sys:String>
-    <sys:String x:Key="Crash.Presentation.ParagraphSeparator">&#xA;&#xA;</sys:String>
     <sys:String x:Key="Crash.Presentation.ReasonOnly">原因&#xA;{0}</sys:String>
     <sys:String x:Key="Crash.Presentation.WithFollowUps">{0}&#xA;&#xA;{1}</sys:String>
     <sys:String x:Key="Crash.Presentation.WithSuggestion">原因&#xA;{0}&#xA;&#xA;你可以尝试&#xA;{1}</sys:String>
@@ -388,7 +386,6 @@
     <sys:String x:Key="Download.Comp.Dependency.Install.Title">安装模组前置确认</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.Install.WithDependencies">安装模组与必需前置</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.Install.WithoutDependencies">仅下载模组本体（不建议）</sys:String>
-    <sys:String x:Key="Download.Comp.Dependency.ListSeparator">&#xA;</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Continue">继续下载</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Message">无法解析模组前置，将仅下载模组本体。</sys:String>
     <sys:String x:Key="Download.Comp.Dependency.ResolveFailed.Title">前置解析失败</sys:String>

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Presentation/CrashResultFormatter.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Presentation/CrashResultFormatter.cs
@@ -489,14 +489,14 @@ internal sealed class CrashResultFormatter
     private static string _BulletList(IEnumerable<string> items)
     {
         return string.Join(
-            Lang.Text("Crash.Presentation.LineSeparator"),
+            Environment.NewLine,
             items.Select(item => Lang.Text("Crash.Presentation.ListItem", item)));
     }
 
     private static string _JoinParagraphs(IEnumerable<string> items)
     {
         return string.Join(
-            Lang.Text("Crash.Presentation.ParagraphSeparator"),
+            Environment.NewLine + Environment.NewLine,
             items.Where(item => !string.IsNullOrWhiteSpace(item)));
     }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -225,7 +225,7 @@ public static class ModCompDependency
         {
             ModBase.Log($"[CompDeps] 无法解析: {result.Unresolved.Count} 个必需前置");
             var dependencies = string.Join(
-                Lang.Text("Download.Comp.Dependency.ListSeparator"),
+                Environment.NewLine,
                 result.Unresolved.Select(dep => Lang.Text(
                     "Download.Comp.Dependency.Unresolved.ListItem",
                     dep.Source,
@@ -248,7 +248,7 @@ public static class ModCompDependency
         if (result.ToInstall is { Count: > 0 })
         {
             var dependencies = string.Join(
-                Lang.Text("Download.Comp.Dependency.ListSeparator"),
+                Environment.NewLine,
                 result.ToInstall.Select(install => Lang.Text(
                     "Download.Comp.Dependency.Install.ListItem",
                     install.ProjectName,


### PR DESCRIPTION
## Summary by Sourcery

标准化崩溃和依赖项消息，使用与环境相关的新行符号，而不是本地化分隔符，以避免解析问题。

Bug Fixes（错误修复）:
- 修复崩溃结果项目符号列表使用本地化行分隔符的问题，该问题在某些场景下可能触发 `XamlParseException`。
- 修复依赖项解析对话框使用本地化列表分隔符的问题，该问题可能导致意外的格式或解析错误。

Enhancements（功能增强）:
- 将崩溃分析和依赖项消息统一到基于新行的格式，以在不同区域设置中获得更好的一致性和可读性。

Documentation（文档）:
- 更新英文和中文本地化资源，以反映新的基于新行格式的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize crash and dependency messages to use environment-specific newlines instead of localized separators to avoid parsing issues.

Bug Fixes:
- Fix crash result bullet lists using a localized line separator that could trigger XamlParseException in certain contexts.
- Fix dependency resolution dialogs using localized list separators that could cause unexpected formatting or parsing errors.

Enhancements:
- Align crash analysis and dependency messages to a consistent newline-based formatting for better readability across locales.

Documentation:
- Update English and Chinese localization resources to reflect the new newline-based formatting behavior.

</details>