### PR TITLE
fix(comp): 自动下载前置模组时文件名遵守“文件名格式”设置 

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -203,8 +203,11 @@ public static class ModCompDependency
                 continue;
             }
 
-            var targetPath = Path.Combine(targetModsFolder ?? string.Empty, ModComp.CompFileNameGet(depProject, depCompFile));
-            downloads.Add((depCompFile.FileName, depCompFile.ToNetFile(targetPath)));
+            // 前置也走“文件名格式”设置（CompFileNameGet），并让返回的展示用文件名与实际落盘文件名一致，
+            // 否则下载完成弹窗会显示未格式化的原始文件名（issue #3283）。
+            var depFileName = ModComp.CompFileNameGet(depProject, depCompFile);
+            var targetPath = Path.Combine(targetModsFolder ?? string.Empty, depFileName);
+            downloads.Add((depFileName, depCompFile.ToNetFile(targetPath)));
         }
 
         return downloads;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -203,8 +203,6 @@ public static class ModCompDependency
                 continue;
             }
 
-            // 前置也走“文件名格式”设置（CompFileNameGet），并让返回的展示用文件名与实际落盘文件名一致，
-            // 否则下载完成弹窗会显示未格式化的原始文件名（issue #3283）。
             var depFileName = ModComp.CompFileNameGet(depProject, depCompFile);
             var targetPath = Path.Combine(targetModsFolder ?? string.Empty, depFileName);
             downloads.Add((depFileName, depCompFile.ToNetFile(targetPath)));


### PR DESCRIPTION
BuildDependencyDownloads 中，前置的落盘路径已用 CompFileNameGet（应用“设置->管理->社区资源获取行为->文件名格式”），但返回给调用方用于下载完成弹窗的展示文件名却是原始的 depCompFile.FileName，导致弹窗显示未格式化（无汉化名）的文件名，与实际落盘文件名不一致。改为提取 depFileName = CompFileNameGet(...)，落盘路径与展示名统一使用它。

resolves #3283 
本PR的提交信息生成由Claude Code Opus 4.8辅助完成，由Opus 4.8对代码进行了审查。