### PR TITLE
feat(link): 更新 EasyTier 到 2.6.4

### DIFF
--- a/PCL.Core/Link/Scaffolding/EasyTier/EasyTierMetadata.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/EasyTierMetadata.cs
@@ -6,7 +6,7 @@ namespace PCL.Core.Link.Scaffolding.EasyTier;
 
 public static class EasyTierMetadata
 {
-    public const string CurrentEasyTierVer = "2.5.0";
+    public const string CurrentEasyTierVer = "2.6.4";
 
     public static string EasyTierFilePath => Path.Combine(Paths.SharedLocalData, "EasyTier",
         CurrentEasyTierVer,


### PR DESCRIPTION
EasyTier 近期（并不）的更新新增了 UPnP 支持，并改进了连接稳定性，降低了 QUIC 内存占用，非常值得更新

## Summary by Sourcery

新功能：
- 启用 EasyTier 2.6.4，其中包含上游改进，例如对 UPnP 的支持以及增强的连接稳定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Enable use of EasyTier 2.6.4, which includes upstream improvements like UPnP support and enhanced connection stability.

</details>