### PR TITLE
fix(install): 修复若干 Mod 加载器的冲突关系不完整问题

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -626,9 +626,6 @@
     <!-- Download.Install.Compat -->
 
     <sys:String x:Key="Download.Install.Compat.CompatForgeSpecificOnly">Compatible only with certain Forge versions</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithCleanroom">Incompatible with Cleanroom</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithFabric">Incompatible with Fabric</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithForge">Incompatible with Forge</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithLiteLoader">Incompatible with LiteLoader</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithLoader">Incompatible with {0}</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithOptiFine">Incompatible with OptiFine</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -626,9 +626,6 @@
     <!-- Download.Install.Compat -->
 
     <sys:String x:Key="Download.Install.Compat.CompatForgeSpecificOnly">仅兼容特定版本的 Forge</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithCleanroom">与 Cleanroom 不兼容</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithFabric">与 Fabric 不兼容</sys:String>
-    <sys:String x:Key="Download.Install.Compat.IncompatibleWithForge">与 Forge 不兼容</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithLiteLoader">与 LiteLoader 不兼容</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithLoader">与 {0} 不兼容</sys:String>
     <sys:String x:Key="Download.Install.Compat.IncompatibleWithOptiFine">与 OptiFine 不兼容</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -1580,13 +1580,13 @@ public partial class PageDownloadInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Cleanroom"))
+        if (selectedLoaderName is not null && selectedLoaderName != "Cleanroom")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         // 检查 Loader
         if (GetLoaderError(LoadCleanroom) is not null)
-            return GetLoaderError(LoadNeoForge);
+            return GetLoaderError(LoadCleanroom);
         // 检查版本
         return ModDownload.dlCleanroomListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
             ? null

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -359,7 +359,7 @@ public partial class PageDownloadInstall
     private ModDownload.DlOptiFineListEntry? selectedOptiFine;
 
     /// <summary>
-    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Quilt / Cleanroom / LabyMod
+    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Quilt / Cleanroom / LabyMod / LegacyFabric
     /// </summary>
     private string? selectedLoaderName;
 
@@ -1159,21 +1159,18 @@ public partial class PageDownloadInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "Quilt" || selectedLoaderName == "LabyMod")
+        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "Quilt" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
             return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
-        // 是否有 Cleanroom
-        if (selectedCleanroom is not null)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithCleanroom");
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
         if (selectedLoaderName == "Forge" && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
-            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithForge");
+            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithFabric");
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Loader
         if (GetLoaderError(LoadOptiFine) is not null)
             return GetLoaderError(LoadOptiFine);
@@ -1197,7 +1194,7 @@ public partial class PageDownloadInstall
 
         if (hasRequiredVersion) return Lang.Text("Download.Install.Compat.CompatForgeSpecificOnly");
 
-        return Lang.Text("Download.Install.Compat.IncompatibleWithForge");
+        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
     }
 
     // 检查某个 OptiFine 是否与某个 Forge 兼容
@@ -1311,6 +1308,8 @@ public partial class PageDownloadInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
+        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LegacyFabric" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
             ? null
@@ -1583,6 +1582,8 @@ public partial class PageDownloadInstall
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
         if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Cleanroom"))
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (selectedLiteLoader is not null) 
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         // 检查 Loader
         if (GetLoaderError(LoadCleanroom) is not null)
             return GetLoaderError(LoadNeoForge);
@@ -2471,8 +2472,10 @@ public partial class PageDownloadInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "LabyMod"))
+        if (selectedLoaderName is not null && selectedLoaderName != "LabyMod")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (selectedLiteLoader is not null)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         foreach (JsonObject Version in ModDownload.dlLabyModListLoader.output.Value["production"]["minecraftVersions"].AsArray())
             if ((Version["version"].ToString() ?? "") == (_vanillaName ?? ""))
                 return null;

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -398,7 +398,7 @@ public partial class PageInstanceInstall
     private ModDownload.DlOptiFineListEntry? selectedOptiFine;
 
     /// <summary>
-    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Quilt / Cleanroom / LabyMod
+    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Quilt / Cleanroom / LabyMod / LegacyFabric
     /// </summary>
     private string? selectedLoaderName;
 
@@ -1438,21 +1438,18 @@ public partial class PageInstanceInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "Quilt" || selectedLoaderName == "LabyMod")
+        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "Quilt" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
-            return Lang.Text("Download.Install.State.GetVersionListFailed", ((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message);
-        // 是否有 Cleanroom
-        if (selectedCleanroom is not null)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithCleanroom");
+            return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
         if (selectedLoaderName == "Forge" && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
-            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithForge");
+            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithFabric");
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Loader
         if (GetLoaderError(LoadOptiFine) is not null)
             return GetLoaderError(LoadOptiFine);
@@ -1476,7 +1473,7 @@ public partial class PageInstanceInstall
 
         if (hasRequiredVersion) return Lang.Text("Download.Install.Compat.CompatForgeSpecificOnly");
 
-        return Lang.Text("Download.Install.Compat.IncompatibleWithForge");
+        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
     }
 
     // 检查某个 OptiFine 是否与某个 Forge 兼容
@@ -1590,6 +1587,8 @@ public partial class PageInstanceInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
+        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LegacyFabric" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
             ? null
@@ -1677,10 +1676,8 @@ public partial class PageInstanceInstall
         {
             if (Version.Category == "universal" || Version.Category == "client")
                 continue; // 跳过无法自动安装的版本
-            if (selectedNeoForge is not null)
-                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", "NeoForge");
-            if (selectedFabric is not null)
-                return Lang.Text("Download.Install.Compat.IncompatibleWithFabric");
+            if (selectedLoaderName is not null && selectedLoaderName != "Forge")
+                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
             if (selectedOptiFine is not null && McVersionComparer.CompareVersionGe(_vanillaName, "1.13") &&
                 McVersionComparer.CompareVersionGe("1.14.3", _vanillaName))
                 return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine"); // 1.13 ~ 1.14.3 OptiFine 检查
@@ -1864,6 +1861,8 @@ public partial class PageInstanceInstall
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
         if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Cleanroom"))
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (selectedLiteLoader is not null) 
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         // 检查 Loader
         if (GetLoaderError(LoadCleanroom) is not null)
             return GetLoaderError(LoadCleanroom);
@@ -2790,8 +2789,10 @@ public partial class PageInstanceInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "LabyMod"))
+        if (selectedLoaderName is not null && selectedLoaderName != "LabyMod")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (selectedLiteLoader is not null)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         foreach (JsonObject Version in ModDownload.dlLabyModListLoader.output.Value["production"]["minecraftVersions"].AsArray())
             if ((Version["version"].ToString() ?? "") == (_vanillaName ?? ""))
                 return null;

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1859,7 +1859,7 @@ public partial class PageInstanceInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Cleanroom"))
+        if (selectedLoaderName is not null && selectedLoaderName != "Cleanroom")
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");


### PR DESCRIPTION
应该 Resolved #2797 

顺便简化了本地化词条

## Summary by Sourcery

统一并修正多个安装器中的模组加载器兼容性检查，以在各安装流程中一致地阻止不兼容的加载器组合，并让面向用户的提示信息与新的术语保持一致。

Bug 修复：
- 修复在安装和下载流程中，对 OptiFine、Forge、Fabric、NeoForge、LiteLoader、Cleanroom、LabyMod、Quilt 和 LegacyFabric 之间不完整或不正确的不兼容性检测问题。
- 修正 Cleanroom 和 LabyMod 安装器检查，以正确拒绝存在冲突的选择，并返回正确的加载器错误来源。

增强：
- 将多条具体的不兼容提示统一为共享的 `IncompatibleWithLoader` 本地化条目，并扩展“已选择加载器”跟踪范围以包括 LegacyFabric。

文档：
- 更新英文和中文本地化字符串，使其与简化后的不兼容提示和加载器术语保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and correct mod loader compatibility checks for various installers to consistently block incompatible loader combinations and align user-facing messages with the new terminology.

Bug Fixes:
- Fix incomplete or incorrect incompatibility detection between OptiFine, Forge, Fabric, NeoForge, LiteLoader, Cleanroom, LabyMod, Quilt, and LegacyFabric across install and download flows.
- Correct Cleanroom and LabyMod installer checks to properly reject conflicting selections and return the correct loader error source.

Enhancements:
- Generalize multiple specific incompatibility messages into a shared IncompatibleWithLoader localization entry and extend selected loader tracking to include LegacyFabric.

Documentation:
- Update English and Chinese localization strings to match the simplified incompatibility messages and loader terminology.

</details>

Bug 修复：
- 修正对 OptiFine、Forge、Fabric、LiteLoader、Cleanroom、NeoForge、LabyMod 和 LegacyFabric 的不兼容检测，使所有冲突的加载器组合都能被一致地拦截。
- 修复 LiteLoader 与其他加载器（如 Cleanroom 和 LabyMod）之间冲突检查不正确或不完整的问题。

增强：
- 通过使用通用的 `IncompatibleWithLoader` 本地化条目，统一并简化加载器不兼容提示信息。
- 将已选加载器名称的跟踪范围扩展到 LegacyFabric，以改进兼容性处理与相关提示信息。

文档：
- 更新本地化文本，使其与新的、简化后的加载器不兼容提示及术语保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一并修正多个安装器中的模组加载器兼容性检查，以在各安装流程中一致地阻止不兼容的加载器组合，并让面向用户的提示信息与新的术语保持一致。

Bug 修复：
- 修复在安装和下载流程中，对 OptiFine、Forge、Fabric、NeoForge、LiteLoader、Cleanroom、LabyMod、Quilt 和 LegacyFabric 之间不完整或不正确的不兼容性检测问题。
- 修正 Cleanroom 和 LabyMod 安装器检查，以正确拒绝存在冲突的选择，并返回正确的加载器错误来源。

增强：
- 将多条具体的不兼容提示统一为共享的 `IncompatibleWithLoader` 本地化条目，并扩展“已选择加载器”跟踪范围以包括 LegacyFabric。

文档：
- 更新英文和中文本地化字符串，使其与简化后的不兼容提示和加载器术语保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and correct mod loader compatibility checks for various installers to consistently block incompatible loader combinations and align user-facing messages with the new terminology.

Bug Fixes:
- Fix incomplete or incorrect incompatibility detection between OptiFine, Forge, Fabric, NeoForge, LiteLoader, Cleanroom, LabyMod, Quilt, and LegacyFabric across install and download flows.
- Correct Cleanroom and LabyMod installer checks to properly reject conflicting selections and return the correct loader error source.

Enhancements:
- Generalize multiple specific incompatibility messages into a shared IncompatibleWithLoader localization entry and extend selected loader tracking to include LegacyFabric.

Documentation:
- Update English and Chinese localization strings to match the simplified incompatibility messages and loader terminology.

</details>

</details>