### PR TITLE
fix(tooltip): 实现 Popup 鼠标事件穿透

### DIFF
--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
@@ -76,6 +77,7 @@ public static class Tooltip
     private static Storyboard? _openStory;
     private static Storyboard? _closeStory;
     private static DispatcherTimer? _latch;
+    private static HwndSourceHook? _transparentHook;
 
     private static readonly MouseEventHandler _OnEnterHandler = OnEnter;
     private static readonly MouseEventHandler _OnMoveHandler = OnMove;
@@ -209,8 +211,11 @@ public static class Tooltip
     {
         if (!_running || s is not FrameworkElement fe || !ReferenceEquals(fe, _target)) return;
 
-        if (!fe.IsEnabled && ToolTipService.GetShowOnDisabled(fe) && _PointInside(fe, Mouse.GetPosition(fe)))
+        if (_PointInside(fe, Mouse.GetPosition(fe)))
+        {
+            e.Handled = true;
             return;
+        }
 
         var next = _SeekOwner(_Over());
         if (next is not null && !ReferenceEquals(next, _target))
@@ -471,6 +476,30 @@ public static class Tooltip
             Placement = PlacementMode.Relative,
             Child = wrap
         };
+
+        // 预创建 HWND 并挂载鼠标穿透钩子，Popup 不接收任何鼠标消息，全部透传到下层窗口
+        const int WM_NCHITTEST = 0x0084;
+        const int HTTRANSPARENT = -1;
+        _transparentHook = (_, msg, _, _, ref handled) =>
+        {
+            if (msg == WM_NCHITTEST)
+            {
+                handled = true;
+                return HTTRANSPARENT;
+            }
+            return IntPtr.Zero;
+        };
+        _flyout.IsOpen = true;
+        _AttachTransparentHook();
+        _flyout.IsOpen = false;
+        _flyout.Opened += (_, _) => _AttachTransparentHook();
+    }
+
+    private static void _AttachTransparentHook()
+    {
+        if (_transparentHook is null || _flyout?.Child is not UIElement child) return;
+        var src = (HwndSource?)PresentationSource.FromVisual(child);
+        src?.AddHook(_transparentHook);
     }
 
     private static void _RenderInside(FrameworkElement owner)


### PR DESCRIPTION
> Generated by Deepseek-v4-pro

## Summary by Sourcery

确保 tooltip 弹出窗口对鼠标完全透明，使底层控件能够接收所有鼠标输入。

Bug 修复：
- 通过将命中测试转发到底层窗口，防止 tooltip 弹出框拦截鼠标事件。
- 通过在控件边界内正确处理鼠标离开事件，避免在悬停于禁用控件时丢失 tooltip 行为。

增强：
- 预先创建 tooltip 弹出窗口的 HWND，并附加全局透明钩子，以在多次打开过程中始终应用鼠标事件透传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure tooltip popup windows are fully mouse-transparent so underlying controls receive all mouse input.

Bug Fixes:
- Prevent tooltip popup from intercepting mouse events by forwarding hit tests to underlying window.
- Avoid losing tooltip behaviour when hovering disabled controls by correctly handling mouse leave inside the control boundary.

Enhancements:
- Pre-create the tooltip popup HWND and attach a global transparency hook to consistently apply mouse event passthrough across openings.

</details>