### PR TITLE
fix: 以静态方法代替静态 Lambda 避免 WeakLanguageChanged.Add 参数校验失败

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadCompFavorites.xaml.cs
@@ -42,8 +42,9 @@ public partial class PageDownloadCompFavorites
         ComboTargetFav.SelectionChanged += ComboTargetFav_Selected;
         HintGetFail.MouseLeftButtonDown += HintGetFail_MouseLeftButtonDown;
         PanSearchBox.TextChanged += SearchRun;
-        WeakLanguageChanged.Add(this, static page => ModBase.RunInUi(page._RefreshCategoryTitles));
+        WeakLanguageChanged.Add(this, OnLanguageChanged); 
     }
+    private static void OnLanguageChanged(PageDownloadCompFavorites page) => ModBase.RunInUi(page._RefreshCategoryTitles);
 
     private ModComp.CompFavorites.FavData CurrentFavTarget
     {

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -23,7 +23,7 @@ public partial class PageDownloadInstall
         InitializeComponent();
         PanScroll = PanBack;
         LoadMinecraft.Text = Lang.Text("Download.Version.LoadingList");
-        WeakLanguageChanged.Add(this, static page => page._OnLanguageChanged());
+        WeakLanguageChanged.Add(this, OnLanguageChanged);
         BtnBack.Click += (_, _) => ExitSelectPage();
         CardOptiFine.Swap += (_, _) => ReloadSelected();
         LoadOptiFine.StateChanged += (_, _, _) => ReloadSelected();
@@ -91,6 +91,7 @@ public partial class PageDownloadInstall
         TextSelectName.KeyDown += TextSelectName_KeyDown;
         BtnStart.Click += (_, _) => BtnStart_Click();
     }
+    private static void OnLanguageChanged(PageDownloadInstall page) => page._OnLanguageChanged();
 
     private void LoaderInit()
     {

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchLeft.xaml.cs
@@ -48,7 +48,7 @@ public partial class PageLaunchLeft
     {
         InitializeComponent();
         Loaded += PageLaunchLeft_Loaded;
-        WeakLanguageChanged.Add(this, static page => ModBase.RunInUi(page.RefreshButtonsUI));
+        WeakLanguageChanged.Add(this, OnLanguageChanged);
         // Handles
         BtnInstance.Click += BtnInstance_Click;
         BtnLaunch.Click += BtnLaunch_Click;
@@ -58,6 +58,7 @@ public partial class PageLaunchLeft
         PanLaunchingInfo.SizeChanged += PanLaunchingInfo_SizeChangedW;
         PanLaunchingInfo.SizeChanged += PanLaunchingInfo_SizeChangedH;
     }
+    private static void OnLanguageChanged(PageLaunchLeft page) => ModBase.RunInUi(page.RefreshButtonsUI);
 
     public void PageLaunchLeft_Loaded(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
给 #3306 擦屁股

## Summary by Sourcery

错误修复：
- 修复由于使用内联静态 lambda 而不是兼容的处理程序导致的 `WeakLanguageChanged.Add` 参数验证失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix WeakLanguageChanged.Add parameter validation failures caused by using inline static lambdas instead of compatible handlers.

</details>