### PR TITLE
fix(setup): 关于页非中国区隐藏 MC 百科时一并收起行高，消除空隙

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml
@@ -107,7 +107,7 @@
                 <Grid Margin="21,40,21,16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="45" />
-                        <RowDefinition Height="45" />
+                        <RowDefinition x:Name="RowMcmod" Height="45" />
                         <RowDefinition Height="45" />
                         <RowDefinition Height="45" />
                         <RowDefinition Height="45" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -42,7 +42,7 @@ public partial class PageSetupAbout
             ItemMcmod.Visibility = Visibility.Collapsed;
             BtnMcmod.Visibility = Visibility.Collapsed;
             ImgMcmod.Visibility = Visibility.Collapsed;
-            // 同时收起该行固定行高，否则元素隐藏后该行仍占 45px、留下空隙（issue #3313）
+            // 同时收起该行固定行高，否则元素隐藏后该行仍占 45px、留下空隙
             RowMcmod.Height = new GridLength(0);
         }
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -42,7 +42,6 @@ public partial class PageSetupAbout
             ItemMcmod.Visibility = Visibility.Collapsed;
             BtnMcmod.Visibility = Visibility.Collapsed;
             ImgMcmod.Visibility = Visibility.Collapsed;
-            // 同时收起该行固定行高，否则元素隐藏后该行仍占 45px、留下空隙
             RowMcmod.Height = new GridLength(0);
         }
 

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupAbout.xaml.cs
@@ -42,6 +42,8 @@ public partial class PageSetupAbout
             ItemMcmod.Visibility = Visibility.Collapsed;
             BtnMcmod.Visibility = Visibility.Collapsed;
             ImgMcmod.Visibility = Visibility.Collapsed;
+            // 同时收起该行固定行高，否则元素隐藏后该行仍占 45px、留下空隙（issue #3313）
+            RowMcmod.Height = new GridLength(0);
         }
 
         LoadContributersAsync();


### PR DESCRIPTION
“特别鸣谢”卡片的 Grid 使用固定 45px 行高。区域格式非“中文（中国）”时虽已 collapseMC 百科的列表项/按钮/图标，但其所在行的固定行高仍保留，留下 45px 空隙。为该行命名RowMcmod，并在隐藏时将其 Height 置为 0，使空隙一并收起。

resolves #3313 

本PR由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 当在非中国大陆地区格式中隐藏 MC 百科部分时，折叠其固定高度的网格行，以消除剩余的 45px 空白。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Collapse the fixed-height grid row for the MC 百科 section when it is hidden in non-mainland Chinese regional formats to eliminate the remaining 45px empty space.

</details>