### PR TITLE
fix(link): EasyTier 在部分情况下不会被正确关闭

### DIFF
--- a/PCL.Core/Link/Lobby/LobbyController.cs
+++ b/PCL.Core/Link/Lobby/LobbyController.cs
@@ -14,6 +14,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using PCL.Core.IO.Net;
 using static PCL.Core.Link.Lobby.LobbyInfoProvider;
@@ -50,7 +51,7 @@ public sealed class LobbyController
     /// <param name="username">Join user name.</param>
     /// <param name="code">Lobby share code.</param>
     /// <returns>Created <see cref="ScaffoldingClientEntity"/>.</returns>
-    public async Task<ScaffoldingClientEntity?> LaunchClientAsync(string username, string code)
+    public async Task<ScaffoldingClientEntity?> LaunchClientAsync(string username, string code, CancellationToken ct = default)
     {
         if (!await _SendTelemetryAsync(false).ConfigureAwait(false))
         {
@@ -60,7 +61,7 @@ public sealed class LobbyController
         try
         {
             var scfEntity = await ScaffoldingFactory
-                .CreateClientAsync(username, code, LobbyType.Scaffolding).ConfigureAwait(false);
+                .CreateClientAsync(username, code, LobbyType.Scaffolding, ct).ConfigureAwait(false);
 
             ScfClientEntity = scfEntity;
 
@@ -118,6 +119,10 @@ public sealed class LobbyController
                 LogWrapper.Error(e, "在加入大厅时出现意外的无效参数");
             }
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             LogWrapper.Error(e, "在加入大厅时发生意外错误");
@@ -146,6 +151,7 @@ public sealed class LobbyController
         {
             var scfEntity = ScaffoldingFactory.CreateServer(port, username);
             ScfServerEntity = scfEntity;
+            IsHost = true;
 
             LogWrapper.Info("LobbyController", "Successfully to launch Scaffolding Server.");
 
@@ -181,16 +187,22 @@ public sealed class LobbyController
     {
         McForward?.Stop();
         McBroadcast?.Stop();
-        if (ScfClientEntity is not null)
+        try
         {
-            await ScfClientEntity.EasyTier.StopAsync().ConfigureAwait(false);
-            await ScfClientEntity.Client.DisposeAsync().ConfigureAwait(false);
-            ScfClientEntity = null;
+            if (ScfClientEntity is not null)
+            {
+                await ScfClientEntity.EasyTier.StopAsync().ConfigureAwait(false);
+                await ScfClientEntity.Client.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (ScfServerEntity is not null)
+            {
+                await ScfServerEntity.EasyTier.StopAsync().ConfigureAwait(false);
+                await ScfServerEntity.Server.DisposeAsync().ConfigureAwait(false);
+            }
         }
-        else if (ScfServerEntity is not null)
+        finally
         {
-            await ScfServerEntity.EasyTier.StopAsync().ConfigureAwait(false);
-            await ScfServerEntity.Server.DisposeAsync().ConfigureAwait(false);
+            ScfClientEntity = null;
             ScfServerEntity = null;
         }
         return 0;

--- a/PCL.Core/Link/Lobby/LobbyService.cs
+++ b/PCL.Core/Link/Lobby/LobbyService.cs
@@ -37,6 +37,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
         new(_CheckGameState, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15));
 
     private static bool _isGameWatcherRunnable = false;
+    private static int _isLeaving;
 
     /// <summary>
     /// Current lobby state.
@@ -109,7 +110,8 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
     /// <inheritdoc />
     public override void Stop()
     {
-        _ = _LobbyController.CloseAsync();
+        _lobbyCts.Cancel();
+        _LobbyController.CloseAsync().GetAwaiter().GetResult();
         _ServerGameWatcher.Dispose();
         _lobbyCts.Dispose();
 
@@ -374,7 +376,7 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
             CurrentUserName = username;
             CurrentLobbyCode = lobbyCode;
 
-            var clientEntity = await _LobbyController.LaunchClientAsync(username, lobbyCode).ConfigureAwait(false);
+            var clientEntity = await _LobbyController.LaunchClientAsync(username, lobbyCode, _lobbyCts.Token).ConfigureAwait(false);
 
             if (clientEntity is null)
             {
@@ -395,6 +397,10 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
 
             return false;
         }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
         catch (Exception ex)
         {
             LogWrapper.Error(ex, "LobbyService", $"Failed to join lobby {lobbyCode}.");
@@ -410,8 +416,6 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
     private static void _ClientOnServerShutDown()
     {
         OnServerShutDown?.Invoke();
-
-        _ = LeaveLobbyAsync();
     }
 
     private static void _ClientOnHeartbeat(IReadOnlyList<PlayerProfile> players, long latency)
@@ -460,10 +464,13 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
     /// </summary>
     public static async Task LeaveLobbyAsync()
     {
-        _SetState(LobbyState.Leaving);
+        if (Interlocked.Exchange(ref _isLeaving, 1) == 1)
+            return;
 
         try
         {
+            _SetState(LobbyState.Leaving);
+
             await _lobbyCts.CancelAsync().ConfigureAwait(false);
 
             Players.Clear();
@@ -497,6 +504,10 @@ public class LobbyService() : GeneralService("lobby", "LobbyService")
         catch (Exception ex)
         {
             LogWrapper.Error(ex, "LobbyService", "Failed when leave lobby.");
+        }
+        finally
+        {
+            _isLeaving = 0;
         }
     }
 

--- a/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
@@ -311,13 +311,14 @@ public class EasyTierEntity
     /// Checks the status of EasyTier network until it is ready or time-out.
     /// </summary>
     /// <returns>Returns 0 when the network is ready, otherwise returns 1 for timeout.</returns>
-    public async Task<(bool, EtPlayerList?)> CheckEasyTierStatusAsync()
+    public async Task<(bool, EtPlayerList?)> CheckEasyTierStatusAsync(CancellationToken ct = default)
     {
         var retryCount = 0;
 
         while (_etProcess is null && retryCount < 10)
         {
-            await Task.Delay(1000).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(1000, ct).ConfigureAwait(false);
             retryCount++;
         }
 
@@ -327,13 +328,14 @@ public class EasyTierEntity
         }
 
         retryCount = 0;
-        while (State is not EtState.Ready && retryCount < 10)
+        while (State is not EtState.Ready && State is not EtState.Stopped && retryCount < 10)
         {
+            ct.ThrowIfCancellationRequested();
             var info = await _GetPlayersAsync().ConfigureAwait(false);
             if (info.Host is null)
             {
                 LogWrapper.Debug("EasyTierEntity", "Retry to get EasyTier Info.");
-                await Task.Delay(1000).ConfigureAwait(false);
+                await Task.Delay(1000, ct).ConfigureAwait(false);
                 retryCount++;
                 continue;
             }
@@ -347,7 +349,7 @@ public class EasyTierEntity
                 return (true, info);
             }
 
-            await Task.Delay(1000).ConfigureAwait(false);
+            await Task.Delay(1000, ct).ConfigureAwait(false);
             retryCount++;
         }
 

--- a/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
+++ b/PCL.Core/Link/Scaffolding/EasyTier/EasyTierEntity.cs
@@ -328,7 +328,7 @@ public class EasyTierEntity
         }
 
         retryCount = 0;
-        while (State is not EtState.Ready && State is not EtState.Stopped && retryCount < 10)
+        while (State is EtState.Active && retryCount < 300)
         {
             ct.ThrowIfCancellationRequested();
             var info = await _GetPlayersAsync().ConfigureAwait(false);

--- a/PCL.Core/Link/Scaffolding/ScaffoldingFactory.cs
+++ b/PCL.Core/Link/Scaffolding/ScaffoldingFactory.cs
@@ -5,6 +5,7 @@ using PCL.Core.Link.Scaffolding.Exceptions;
 using PCL.Core.Link.Scaffolding.Server;
 using PCL.Core.App;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using PCL.Core.IO.Net;
 
@@ -20,7 +21,7 @@ public static class ScaffoldingFactory
     /// <exception cref="FailedToGetPlayerException">Thrown if failed to get host player info.</exception>
     /// <exception cref="InvalidOperationException">Failed to get EasyTier Info.</exception>
     public static async Task<ScaffoldingClientEntity> CreateClientAsync
-        (string playerName, string lobbyCode, LobbyType from)
+        (string playerName, string lobbyCode, LobbyType from, CancellationToken ct = default)
     {
         var machineId = Utils.Secret.Identify.LauncherId;
 
@@ -32,37 +33,43 @@ public static class ScaffoldingFactory
         var etEntity = _CreateEasyTierEntity(info, 0, 0, false);
         etEntity.Launch();
 
-        var (etStatus, players) = await etEntity.CheckEasyTierStatusAsync().ConfigureAwait(false);
-
-        if (!etStatus || players is null)
+        try
         {
-            throw new InvalidOperationException("Failed to get EasyTier Info.");
+            var (etStatus, players) = await etEntity.CheckEasyTierStatusAsync(ct).ConfigureAwait(false);
+
+            if (!etStatus || players is null)
+            {
+                throw new InvalidOperationException("Failed to get EasyTier Info.");
+            }
+
+            if (players.Players is null)
+            {
+                throw new FailedToGetPlayerException();
+            }
+
+            var hostInfo = players.Host;
+
+            if (hostInfo is null)
+            {
+                throw new FailedToGetPlayerException("Can not get the host information.");
+            }
+
+            if (!int.TryParse(hostInfo.HostName[22..], out var scfPort))
+            {
+                throw new ArgumentException("Invalid hostname.", nameof(hostInfo));
+            }
+
+            var localPort = await etEntity.AddPortForwardAsync(hostInfo.Ip, scfPort).ConfigureAwait(false);
+
+            var client = new ScaffoldingClient("127.0.0.1", localPort, playerName, machineId, _LobbyVendor);
+
+            return new ScaffoldingClientEntity(client, etEntity, hostInfo);
         }
-
-        if (players.Players is null)
-        {
-            throw new FailedToGetPlayerException();
-        }
-
-        var hostInfo = players.Host;
-
-        if (hostInfo is null)
+        catch
         {
             await etEntity.StopAsync().ConfigureAwait(false);
-            throw new FailedToGetPlayerException("Can not get the host information.");
+            throw;
         }
-
-        if (!int.TryParse(hostInfo.HostName[22..], out var scfPort))
-        {
-            await etEntity.StopAsync().ConfigureAwait(false);
-            throw new ArgumentException("Invalid hostname.", nameof(hostInfo));
-        }
-
-        var localPort = await etEntity.AddPortForwardAsync(hostInfo.Ip, scfPort).ConfigureAwait(false);
-
-        var client = new ScaffoldingClient("127.0.0.1", localPort, playerName, machineId, _LobbyVendor);
-
-        return new ScaffoldingClientEntity(client, etEntity, hostInfo);
     }
 
     /// <summary>


### PR DESCRIPTION
> Generated by DeepSeek v4 Pro / max thinking

## Summary by Sourcery

确保基于 EasyTier 的大厅客户端和服务器能够被正确取消与关闭，并让加入/离开大厅的流程在面对取消操作和并发退出时更加可靠。

Bug Fixes:
- 保证在客户端创建失败或关闭大厅客户端/服务器实体时，EasyTier 进程会被停止并释放资源。
- 通过串行化 `LeaveLobbyAsync` 调用，防止重复或重叠的大厅离开操作。
- 通过从心跳处理器中移除自动离开调用，避免在服务器关闭时意外离开大厅。

Enhancements:
- 在大厅客户端创建过程和 EasyTier 就绪检查中向下传递取消令牌，以便在服务停止时实现协作式关停。
- 在服务停止期间同步等待大厅关闭，确保资源被完全释放。
- 在大厅服务器启动时跟踪主机状态，以便更清晰地管理控制器状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure EasyTier-based lobby clients and servers are correctly cancelled and shut down, and make lobby join/leave flows more robust against cancellation and concurrent exits.

Bug Fixes:
- Guarantee EasyTier processes are stopped and disposed when client creation fails or when closing lobby client/server entities.
- Prevent duplicate or overlapping lobby leave operations by serializing LeaveLobbyAsync calls.
- Avoid leaving lobbies unexpectedly on server shutdown by removing the automatic leave call from the heartbeat handler.

Enhancements:
- Propagate cancellation tokens through lobby client creation and EasyTier readiness checks to allow cooperative shutdown on service stop.
- Synchronously await lobby closure during service stop to ensure resources are fully released.
- Track host state on lobby server launch for clearer controller state management.

</details>