### PR TITLE
ref(net): 调整下载器获取 HttpClient 的逻辑避免无法应用 API Key

### DIFF
--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -210,10 +210,7 @@ public static class FileDownloader
     private static HttpClient GetHttpClient(string url)
     {
         if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
-            && parsedUri.Host == "edge.forgecdn.net"
-            || parsedUri.Host == "mediafilez.forgecdn.net"
-            || parsedUri.Host == "forgecdn.net"
-            || parsedUri.Host == "api.curseforge.com")
+            && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")
         {
             return NetworkService.GetClient(NetworkService.CurseForgeApi);
         }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -88,7 +88,7 @@ public static class FileDownloader
             BlockTimeout = 60000,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
-            CustomHttpClientFactory = () => GetHttpClient(url),
+            CustomHttpClientFactory = () => GetHttpClient(url, customUserAgent),
             MinimumSizeOfChunking = 1024 * 1024L,
         };
 
@@ -207,7 +207,7 @@ public static class FileDownloader
         }
     }
 
-    private static HttpClient GetHttpClient(string url)
+    private static HttpClient GetHttpClient(string url, string? customUserAgent)
     {
         if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
             && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")
@@ -215,6 +215,14 @@ public static class FileDownloader
             return NetworkService.GetClient(NetworkService.CurseForgeApi);
         }
 
+        if (!string.IsNullOrWhiteSpace(customUserAgent))
+        {
+            var client = NetworkService.GetClient();
+            client.DefaultRequestHeaders.Remove("User-Agent");
+            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", customUserAgent);
+            return client;
+        }
+        
         return NetworkService.GetClient();
     }
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -88,7 +88,7 @@ public static class FileDownloader
             BlockTimeout = 60000,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
-            CustomHttpClientFactory = () => GetHttpClient(url, customUserAgent),
+            CustomHttpClientFactory = () => GetHttpClient(url),
             MinimumSizeOfChunking = 1024 * 1024L,
         };
 
@@ -207,7 +207,7 @@ public static class FileDownloader
         }
     }
 
-    private static HttpClient GetHttpClient(string url, string? customUserAgent)
+    private static HttpClient GetHttpClient(string url)
     {
         if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
             && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net.Http;
 using Downloader;
 using PCL.Core.IO.Net;
 
@@ -87,8 +88,7 @@ public static class FileDownloader
             BlockTimeout = 60000,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
-            RequestConfiguration = DownloadRequestFactory.Create(url, useBrowserUserAgent, customUserAgent),
-            CustomHttpClientFactory = () => NetworkService.GetClient(),
+            CustomHttpClientFactory = () => GetHttpClient(url),
             MinimumSizeOfChunking = 1024 * 1024L,
         };
 
@@ -205,5 +205,19 @@ public static class FileDownloader
                 Thread.Sleep(100);
             }
         }
+    }
+
+    private static HttpClient GetHttpClient(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
+            && parsedUri.Host == "edge.forgecdn.net"
+            || parsedUri.Host == "mediafilez.forgecdn.net"
+            || parsedUri.Host == "forgecdn.net"
+            || parsedUri.Host == "api.curseforge.com")
+        {
+            return NetworkService.GetClient(NetworkService.CurseForgeApi);
+        }
+
+        return NetworkService.GetClient();
     }
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -78,6 +78,10 @@ public static class FileDownloader
         CleanupTempFiles(localPath);
 
         var perFileThreadLimit = enableParallelChunks ? Math.Max(1, ModNet.NetTaskThreadLimit) : 1;
+        var isCurseForgeUrl = IsCurseForgeUrl(url);
+        var requestCustomUserAgent = !isCurseForgeUrl && !string.IsNullOrWhiteSpace(customUserAgent)
+            ? customUserAgent
+            : null;
         var configuration = new DownloadConfiguration
         {
             ChunkCount = perFileThreadLimit,
@@ -88,9 +92,14 @@ public static class FileDownloader
             BlockTimeout = 60000,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
-            CustomHttpClientFactory = () => GetHttpClient(url, customUserAgent),
             MinimumSizeOfChunking = 1024 * 1024L,
         };
+
+        if (requestCustomUserAgent is not null)
+            configuration.CustomHttpMessageHandlerFactory = () => new CustomUserAgentMessageHandler(requestCustomUserAgent);
+        else
+            configuration.CustomHttpClientFactory = () =>
+                NetworkService.GetClient(isCurseForgeUrl ? NetworkService.CurseForgeApi : NetworkService.Default);
 
         using var downloader = new DownloadService(configuration);
         using var cancelReg = cancellationToken.Register(() =>
@@ -207,22 +216,63 @@ public static class FileDownloader
         }
     }
 
-    private static HttpClient GetHttpClient(string url, string? customUserAgent)
+    private static bool IsCurseForgeUrl(string url)
     {
-        if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
-            && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")
+        return Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
+            && IsCurseForgeHost(parsedUri.Host);
+    }
+
+    private static bool IsCurseForgeHost(string host)
+    {
+        return host.Equals("edge.forgecdn.net", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("mediafilez.forgecdn.net", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("forgecdn.net", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("api.curseforge.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class CustomUserAgentMessageHandler(string customUserAgent) : HttpMessageHandler
+    {
+        private readonly HttpClient _client = NetworkService.GetClient();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return NetworkService.GetClient(NetworkService.CurseForgeApi);
+            var forwardedRequest = CloneRequest(request);
+            forwardedRequest.Headers.Remove("User-Agent");
+            forwardedRequest.Headers.TryAddWithoutValidation("User-Agent", customUserAgent);
+
+            try
+            {
+                return await _client.SendAsync(forwardedRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                forwardedRequest.Dispose();
+                throw;
+            }
         }
 
-        if (!string.IsNullOrWhiteSpace(customUserAgent))
+        protected override void Dispose(bool disposing)
         {
-            var client = NetworkService.GetClient();
-            client.DefaultRequestHeaders.Remove("User-Agent");
-            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", customUserAgent);
-            return client;
+            if (disposing)
+                _client.Dispose();
+
+            base.Dispose(disposing);
         }
-        
-        return NetworkService.GetClient();
+
+        private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Version = request.Version,
+                VersionPolicy = request.VersionPolicy
+            };
+
+            foreach (var header in request.Headers)
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            return clone;
+        }
     }
+
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -78,10 +78,6 @@ public static class FileDownloader
         CleanupTempFiles(localPath);
 
         var perFileThreadLimit = enableParallelChunks ? Math.Max(1, ModNet.NetTaskThreadLimit) : 1;
-        var isCurseForgeUrl = IsCurseForgeUrl(url);
-        var requestCustomUserAgent = !isCurseForgeUrl && !string.IsNullOrWhiteSpace(customUserAgent)
-            ? customUserAgent
-            : null;
         var configuration = new DownloadConfiguration
         {
             ChunkCount = perFileThreadLimit,
@@ -92,14 +88,9 @@ public static class FileDownloader
             BlockTimeout = 60000,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
+            CustomHttpClientFactory = () => GetHttpClient(url, customUserAgent),
             MinimumSizeOfChunking = 1024 * 1024L,
         };
-
-        if (requestCustomUserAgent is not null)
-            configuration.CustomHttpMessageHandlerFactory = () => new CustomUserAgentMessageHandler(requestCustomUserAgent);
-        else
-            configuration.CustomHttpClientFactory = () =>
-                NetworkService.GetClient(isCurseForgeUrl ? NetworkService.CurseForgeApi : NetworkService.Default);
 
         using var downloader = new DownloadService(configuration);
         using var cancelReg = cancellationToken.Register(() =>
@@ -216,63 +207,22 @@ public static class FileDownloader
         }
     }
 
-    private static bool IsCurseForgeUrl(string url)
+    private static HttpClient GetHttpClient(string url, string? customUserAgent)
     {
-        return Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
-            && IsCurseForgeHost(parsedUri.Host);
-    }
-
-    private static bool IsCurseForgeHost(string host)
-    {
-        return host.Equals("edge.forgecdn.net", StringComparison.OrdinalIgnoreCase)
-            || host.Equals("mediafilez.forgecdn.net", StringComparison.OrdinalIgnoreCase)
-            || host.Equals("forgecdn.net", StringComparison.OrdinalIgnoreCase)
-            || host.Equals("api.curseforge.com", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private sealed class CustomUserAgentMessageHandler(string customUserAgent) : HttpMessageHandler
-    {
-        private readonly HttpClient _client = NetworkService.GetClient();
-
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsedUri)
+            && parsedUri.Host is "edge.forgecdn.net" or "mediafilez.forgecdn.net" or "forgecdn.net" or "api.curseforge.com")
         {
-            var forwardedRequest = CloneRequest(request);
-            forwardedRequest.Headers.Remove("User-Agent");
-            forwardedRequest.Headers.TryAddWithoutValidation("User-Agent", customUserAgent);
-
-            try
-            {
-                return await _client.SendAsync(forwardedRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch
-            {
-                forwardedRequest.Dispose();
-                throw;
-            }
+            return NetworkService.GetClient(NetworkService.CurseForgeApi);
         }
 
-        protected override void Dispose(bool disposing)
+        if (!string.IsNullOrWhiteSpace(customUserAgent))
         {
-            if (disposing)
-                _client.Dispose();
-
-            base.Dispose(disposing);
+            var client = NetworkService.GetClient();
+            client.DefaultRequestHeaders.Remove("User-Agent");
+            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", customUserAgent);
+            return client;
         }
-
-        private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
-        {
-            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
-            {
-                Version = request.Version,
-                VersionPolicy = request.VersionPolicy
-            };
-
-            foreach (var header in request.Headers)
-                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
-
-            return clone;
-        }
+        
+        return NetworkService.GetClient();
     }
-
 }

--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -214,14 +214,6 @@ public static class FileDownloader
         {
             return NetworkService.GetClient(NetworkService.CurseForgeApi);
         }
-
-        if (!string.IsNullOrWhiteSpace(customUserAgent))
-        {
-            var client = NetworkService.GetClient();
-            client.DefaultRequestHeaders.Remove("User-Agent");
-            client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", customUserAgent);
-            return client;
-        }
         
         return NetworkService.GetClient();
     }

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml
@@ -57,12 +57,6 @@
                             </local:MyTextBox.ValidateRules>
                         </local:MyTextBox>
 
-                        <TextBlock Grid.Column="0" Grid.Row="1"
-                                   Text="{DynamicResource Tools.Test.CustomDownload.UserAgent}" />
-                        <local:MyTextBox x:Name="TextUserAgent" Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
-                                         ValidatedTextChanged="TextUserAgent_OnValidatedTextChanged"
-                                         Margin="0,10" />
-
                         <TextBlock Grid.Column="0" Grid.Row="2"
                                    Text="{DynamicResource Tools.Test.CustomDownload.SaveTo}" />
                         <local:MyTextBox x:Name="TextDownloadFolder" Grid.Column="1" Grid.Row="2" Margin="0,10"

--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -54,7 +54,6 @@ public partial class PageToolsTest
 
         TextDownloadFolder.Validate();
         TextDownloadName.Validate();
-        TextUserAgent.Text = States.Tool.DownloadUserAgent;
     }
 
     private void StartButtonRefresh()
@@ -78,11 +77,6 @@ public partial class PageToolsTest
     {
         States.Tool.DownloadFolder = TextDownloadFolder.Text;
         TextDownloadName.Validate();
-    }
-
-    private void SaveCustomUserAgent(object sender, RoutedEventArgs e)
-    {
-        States.Tool.DownloadUserAgent = TextUserAgent.Text;
     }
 
     private static void DownloadState(ModLoader.LoaderCombo<int> loader)
@@ -352,7 +346,7 @@ public partial class PageToolsTest
 
     private void BtnDownloadStart_Click(object sender, MouseButtonEventArgs e)
     {
-        StartCustomDownload(TextDownloadUrl.Text, TextDownloadName.Text, TextDownloadFolder.Text, TextUserAgent.Text);
+        StartCustomDownload(TextDownloadUrl.Text, TextDownloadName.Text, TextDownloadFolder.Text);
         TextDownloadUrl.Text = "";
         TextDownloadUrl.Validate();
         TextDownloadUrl.ForceShowAsSuccess();
@@ -761,11 +755,4 @@ public partial class PageToolsTest
         SaveCacheDownloadFolder(sender, e);
         TextDownloadName_ValidateChanged(sender, e);
     }
-
-    private void TextUserAgent_OnValidatedTextChanged(object sender, RoutedEventArgs e)
-    {
-        SaveCustomUserAgent(sender, e);
-        TextDownloadFolder_ValidateChanged(sender, e);
-    }
-
 }


### PR DESCRIPTION
## Summary by Sourcery

集中管理用于下载的 HttpClient 选择，并根据目标主机应用针对 CurseForge 的特定配置，同时简化测试工具下载界面。

增强内容：
- 将针对 CurseForge 及相关 ForgeCDN 主机的下载请求通过专用的 HttpClient 配置进行路由，以支持 API 密钥的使用。
- 从工具测试页面中移除手动自定义 User-Agent 的处理，改为使用集中化的 HTTP 客户端配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize HttpClient selection for downloads and apply CurseForge-specific configuration based on target host while simplifying the test tools download UI.

Enhancements:
- Route downloads targeting CurseForge and related ForgeCDN hosts through a dedicated HttpClient configuration to support API key usage.
- Remove manual custom User-Agent handling from the tools test page in favor of centralized HTTP client configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集中管理用于下载的 HttpClient 选择，并根据目标主机应用针对 CurseForge 的特定配置，同时简化测试工具下载界面。

增强内容：
- 将针对 CurseForge 及相关 ForgeCDN 主机的下载请求通过专用的 HttpClient 配置进行路由，以支持 API 密钥的使用。
- 从工具测试页面中移除手动自定义 User-Agent 的处理，改为使用集中化的 HTTP 客户端配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize HttpClient selection for downloads and apply CurseForge-specific configuration based on target host while simplifying the test tools download UI.

Enhancements:
- Route downloads targeting CurseForge and related ForgeCDN hosts through a dedicated HttpClient configuration to support API key usage.
- Remove manual custom User-Agent handling from the tools test page in favor of centralized HTTP client configuration.

</details>

</details>
- 针对目标主机集中管理下载所用的 HttpClient 选择，以支持针对 CurseForge 的特定配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集中管理用于下载的 HttpClient 选择，并根据目标主机应用针对 CurseForge 的特定配置，同时简化测试工具下载界面。

增强内容：
- 将针对 CurseForge 及相关 ForgeCDN 主机的下载请求通过专用的 HttpClient 配置进行路由，以支持 API 密钥的使用。
- 从工具测试页面中移除手动自定义 User-Agent 的处理，改为使用集中化的 HTTP 客户端配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize HttpClient selection for downloads and apply CurseForge-specific configuration based on target host while simplifying the test tools download UI.

Enhancements:
- Route downloads targeting CurseForge and related ForgeCDN hosts through a dedicated HttpClient configuration to support API key usage.
- Remove manual custom User-Agent handling from the tools test page in favor of centralized HTTP client configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集中管理用于下载的 HttpClient 选择，并根据目标主机应用针对 CurseForge 的特定配置，同时简化测试工具下载界面。

增强内容：
- 将针对 CurseForge 及相关 ForgeCDN 主机的下载请求通过专用的 HttpClient 配置进行路由，以支持 API 密钥的使用。
- 从工具测试页面中移除手动自定义 User-Agent 的处理，改为使用集中化的 HTTP 客户端配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize HttpClient selection for downloads and apply CurseForge-specific configuration based on target host while simplifying the test tools download UI.

Enhancements:
- Route downloads targeting CurseForge and related ForgeCDN hosts through a dedicated HttpClient configuration to support API key usage.
- Remove manual custom User-Agent handling from the tools test page in favor of centralized HTTP client configuration.

</details>

</details>

</details>