### PR TITLE
feat(homepage): 增删一些自定义主页预设

### DIFF
--- a/PCL.Core/App/Config.cs
+++ b/PCL.Core/App/Config.cs
@@ -375,7 +375,7 @@ public static partial class Config
             /// <summary>
             /// 预设选项。
             /// </summary>
-            [ConfigItem<int>("UiCustomPreset", 14, ConfigSource.Local)] public partial int SelectedPreset { get; set; }
+            [ConfigItem<int>("UiCustomPreset", 0, ConfigSource.Local)] public partial int SelectedPreset { get; set; }
 
             /// <summary>
             /// 自定义 URL。

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -3089,6 +3089,9 @@
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McOfficialFeed">Minecraft Official Feed</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McSkin">Minecraft Skin Recommendation (Author: wkea)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McUpdateSummary">Minecraft Update Summary (Author: pynickle, partially AI-generated)</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.NewsToday">News Today (Author: EYicheng)</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.MinecraftKnowledge">Minecraft Knowledge (Author: awaEric233)</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.ModpackRecommendation">Modpack Recommendation Engine (Author: CHMYGZ)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenBmclapi">OpenBMCLAPI Dashboard Lite (Authors: Silverteal, Mxmilu666)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenMcim">OpenMCIM Dashboard (Author: SALTWOOD)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.PclAnnouncement">PCL CE Announcements</sys:String>

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -1873,6 +1873,8 @@
     <sys:String x:Key="Main.UpdateLog.Empty">Welcome!</sys:String>
     <sys:String x:Key="Main.UpdateLog.FullChangelog">Full changelog</sys:String>
     <sys:String x:Key="Main.UpdateLog.Title">PCL CE has been updated to {0} {1}</sys:String>
+    <sys:String x:Key="Main.HomepageReset.Title">Homepage preset setting has been reset</sys:String>
+    <sys:String x:Key="Main.HomepageReset.Content">The homepage preset setting has been reset due to the launcher update.&#xA;Please go to Settings - Personalization and select the preset again.</sys:String>
 
     <!-- Main.FileDrag -->
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -3092,6 +3092,7 @@
     <sys:String x:Key="Setup.Ui.Homepage.Preset.NewsToday">News Today (Author: EYicheng)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.MinecraftKnowledge">Minecraft Knowledge (Author: awaEric233)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.ModpackRecommendation">Modpack Recommendation Engine (Author: CHMYGZ)</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.Bangumi">Bangumi Anime (Author: wzyaeu)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenBmclapi">OpenBMCLAPI Dashboard Lite (Authors: Silverteal, Mxmilu666)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenMcim">OpenMCIM Dashboard (Author: SALTWOOD)</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.PclAnnouncement">PCL CE Announcements</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -1873,6 +1873,8 @@
     <sys:String x:Key="Main.UpdateLog.Empty">欢迎使用呀~</sys:String>
     <sys:String x:Key="Main.UpdateLog.FullChangelog">完整更新日志</sys:String>
     <sys:String x:Key="Main.UpdateLog.Title">PCL CE 已更新至 {0} {1}</sys:String>
+    <sys:String x:Key="Main.HomepageReset.Title">主页预设已重置</sys:String>
+    <sys:String x:Key="Main.HomepageReset.Content">由于启动器更新，已重置主页预设。请重新前往 设置 - 个性化 选择预设</sys:String>
 
     <!-- Main.FileDrag -->
 

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -3092,6 +3092,7 @@
     <sys:String x:Key="Setup.Ui.Homepage.Preset.NewsToday">今日新闻热点（作者：EYicheng）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.MinecraftKnowledge">Minecraft 芝士站（作者：awaEric233）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.ModpackRecommendation">整合包推荐引擎（作者：CHMYGZ）</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.Bangumi">Bangumi 番剧主页（作者：wzyaeu）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenBmclapi">OpenBMCLAPI 仪表盘 Lite（作者：Silverteal、Mxmilu666）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenMcim">OpenMCIM 仪表盘（作者：SALTWOOD）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.PclAnnouncement">PCL CE 公告栏</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -3089,6 +3089,9 @@
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McOfficialFeed">Minecraft 官方信息流</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McSkin">Minecraft 皮肤推荐（作者：wkea）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.McUpdateSummary">Minecraft 更新摘要（作者：pynickle，部分由 AI 生成）</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.NewsToday">今日新闻热点（作者：EYicheng）</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.MinecraftKnowledge">Minecraft 芝士站（作者：awaEric233）</sys:String>
+    <sys:String x:Key="Setup.Ui.Homepage.Preset.ModpackRecommendation">整合包推荐引擎（作者：CHMYGZ）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenBmclapi">OpenBMCLAPI 仪表盘 Lite（作者：Silverteal、Mxmilu666）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.OpenMcim">OpenMCIM 仪表盘（作者：SALTWOOD）</sys:String>
     <sys:String x:Key="Setup.Ui.Homepage.Preset.PclAnnouncement">PCL CE 公告栏</sys:String>

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -345,6 +345,13 @@ public partial class FormMain
         if (lowerVersionCode >= ModBase.versionCode)
             return;
         ShowUpdateLog();
+        
+        // 重置自定义主页配置
+        if (lastVersionCode < 521 && Config.Preference.Homepage.SelectedPreset >= 3)
+        {
+            Config.Preference.Homepage.SelectedPreset = 0;
+            ModMain.MyMsgBox("由于版本更新，已重置主页预设，请重新前往 设置 - 个性化 选择预设", "主页预设已重置");
+        }
     }
 
     private void DowngradeSub(int lastVersionCode)

--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -350,7 +350,7 @@ public partial class FormMain
         if (lastVersionCode < 521 && Config.Preference.Homepage.SelectedPreset >= 3)
         {
             Config.Preference.Homepage.SelectedPreset = 0;
-            ModMain.MyMsgBox("由于版本更新，已重置主页预设，请重新前往 设置 - 个性化 选择预设", "主页预设已重置");
+            ModMain.MyMsgBox(Lang.Text("Main.HomepageReset.Content"), Lang.Text("Main.HomepageReset.Title"));
         }
     }
 

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -138,97 +138,103 @@ public partial class PageLaunchRight : IRefreshable
                     content = LoadFromNetwork(url);
                     break;
 
-                case 3:
-                    LogWrapper.Info("[Page] 主页预设：简单主页");
-                    url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/MFn233/Custom.xaml";
-                    content = LoadFromNetwork(url);
-                    break;
+                // case 3:
+                //     LogWrapper.Info("[Page] 主页预设：简单主页");
+                //     url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/MFn233/Custom.xaml";
+                //     content = LoadFromNetwork(url);
+                //     break;
 
-                case 4:
+                case 3:
                     LogWrapper.Info("[Page] 主页预设：每日整合包推荐");
                     url = "https://pclsub.sodamc.com/";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 5:
+                case 4:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 皮肤推荐");
                     url = "https://forgepixel.com/pcl_sub_file";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 6:
+                case 5:
                     LogWrapper.Info("[Page] 主页预设：OpenBMCLAPI 仪表盘 Lite");
                     url = "https://pcl-bmcl.milu.ink/";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 7:
-                    LogWrapper.Info("[Page] 主页预设：主页市场");
-                    url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/JingHai-Lingyun/Custom.xaml";
-                    content = LoadFromNetwork(url);
-                    break;
+                // case 7:
+                //     LogWrapper.Info("[Page] 主页预设：主页市场");
+                //     url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/JingHai-Lingyun/Custom.xaml";
+                //     content = LoadFromNetwork(url);
+                //     break;
 
-                case 8:
-                    LogWrapper.Info("[Page] 主页预设：更新日志");
-                    url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/Joker2184/UpdateHomepage.xaml";
-                    content = LoadFromNetwork(url);
-                    break;
+                // case 8:
+                //     LogWrapper.Info("[Page] 主页预设：更新日志");
+                //     url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/Joker2184/UpdateHomepage.xaml";
+                //     content = LoadFromNetwork(url);
+                //     break;
 
-                case 9:
+                case 6:
                     LogWrapper.Info("[Page] 主页预设：PCL 新功能说明书");
                     url = "https://raw.gitcode.com/WForst-Breeze/WhatsNewPCL/raw/main/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 10:
-                    LogWrapper.Info("[Page] 主页预设：OpenMCIM Dashboard");
-                    url = "https://files.mcimirror.top/PCL";
-                    content = LoadFromNetwork(url);
-                    break;
+                // case 10:
+                //     LogWrapper.Info("[Page] 主页预设：OpenMCIM Dashboard");
+                //     url = "https://files.mcimirror.top/PCL";
+                //     content = LoadFromNetwork(url);
+                //     break;
 
-                case 11:
+                case 7:
                     LogWrapper.Info("[Page] 主页预设：杂志主页");
                     url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/Ext1nguisher/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 12:
+                case 8:
                     LogWrapper.Info("[Page] 主页预设：PCL GitHub 仪表盘");
                     url = "https://ddf.pcl-community.org/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 13:
+                case 9:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 更新摘要");
                     url = "https://raw.gitcode.com/ENC_Euphony/PCL-AI-Summary-HomePage/raw/master/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
                 
-                case 14:
+                case 10:
                     LogWrapper.Info("[Page] 主页预设：今日新闻热点");
                     url = "https://pcl.wyc-w.top/index.xaml";
                     content = LoadFromNetwork(url);
                     break;
                 
-                case 15:
+                case 11:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 芝士站");
                     url = "https://www.xxag.top/mkss";
                     content = LoadFromNetwork(url);
                     break;
                 
-                case 16:
+                case 12:
                     LogWrapper.Info("[Page] 主页预设：整合包推荐引擎");
                     url = "https://qawsedrftgyhujiko.fun/pcl2/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
 
-                case 17:
+                case 13:
+                    LogWrapper.Info("[Page] 主页预设：Bangumi 番剧主页");
+                    url = "https://bangumi.p.kaphia.qzz.io";
+                    content = LoadFromNetwork(url);
+                    break;
+                
+                case 14:
                     LogWrapper.Info("[Page] 主页预设：PCL CE 公告栏");
                     url = "https://s3.pysio.online/pcl2-ce/apiv2/pages/announce.xaml";
                     content = LoadFromNetwork(url);
                     break;
                 
-                case 18:
+                case 15:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 信息流");
                     Dispatcher.Invoke(() =>
                     {

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -203,13 +203,32 @@ public partial class PageLaunchRight : IRefreshable
                     url = "https://raw.gitcode.com/ENC_Euphony/PCL-AI-Summary-HomePage/raw/master/Custom.xaml";
                     content = LoadFromNetwork(url);
                     break;
-
+                
                 case 14:
+                    LogWrapper.Info("[Page] 主页预设：今日新闻热点");
+                    url = "https://pcl.wyc-w.top/index.xaml";
+                    content = LoadFromNetwork(url);
+                    break;
+                
+                case 15:
+                    LogWrapper.Info("[Page] 主页预设：Minecraft 芝士站");
+                    url = "https://www.xxag.top/mkss";
+                    content = LoadFromNetwork(url);
+                    break;
+                
+                case 16:
+                    LogWrapper.Info("[Page] 主页预设：整合包推荐引擎");
+                    url = "https://qawsedrftgyhujiko.fun/pcl2/Custom.xaml";
+                    content = LoadFromNetwork(url);
+                    break;
+
+                case 17:
                     LogWrapper.Info("[Page] 主页预设：PCL CE 公告栏");
                     url = "https://s3.pysio.online/pcl2-ce/apiv2/pages/announce.xaml";
                     content = LoadFromNetwork(url);
                     break;
-                case 15:
+                
+                case 18:
                     LogWrapper.Info("[Page] 主页预设：Minecraft 信息流");
                     Dispatcher.Invoke(() =>
                     {

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -354,6 +354,9 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.Magazine}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.GitHub}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McUpdateSummary}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.NewsToday}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.MinecraftKnowledge}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.ModpackRecommendation}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclAnnouncement}"/>
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McOfficialFeed}"/>
                         </local:MyComboBox>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -343,14 +343,14 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.Trivia}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.EchoCave}" Visibility="Collapsed" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McNews}" />
-                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.SimpleHomepage}" />
+                            <!-- <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.SimpleHomepage}" /> -->
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.DailyModpack}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McSkin}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.OpenBmclapi}" />
-                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclMarket}" />
-                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclNews}" />
+                            <!-- <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclMarket}" /> -->
+                            <!-- <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclNews}" /> -->
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclManual}" />
-                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.OpenMcim}" Visibility="Collapsed" />
+                            <!-- <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.OpenMcim}" Visibility="Collapsed" /> -->
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.Magazine}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.GitHub}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McUpdateSummary}" />

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -357,6 +357,7 @@
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.NewsToday}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.MinecraftKnowledge}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.ModpackRecommendation}" />
+                            <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.Bangumi}" />
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.PclAnnouncement}"/>
                             <local:MyComboBoxItem Content="{DynamicResource Setup.Ui.Homepage.Preset.McOfficialFeed}"/>
                         </local:MyComboBox>


### PR DESCRIPTION
Close #3349

## Summary by Sourcery

添加新的主页预设，并将其集成到启动器 UI 和本地化中。

新功能：
- 引入多个新的主页预设选项，这些选项由远程 XAML 内容 URL 提供支持。
- 在设置 UI 中展示新的主页预设，并提供对应的英文和中文本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new homepage presets and wire them into the launcher UI and localization.

New Features:
- Introduce multiple new homepage preset options backed by remote XAML content URLs.
- Expose the new homepage presets in the setup UI with corresponding localized strings in English and Chinese.

</details>