### PR TITLE
fix(config): 单个配置项损坏时重置为默认值而非致命崩溃

### DIFF
--- a/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
+++ b/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
@@ -101,7 +101,16 @@ public class FileConfigStorage : ConfigStorage
         {
             case StorageAction.Get:
                 if (!File.Exists(strKey)) return false;
-                value = File.Get<TValue>(strKey);
+                try
+                {
+                    value = File.Get<TValue>(strKey);
+                }
+                catch (Exception ex)
+                {
+                    LogWrapper.Warn(ex, "Config", $"配置项 {strKey} 读取失败（可能已损坏），重置为默认值");
+                    _writeActionChannel.Writer.TryWrite((strKey, () => File.Remove(strKey)));
+                    return false;
+                }
                 return true;
             case StorageAction.Exists:
                 // 由于 Exists 的 value 类型一定是 bool，此处可 unsafe 直接赋值

--- a/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
+++ b/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
@@ -108,7 +108,19 @@ public class FileConfigStorage : ConfigStorage
                 catch (Exception ex)
                 {
                     LogWrapper.Warn(ex, "Config", $"配置项 {strKey} 读取失败（可能已损坏），重置为默认值");
-                    _writeActionChannel.Writer.TryWrite((strKey, () => File.Remove(strKey)));
+                    if (!_writeActionChannel.Writer.TryWrite((strKey, () => File.Remove(strKey))))
+                    {
+                        LogWrapper.Warn("Config", $"配置项 {strKey} 清理任务入队失败，改为同步删除");
+                        try
+                        {
+                            File.Remove(strKey);
+                            File.Sync();
+                        }
+                        catch (Exception cleanupEx)
+                        {
+                            LogWrapper.Error(cleanupEx, "Config", $"配置项 {strKey} 同步删除失败，可能需人工处理");
+                        }
+                    }
                     return false;
                 }
                 return true;

--- a/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
+++ b/PCL.Core/App/Configuration/Storage/FileConfigStorage.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -105,7 +107,13 @@ public class FileConfigStorage : ConfigStorage
                 {
                     value = File.Get<TValue>(strKey);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is JsonException
+                                               or InvalidCastException
+                                               or FormatException
+                                               or OverflowException
+                                               or ArgumentException
+                                               or KeyNotFoundException
+                                               or InvalidDataException)
                 {
                     LogWrapper.Warn(ex, "Config", $"配置项 {strKey} 读取失败（可能已损坏），重置为默认值");
                     if (!_writeActionChannel.Writer.TryWrite((strKey, () => File.Remove(strKey))))

--- a/PCL.Core/App/Configuration/Storage/JsonFileProvider.cs
+++ b/PCL.Core/App/Configuration/Storage/JsonFileProvider.cs
@@ -79,7 +79,7 @@ public class JsonFileProvider : CommonFileProvider, IEnumerableKeyProvider
             Set(key, fallback);
             return fallback;
         }
-        Exception GetNullException() => new NullReferenceException($"Deserialized value is null: '{key}'");
+        Exception GetNullException() => new InvalidDataException($"Deserialized value is null: '{key}'");
     }
 
     public override void Set<T>(string key, T value)


### PR DESCRIPTION
某个配置项的值损坏为非法内容时，JsonFileProvider.Get<T> 会抛出 JsonException；因其不是ConfigFileInitException，ConfigService 会走到 Context.Fatal，导致每次启动都在读取该项 （如 ThemeConfigGroup.DarkColor）时崩溃、无法进入界面，且损坏项不会被重置（用户重置设置 也无效）。在 FileConfigStorage 的 Get 访问中兜住读取异常：记录警告、队列删除该损坏项以持久化 重置，并返回 false 回退到编码默认值，使启动可继续。整文件损坏的场景仍由 ConfigService 既有的 .failbackup/.bak 恢复逻辑处理。

resolves #3280 

本PR的提交信息生成由Claude Code Opus 4.8辅助生成，由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 通过将读取失败视为非致命错误并将该配置项重置为默认值，防止在读取单个损坏的配置条目时导致应用程序崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent application crashes when reading a single corrupted configuration entry by treating read failures as non-fatal and resetting the entry to its default value.

</details>