### PR TITLE
fix(tools): 自定义下载页加载时刷新按钮状态

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageTools/PageToolsTest.xaml.cs
@@ -54,6 +54,8 @@ public partial class PageToolsTest
 
         TextDownloadFolder.Validate();
         TextDownloadName.Validate();
+        TextDownloadUrl.Validate();
+        StartButtonRefresh();
     }
 
     private void StartButtonRefresh()


### PR DESCRIPTION
PageToolsTest 的 MeLoaded 在加载时将 BtnDownloadStart 置为禁用，但既未校验 TextDownloadUrl，也未调用真正计算按钮启用状态的 StartButtonRefresh，导致下载按钮初始一直灰色、需手动改动下载地址（触发 ValidatedTextChanged→StartButtonRefresh）才会恢复。
在 MeLoaded 末尾补上TextDownloadUrl.Validate() 与 StartButtonRefresh()，使按钮在加载时即按 URL/文件夹/文件名三项校验结果正确启用/禁用。

resolves #3350 

本PR的提交信息生成由Claude Code Opus 4.8生成，由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 确保在初始加载时，根据 URL、文件夹和文件名的校验结果正确启用或禁用下载按钮，而不是在 URL 字段被编辑之前一直保持禁用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the download button is correctly enabled or disabled on initial load based on URL, folder, and filename validation instead of remaining disabled until the URL field is edited.

</details>