### PR TITLE
feat(profile): 档案列表为空时提示用户需要先创建一个正版档案才能使用其他验证类型

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1552,6 +1552,7 @@
     <sys:String x:Key="Launch.Account.Profile.Create">New profile</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Create.SelectAuthType.Title">New profile - Select login type</sys:String>
     <sys:String x:Key="Launch.Account.Profile.CreateAndSelectHint">Create and select a profile before launching the game</sys:String>
+    <sys:String x:Key="Launch.Account.Profile.RequireMicrosoftHint">A Microsoft profile is required to create profiles using other login types</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Created">Profile created!</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Delete">Delete profile</sys:String>
     <sys:String x:Key="Launch.Account.Profile.DeleteConfirm.Message">You are about to delete this profile. This action cannot be undone.&#xA;Are you sure you want to continue?</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1552,6 +1552,7 @@
     <sys:String x:Key="Launch.Account.Profile.Create">新建档案</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Create.SelectAuthType.Title">新建档案 - 选择验证类型</sys:String>
     <sys:String x:Key="Launch.Account.Profile.CreateAndSelectHint">新建并选择一个档案以启动游戏</sys:String>
+    <sys:String x:Key="Launch.Account.Profile.RequireMicrosoftHint">需要先进行一次正版验证才能使用其他验证方式</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Created">档案新建成功！</sys:String>
     <sys:String x:Key="Launch.Account.Profile.Delete">删除档案</sys:String>
     <sys:String x:Key="Launch.Account.Profile.DeleteConfirm.Message">你正在选择删除此档案，该操作无法撤销。&#xA;确定继续？</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfile.xaml
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfile.xaml
@@ -10,6 +10,7 @@
 
     <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
         <RowDefinition Height="10" />
         <RowDefinition Height="*" />
         <RowDefinition Height="10" />
@@ -20,9 +21,11 @@
     <local:MyHint x:Name="HintSelect" Margin="0,10,0,0" Theme="Blue" Text="{DynamicResource Launch.Account.Profile.SelectHint}" Grid.Row="0" CanClose="True"
                    RelativeSetup="HintProfileSelect" />
     <local:MyHint x:Name="HintCreate" Margin="0,10,0,0" Theme="Blue" Text="{DynamicResource Launch.Account.Profile.CreateAndSelectHint}" Grid.Row="0"
-                  Visibility="Collapsed" />
+                   Visibility="Collapsed" />
+    <local:MyHint x:Name="HintMicrosoft" Margin="0,10,0,0" Theme="Yellow" Text="{DynamicResource Launch.Account.Profile.RequireMicrosoftHint}" Grid.Row="1"
+                   Visibility="Collapsed" />
 
-    <local:MyScrollViewer Grid.Row="2" MaxHeight="300" Margin="10,0,10,0">
+    <local:MyScrollViewer Grid.Row="3" MaxHeight="300" Margin="10,0,10,0">
         <!-- 世界需要 MVVM -->
         <ItemsControl ItemsSource="{Binding ProfileCollection}">
             <ItemsControl.ItemTemplate>
@@ -36,7 +39,7 @@
         </ItemsControl>
     </local:MyScrollViewer>
 
-    <local:MyCard Grid.Row="4" HorizontalAlignment="Center" x:Name="PanButtons" Opacity="10"
+    <local:MyCard Grid.Row="5" HorizontalAlignment="Center" x:Name="PanButtons" Opacity="10"
                   CornerRadius="5" Margin="0,0,4,0">
         <StackPanel Orientation="Horizontal" Margin="10,3,0,3">
             <local:MyIconButton Height="24" Margin="0,0.5,9,0" x:Name="BtnNew"

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfile.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginProfile.xaml.cs
@@ -43,8 +43,9 @@ public partial class PageLoginProfile
         ModProfile.GetProfile();
         try
         {
-            foreach (var Profile in ModProfile.profileList)
-                ProfileCollection.Add(new ProfileItem(Profile));
+            foreach (var p in ModProfile.profileList)
+                ProfileCollection.Add(new ProfileItem(p));
+            HintMicrosoft.Visibility = ModProfile.profileList.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
             ModBase.Log("[Profile] 档案列表刷新完成");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary by Sourcery

当配置文件列表为空时，显示一个面向用户的提示，说明在使用其他身份验证类型之前必须先创建一个有效的配置文件。

New Features:
- 在登录配置文件页面添加“空配置文件”提示，当不存在任何配置文件时该提示会显示。

Enhancements:
- 更新登录配置文件页面布局和本地化资源，以支持新的“空配置文件”提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Show a user-facing hint when the profile list is empty to indicate that a valid profile must be created before using other authentication types.

New Features:
- Add an empty-profile hint on the login profile page that becomes visible when no profiles exist.

Enhancements:
- Update the login profile page layout and localization resources to support the new empty-profile hint message.

</details>