### PR TITLE
fix(comp): CompFile 的集合字段初始化为空列表，避免 ToJson 空引用崩溃

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -2717,11 +2717,11 @@ public static class ModComp
         //  <summary>
         //  未经处理的支持的游戏版本列表。
         // </summary>
-        public readonly List<string> RawGameVersions;
+        public readonly List<string> RawGameVersions = new();
         /// <summary>
         ///     支持的游戏版本列表。类型包括："26.1.5"，"26.1"，"26.1 预览版"，"1.18.5"，"1.18"，"1.18 预览版"，"21w15a"，"未知版本"。
         /// </summary>
-        public readonly List<string> GameVersions;
+        public readonly List<string> GameVersions = new();
 
         /// <summary>
         ///     文件的 SHA1 或 MD5。
@@ -2736,7 +2736,7 @@ public static class ModComp
         /// <summary>
         ///     支持的 Mod 加载器列表。可能为空。
         /// </summary>
-        public readonly List<CompLoaderType> ModLoaders;
+        public readonly List<CompLoaderType> ModLoaders = new();
 
         /// <summary>
         ///     该文件的所有可选依赖工程的 Project.Id。


### PR DESCRIPTION
CompFile 的 ModLoaders / RawGameVersions / GameVersions 三个 readonly 集合字段声明处未初始化，而 CompFile(JsonObject) 构造函数仅在缓存 JSON 含对应键时才赋值（if ContainsKey）。
当数据缺失这些键时字段保持 null，随后 CompFile.ToJson() 对其调用 .Select() 便抛出ArgumentNullException(Parameter 'source')，表现为启用/禁用某些模组时启动器直接崩溃弹错误窗口；ToListItem 中的 GameVersions.All(...) 亦会因 null 崩溃。
为这三个字段声明补上 = new()，与 Dependencies 等其他集合字段一致，从源头保证非 null。

resolves #3058 

本PR的提交信息生成由Claude Code Opus 4.8辅助完成，由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 确保 `CompFile` 中的 `RawGameVersions`、`GameVersions` 和 `ModLoaders` 始终初始化为空列表，以避免在 JSON 序列化和进行列表操作时触发 `ArgumentNullException`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure RawGameVersions, GameVersions, and ModLoaders in CompFile are always initialized to empty lists to avoid ArgumentNullException during JSON serialization and list operations.

</details>