### PR TITLE
imp: 使用 IEC 单位

### DIFF
--- a/PCL.Core/App/Essentials/StartupService.cs
+++ b/PCL.Core/App/Essentials/StartupService.cs
@@ -94,7 +94,7 @@ public sealed partial class StartupService
         info.Append("\n系统版本: ").Append(Environment.OSVersion.Version).Append(" (").Append(GetArchitectureName(RuntimeInformation.OSArchitecture)).Append(')');
         var memory = KernelInterop.GetPhysicalMemoryBytes();
         const int memoryDiv = 1024 * 1024;
-        info.Append("\n可用内存: ").Append(memory.Available / memoryDiv).Append('/').Append(memory.Total / memoryDiv).Append(" MB");
+        info.Append("\n可用内存: ").Append(memory.Available / memoryDiv).Append('/').Append(memory.Total / memoryDiv).Append(" MiB");
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         var cp = Encoding.GetEncoding(0);
         info.Append("\n默认代码页: ").Append(cp.EncodingName).Append(" (").Append(cp.CodePage).Append(')');

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -202,12 +202,12 @@
 
     <sys:String x:Key="Crash.Report.Environment.Cpu">CPU：{0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.EnvironmentSection">- Environment information -</sys:String>
-    <sys:String x:Key="Crash.Report.Environment.Gpu">GPU {0}: {1} ({2} MB, {3})</sys:String>
+    <sys:String x:Key="Crash.Report.Environment.Gpu">GPU {0}: {1} ({2} MiB, {3})</sys:String>
     <sys:String x:Key="Crash.Report.Environment.InstanceSection">- Instance information -</sys:String>
     <sys:String x:Key="Crash.Report.Environment.LauncherId">Identification code: {0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.LauncherVersion">PCL CE version: {0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.Log4j2NoLookups">Log4j2 NoLookups：{0}</sys:String>
-    <sys:String x:Key="Crash.Report.Environment.MemoryAllocation">Memory allocation (allocated memory / installed physical memory): {0} / {1} GB ({2} MB)</sys:String>
+    <sys:String x:Key="Crash.Report.Environment.MemoryAllocation">Memory allocation (allocated memory / installed physical memory): {0} / {1} GiB ({2} MiB)</sys:String>
     <sys:String x:Key="Crash.Report.Environment.MinecraftFolder">Minecraft folder: {0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.OperatingSystem">Operating system: {0} (64-bit: {1}, ARM64: {2})</sys:String>
     <sys:String x:Key="Crash.Report.Environment.ProfileName">Profile name: {0} (login method: {1})</sys:String>
@@ -1644,7 +1644,7 @@
     <sys:String x:Key="Launch.Skin.File.Error">Skin file error</sys:String>
     <sys:String x:Key="Launch.Skin.FileDialog.Filter">Skin file (*.png;*.jpg;*.webp)|*.png;*.jpg;*.webp</sys:String>
     <sys:String x:Key="Launch.Skin.FileDialog.Title">Select skin file</sys:String>
-    <sys:String x:Key="Launch.Skin.FileTooLarge">The skin file must be smaller than 24 KB. The selected file is {0} KB.</sys:String>
+    <sys:String x:Key="Launch.Skin.FileTooLarge">The skin file must be smaller than 24 KiB. The selected file is {0} KiB.</sys:String>
     <sys:String x:Key="Launch.Skin.InvalidSize">The skin image should be 64x32 pixels or 64x64 pixels!</sys:String>
     <sys:String x:Key="Launch.Skin.Load.Error.Avatar">Failed to load avatar: {0}</sys:String>
     <sys:String x:Key="Launch.Skin.Load.Error.Corrupted">Skin file is corrupted: {0}</sys:String>
@@ -2756,11 +2756,11 @@
 
     <sys:String x:Key="Setup.Launch.Memory.Auto">Auto</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Auto.ToolTip">Dynamically adjust the memory allocated to the game based on the installed mods and available system memory.</sys:String>
-    <sys:String x:Key="Setup.Launch.Memory.AvailableSuffix">Available: {0} GB</sys:String>
+    <sys:String x:Key="Setup.Launch.Memory.AvailableSuffix">Available: {0} GiB</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.GameAllocation">Game allocation</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Title">Game memory</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.UsedTotal">Used / installed memory</sys:String>
-    <sys:String x:Key="Setup.Launch.Memory.Warning.Java32Bit">32-bit Java can only allocate up to 1 GB of memory. It is strongly recommended to use 64-bit Java!</sys:String>
+    <sys:String x:Key="Setup.Launch.Memory.Warning.Java32Bit">32-bit Java can only allocate up to 1 GiB of memory. It is strongly recommended to use 64-bit Java!</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Warning.TooMuch">You have allocated too much memory to the game, which may cause crashes. It is recommended to use Auto first!</sys:String>
 
     <!-- Setup.Launch.Options -->

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -202,12 +202,12 @@
 
     <sys:String x:Key="Crash.Report.Environment.Cpu">CPU：{0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.EnvironmentSection">- 环境信息 -</sys:String>
-    <sys:String x:Key="Crash.Report.Environment.Gpu">显卡 {0}：{1} ({2} MB, {3})</sys:String>
+    <sys:String x:Key="Crash.Report.Environment.Gpu">显卡 {0}：{1} ({2} MiB, {3})</sys:String>
     <sys:String x:Key="Crash.Report.Environment.InstanceSection">- 实例信息 -</sys:String>
     <sys:String x:Key="Crash.Report.Environment.LauncherId">识别码：{0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.LauncherVersion">PCL CE 版本：{0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.Log4j2NoLookups">Log4j2 NoLookups：{0}</sys:String>
-    <sys:String x:Key="Crash.Report.Environment.MemoryAllocation">内存分配 (分配的内存 / 已安装物理内存)：{0} / {1} GB ({2} MB)</sys:String>
+    <sys:String x:Key="Crash.Report.Environment.MemoryAllocation">内存分配 (分配的内存 / 已安装物理内存)：{0} / {1} GiB ({2} MiB)</sys:String>
     <sys:String x:Key="Crash.Report.Environment.MinecraftFolder">MC 文件夹：{0}</sys:String>
     <sys:String x:Key="Crash.Report.Environment.OperatingSystem">操作系统：{0}（64 位：{1}, ARM64: {2}）</sys:String>
     <sys:String x:Key="Crash.Report.Environment.ProfileName">档案名称：{0} (验证方式：{1})</sys:String>
@@ -1644,7 +1644,7 @@
     <sys:String x:Key="Launch.Skin.File.Error">皮肤文件存在错误</sys:String>
     <sys:String x:Key="Launch.Skin.FileDialog.Filter">皮肤文件(*.png;*.jpg;*.webp)|*.png;*.jpg;*.webp</sys:String>
     <sys:String x:Key="Launch.Skin.FileDialog.Title">选择皮肤文件</sys:String>
-    <sys:String x:Key="Launch.Skin.FileTooLarge">皮肤文件大小需小于 24 KB，而所选文件大小为 {0} KB</sys:String>
+    <sys:String x:Key="Launch.Skin.FileTooLarge">皮肤文件大小需小于 24 KiB，而所选文件大小为 {0} KiB</sys:String>
     <sys:String x:Key="Launch.Skin.InvalidSize">皮肤图片大小应为 64x32 像素或 64x64 像素！</sys:String>
     <sys:String x:Key="Launch.Skin.Load.Error.Avatar">载入头像失败：{0}</sys:String>
     <sys:String x:Key="Launch.Skin.Load.Error.Corrupted">皮肤文件已损坏：{0}</sys:String>
@@ -2756,11 +2756,11 @@
 
     <sys:String x:Key="Setup.Launch.Memory.Auto">自动配置</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Auto.ToolTip">根据安装的模组量与电脑剩余内存，动态调整为游戏分配的内存</sys:String>
-    <sys:String x:Key="Setup.Launch.Memory.AvailableSuffix">可用 {0} GB</sys:String>
+    <sys:String x:Key="Setup.Launch.Memory.AvailableSuffix">可用 {0} GiB</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.GameAllocation">游戏分配</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Title">游戏内存</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.UsedTotal">已使用内存 / 已安装内存</sys:String>
-    <sys:String x:Key="Setup.Launch.Memory.Warning.Java32Bit">32 位 Java 只能分配最多 1 GB 的内存。强烈建议换用 64 位的 Java！</sys:String>
+    <sys:String x:Key="Setup.Launch.Memory.Warning.Java32Bit">32 位 Java 只能分配最多 1 GiB 的内存。强烈建议换用 64 位的 Java！</sys:String>
     <sys:String x:Key="Setup.Launch.Memory.Warning.TooMuch">你给游戏分配的内存过多，这可能引发游戏崩溃。建议优先考虑「自动分配」选项！</sys:String>
 
     <!-- Setup.Launch.Options -->

--- a/PCL.Core/IO/ByteStream.cs
+++ b/PCL.Core/IO/ByteStream.cs
@@ -6,7 +6,7 @@ namespace PCL.Core.IO;
 
 public class ByteStream(Stream stream)
 {
-    private static readonly string[] _Units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    private static readonly string[] _Units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
     public long Length => stream.Length;
 
     public string GetReadableLength()

--- a/PCL.Core/IO/Storage/Cache/CacheOptions.cs
+++ b/PCL.Core/IO/Storage/Cache/CacheOptions.cs
@@ -14,13 +14,13 @@ public record CacheOptions
     public required string FileCacheRoot { get; init; }
     /// <summary>
     /// Max physical cache size. When the total cache size exceeds this limit, the eviction process will be triggered to free up space.<br/>
-    /// <b>(Default: 2 GB)</b>
+    /// <b>(Default: 2 GiB)</b>
     /// </summary>
-    public long MaxCacheSize { get; init; } = 2L * 1024 * 1024 * 1024; // 2 GB
+    public long MaxCacheSize { get; init; } = 2L * 1024 * 1024 * 1024; // 2 GiB
     /// <summary>
     /// SQLite inline storage size limit. Cache entries smaller than or equal to this size will be stored directly in the SQLite database, while larger entries will be stored as file-mapped.<br/>
     /// </summary>
-    public int MaxInlineSize { get; init; } = 256 * 1024; // 256 KB
+    public int MaxInlineSize { get; init; } = 256 * 1024; // 256 KiB
     /// <summary>
     /// Background eviction interval. The cache will automatically check for expired entries and evict them at this interval.<br/>
     /// <b>(Default: 5 minutes)</b>
@@ -28,9 +28,9 @@ public record CacheOptions
     public TimeSpan EvictionInterval { get; init; } = TimeSpan.FromMinutes(5);
     /// <summary>
     /// Reserve bytes for the cache. This amount of space will always be reserved for the cache, even when eviction is triggered.<br/>
-    /// <b>(Default: 256 MB)</b>
+    /// <b>(Default: 256 MiB)</b>
     /// </summary>
-    public long ReserveBytes { get; init; } = 256L * 1024 * 1024; // 256 MB
+    public long ReserveBytes { get; init; } = 256L * 1024 * 1024; // 256 MiB
     /// <summary>
     /// Whether to enable compression for cache entries. (Enabled by default)<br/>
     /// </summary>

--- a/PCL.Core/IO/Storage/Cache/CachePolicy.cs
+++ b/PCL.Core/IO/Storage/Cache/CachePolicy.cs
@@ -31,7 +31,7 @@ public record CachePolicy
     public CachePriority Priority { get; init; } = CachePriority.Normal;
     /// <summary>
     /// Gets the storage mode for the cached item.<br/>
-    /// Auto &lt;= 256KB: Inline, &gt; 256KB: FileMapped
+    /// Auto &lt;= 256KiB: Inline, &gt; 256KiB: FileMapped
     /// </summary>
     public CacheStorageMode StorageMode { get; init; } = CacheStorageMode.Auto;
     /// <summary>

--- a/PCL.Core/Utils/OS/HardwareInfo.cs
+++ b/PCL.Core/Utils/OS/HardwareInfo.cs
@@ -20,7 +20,7 @@ public static class HardwareInfo
     public static IReadOnlyList<GPUInfo> GPUs { get; private set; } = [];
 
     /// <summary>
-    /// 已安装物理内存大小，单位 MB
+    /// 已安装物理内存大小，单位 MiB
     /// </summary>
     public static long SystemMemorySize = (long)KernelInterop.GetPhysicalMemoryBytes().Total / 1024 / 1024;
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml
@@ -178,12 +178,12 @@
                                    TextTrimming="None" Margin="2,0,0,5" FontSize="11" HorizontalAlignment="Left" />
                         <StackPanel Grid.Row="2" Orientation="Horizontal" Grid.ColumnSpan="3" Margin="2,3,0,0"
                                     HorizontalAlignment="Left">
-                            <TextBlock x:Name="LabRamUsed" Text="4.7 GB" FontSize="16"
+                            <TextBlock x:Name="LabRamUsed" Text="4.7 GiB" FontSize="16"
                                        Foreground="{DynamicResource ColorBrushMemory}" TextTrimming="None" />
-                            <TextBlock x:Name="LabRamTotal" Text=" / 7.9 GB" FontSize="16"
+                            <TextBlock x:Name="LabRamTotal" Text=" / 7.9 GiB" FontSize="16"
                                        Foreground="{DynamicResource ColorBrushMemory}" TextTrimming="None" />
                         </StackPanel>
-                        <TextBlock Grid.Row="2" x:Name="LabRamGame" Text="2.5 GB" Grid.ColumnSpan="3"
+                        <TextBlock Grid.Row="2" x:Name="LabRamGame" Text="2.5 GiB" Grid.ColumnSpan="3"
                                    TextTrimming="None" Margin="2,3,0,0" FontSize="16"
                                    Foreground="{DynamicResource ColorBrushMemory}" HorizontalAlignment="Left" />
                     </Grid>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.cs
@@ -277,9 +277,9 @@ public partial class PageInstanceSetup
         else
             SliderRamCustom.MaxValue = (int)Math.Round(Math.Floor((ramTotal - 16d) / 2d) + 33d);
         // 设置文本
-        LabRamGame.Text = $"{Lang.Number(ramGame, "N1")} GB{(ramGame != ramGameActual ? $" ({Lang.Text("Setup.Launch.Memory.AvailableSuffix", Lang.Number(ramGameActual, "N1"))})" : "")}";
-        LabRamUsed.Text = $"{Lang.Number(ramUsed, "N1")} GB";
-        LabRamTotal.Text = $" / {Lang.Number(ramTotal, "N1")} GB";
+        LabRamGame.Text = $"{Lang.Number(ramGame, "N1")} GiB{(ramGame != ramGameActual ? $" ({Lang.Text("Setup.Launch.Memory.AvailableSuffix", Lang.Number(ramGameActual, "N1"))})" : "")}";
+        LabRamUsed.Text = $"{Lang.Number(ramUsed, "N1")} GiB";
+        LabRamTotal.Text = $" / {Lang.Number(ramTotal, "N1")} GiB";
         LabRamWarn.Visibility =
             ramGame == 1d && !ModJava.IsGameSet64BitJava(PageInstanceLeft.McInstance) && !SystemInfo.Is32BitSystem &&
             ModJava.Javas.ExistAnyJava()

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -219,12 +219,12 @@
                                    TextTrimming="None" Margin="2,0,0,5" FontSize="11" HorizontalAlignment="Left" />
                         <StackPanel Grid.Row="2" Orientation="Horizontal" Grid.ColumnSpan="3" Margin="2,3,0,0"
                                     HorizontalAlignment="Left">
-                            <TextBlock x:Name="LabRamUsed" Text="4.7 GB" FontSize="16"
+                            <TextBlock x:Name="LabRamUsed" Text="4.7 GiB" FontSize="16"
                                        Foreground="{DynamicResource ColorBrushMemory}" TextTrimming="None" />
-                            <TextBlock x:Name="LabRamTotal" Text=" / 7.9 GB" FontSize="16"
+                            <TextBlock x:Name="LabRamTotal" Text=" / 7.9 GiB" FontSize="16"
                                        Foreground="{DynamicResource ColorBrushMemory}" TextTrimming="None" />
                         </StackPanel>
-                        <TextBlock Grid.Row="2" x:Name="LabRamGame" Text="2.5 GB" Grid.ColumnSpan="3"
+                        <TextBlock Grid.Row="2" x:Name="LabRamGame" Text="2.5 GiB" Grid.ColumnSpan="3"
                                    TextTrimming="None" Margin="2,3,0,0" FontSize="16"
                                    Foreground="{DynamicResource ColorBrushMemory}" HorizontalAlignment="Left" />
                     </Grid>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -238,9 +238,9 @@ public partial class PageSetupLaunch
         else
             SliderRamCustom.MaxValue = (int)Math.Round(Math.Floor((ramTotal - 16d) / 2d) + 33d);
         // 设置文本
-        LabRamGame.Text = $"{Lang.Number(ramGame, "N1")} GB{(ramGame != ramGameActual ? $" ({Lang.Text("Setup.Launch.Memory.AvailableSuffix", Lang.Number(ramGameActual, "N1"))})" : "")}";
-        LabRamUsed.Text = $"{Lang.Number(ramUsed, "N1")} GB";
-        LabRamTotal.Text = $" / {Lang.Number(ramTotal, "N1")} GB";
+        LabRamGame.Text = $"{Lang.Number(ramGame, "N1")} GiB{(ramGame != ramGameActual ? $" ({Lang.Text("Setup.Launch.Memory.AvailableSuffix", Lang.Number(ramGameActual, "N1"))})" : "")}";
+        LabRamUsed.Text = $"{Lang.Number(ramUsed, "N1")} GiB";
+        LabRamTotal.Text = $" / {Lang.Number(ramTotal, "N1")} GiB";
         LabRamWarn.Visibility =
             ramGame == 1d && !ModJava.IsGameSet64BitJava() && !SystemInfo.Is32BitSystem && ModJava.Javas.ExistAnyJava()
                 ? Visibility.Visible


### PR DESCRIPTION
Close #3367

## Summary by Sourcery

在缓存配置、硬件信息、字节大小格式化以及内存显示的 UI 文本中，统一采用 IEC 二进制单位（KiB、MiB、GiB 等）。

Enhancements:
- 将缓存选项默认值和缓存策略文档与 IEC 二进制大小单位对齐。
- 更新字节长度格式化逻辑，使用 IEC 单位后缀而非十进制单位。
- 在启动日志和设置页面中统一 RAM 和内存大小标签，以 MiB/GiB 显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt IEC binary units (KiB, MiB, GiB, etc.) consistently across cache configuration, hardware information, byte size formatting, and RAM display UI text.

Enhancements:
- Align cache option defaults and cache policy documentation with IEC binary size units.
- Update byte length formatting to use IEC unit suffixes instead of decimal units.
- Standardize RAM and memory size labels in startup logs and setup pages to display MiB/GiB.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在缓存配置、硬件信息、字节大小格式化以及内存显示的 UI 文本中，统一采用 IEC 二进制单位（KiB、MiB、GiB 等）。

Enhancements:
- 将缓存选项默认值和缓存策略文档与 IEC 二进制大小单位对齐。
- 更新字节长度格式化逻辑，使用 IEC 单位后缀而非十进制单位。
- 在启动日志和设置页面中统一 RAM 和内存大小标签，以 MiB/GiB 显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt IEC binary units (KiB, MiB, GiB, etc.) consistently across cache configuration, hardware information, byte size formatting, and RAM display UI text.

Enhancements:
- Align cache option defaults and cache policy documentation with IEC binary size units.
- Update byte length formatting to use IEC unit suffixes instead of decimal units.
- Standardize RAM and memory size labels in startup logs and setup pages to display MiB/GiB.

</details>

</details>