### PR TITLE
fix(select-left): 移除多余的 ToolTip 偏移量

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.cs
@@ -229,8 +229,6 @@ public partial class PageSelectLeft : IRefreshable
                     SvgIcon = "lucide/folder-plus"
                 };
                 ToolTipService.SetPlacement(itemCreate, PlacementMode.Right);
-                ToolTipService.SetHorizontalOffset(itemCreate, -50);
-                ToolTipService.SetVerticalOffset(itemCreate, 2.5);
                 itemCreate.Click += (_, _) => ModMain.frmSelectLeft.Create_Click();
                 ModMain.frmSelectLeft.PanList.Children.Add(itemCreate);
             }
@@ -246,8 +244,6 @@ public partial class PageSelectLeft : IRefreshable
                 SvgIcon = "lucide/folder-input"
             };
             ToolTipService.SetPlacement(itemAdd, PlacementMode.Right);
-            ToolTipService.SetHorizontalOffset(itemAdd, -50);
-            ToolTipService.SetVerticalOffset(itemAdd, 2.5);
             itemAdd.Click += (_, _) => ModMain.frmSelectLeft.Add_Click();
             ModMain.frmSelectLeft.PanList.Children.Add(itemAdd);
 
@@ -262,8 +258,6 @@ public partial class PageSelectLeft : IRefreshable
                 SvgIcon = "lucide/package-plus"
             };
             ToolTipService.SetPlacement(itemInstall, PlacementMode.Right);
-            ToolTipService.SetHorizontalOffset(itemInstall, -50);
-            ToolTipService.SetVerticalOffset(itemInstall, 2.5);
             itemInstall.Click += (_, _) => ModModpack.ModpackInstall();
             ModMain.frmSelectLeft.PanList.Children.Add(itemInstall);
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 移除选择左侧菜单操作中不必要的水平和垂直工具提示偏移，以防止工具提示位置错位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary horizontal and vertical tooltip offsets from select-left menu actions to prevent misaligned tooltips.

</details>