### PR TITLE
fix(instance-saves-datapack): 修复数据包下载路径错误

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -664,7 +664,9 @@ public partial class PageInstanceSavesDatapack : IRefreshable
     /// </summary>
     private void BtnManageDownload_Click(object sender, MouseButtonEventArgs e)
     {
-        PageDownloadCompDetail.cachedFolder[ModComp.CompType.DataPack] = Path.Combine(PageInstanceSavesLeft.currentSave, "datapacks");
+        var datapackPath = Path.Combine(PageInstanceSavesLeft.currentSave, "datapacks");
+        Directory.CreateDirectory(datapackPath);
+        PageDownloadCompDetail.cachedFolder[ModComp.CompType.DataPack] = datapackPath;
         ModMain.frmMain.PageChange(FormMain.PageType.Download, FormMain.PageSubType.DownloadDataPack);
         PageComp.targetVersion = PageInstanceLeft.McInstance; // 将当前实例设置为筛选器
     }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -664,6 +664,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
     /// </summary>
     private void BtnManageDownload_Click(object sender, MouseButtonEventArgs e)
     {
+        PageDownloadCompDetail.cachedFolder[ModComp.CompType.DataPack] = Path.Combine(PageInstanceSavesLeft.currentSave, "datapacks");
         ModMain.frmMain.PageChange(FormMain.PageType.Download, FormMain.PageSubType.DownloadDataPack);
         PageComp.targetVersion = PageInstanceLeft.McInstance; // 将当前实例设置为筛选器
     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 更正数据包下载的缓存文件夹路径，使其指向当前实例存档的 `datapacks` 目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the datapack download cached folder path to point to the current instance save’s datapacks directory.

</details>