### PR TITLE
fix: 修复返回 VersionSaves 页面时同步子页面状态

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -1898,6 +1898,7 @@ public partial class FormMain
                         if (ModMain.frmInstanceSavesLeft is null)
                             ModMain.frmInstanceSavesLeft = new PageInstanceSavesLeft();
                         PageInstanceSavesLeft.currentSave = stack.additional.Value.SavePath;
+                        subType = ModMain.frmInstanceSavesLeft.pageID;
                         PageChangeAnim(ModMain.frmInstanceSavesLeft,
                             (FrameworkElement)ModMain.frmInstanceSavesLeft.PageGet(subType));
                         break;


### PR DESCRIPTION
close #3341

## Summary by Sourcery

错误修复：
- 修正返回到 `VersionSaves/InstanceSavesLeft` 视图时的子页面选择，使子页面与当前存档匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct child page selection when returning to the VersionSaves/InstanceSavesLeft view so the subpage matches the current save.

</details>