### PR TITLE
fix(tooltip): 切换控件时关闭弹窗再重开以重新定位到新位置

### DIFF
--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -380,7 +380,11 @@ public static class Tooltip
             var sb = _closeStory!.Clone();
             sb.Completed += (_, _) =>
             {
-                if (mark == _gen) _PopUp(target, pt);
+                if (mark == _gen)
+                {
+                    _flyout.IsOpen = false;
+                    _PopUp(target, pt);
+                }
                 sb.Remove(_shell!);
             };
             _shell!.BeginStoryboard(sb);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保在切换目标时关闭并重新打开工具提示弹出窗口，以便其能够正确重新定位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure tooltip flyout is closed and reopened when switching targets so it repositions correctly.

</details>