### PR TITLE
chore(bump): 2.15.0-beta.7

### DIFF
--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -3,8 +3,8 @@
   "version": {
     "base": "2.15.0",
     "upstream": "2.12.1",
-    "suffix": "beta.6",
-    "code": 520
+    "suffix": "beta.7",
+    "code": 521
   },
   "licenses": [
     {


### PR DESCRIPTION
## Summary by Sourcery

在 `metadata.json` 中将启动器元数据版本提升到 `2.15.0-beta.7`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump launcher metadata version to 2.15.0-beta.7 in metadata.json.

</details>