### PR TITLE
fix(tooltip): 修复文字垂直居中和鼠标离开窗口时收起

### DIFF
--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -529,6 +529,7 @@ public static class Tooltip
                 Margin = _InnerPad,
                 FontSize = TipFontSize,
                 LineHeight = TipLineHeight,
+                LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
                 MaxWidth = tipW
             };
             tb.SetResourceReference(TextBlock.ForegroundProperty, "ColorBrush1");

--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -118,6 +118,15 @@ public static class Tooltip
             FrameworkElement.LoadedEvent, _OnComboLoadedHandler, true);
         EventManager.RegisterClassHandler(typeof(ComboBox),
             UIElement.PreviewMouseDownEvent, _OnComboMouseDownHandler, true);
+
+        EventManager.RegisterClassHandler(typeof(Window),
+            UIElement.MouseLeaveEvent, new MouseEventHandler(OnWindowLeave), true);
+    }
+
+    private static void OnWindowLeave(object s, MouseEventArgs e)
+    {
+        if (_target is not null)
+            _WindDown();
     }
 
     public static void Disable()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过在 tooltip 文本块上设置合适的行堆叠策略，修复 tooltip 文本的垂直对齐问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix tooltip text vertical alignment by setting an appropriate line stacking strategy on the tooltip text block.

</details>