### PR TITLE
chore: 调整 `成功提取资源包图标` 的日志级别

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -1621,7 +1621,7 @@ public static class ModLocalComp
                             ModBase.WriteFile(Logo, entryStream);
                         }
 
-                        ModBase.Log("成功提取资源包图标：" + path, ModBase.LogLevel.Debug);
+                        ModBase.Log("成功提取资源包图标：" + path, ModBase.LogLevel.Developer);
                     }
                     catch (Exception logoEx)
                     {


### PR DESCRIPTION
## Summary by Sourcery

将成功提取资源包图标时的日志级别，从 Debug 调整为 Developer。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the log level for successful resource pack icon extraction to use the Developer level instead of Debug.

</details>