### PR TITLE
feat(mod): 内嵌模组(Jar-in-Jar)自动解析与崩溃导出

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -218,11 +218,11 @@
 
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateDescription">These mods may conflict with their bundled copies and cause crashes:</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateEntry">{0} [{1}] &lt;-&gt; bundled in {2} ({3})</sys:String>
-    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">(Matched by Mod ID; may include false positives.)</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">(Matched by mod ID and may include false positives.)</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateNone">None</sys:String>
-    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateSection">=== Potentially duplicated mods (installed standalone AND bundled via Jar-in-Jar) ===</sys:String>
-    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarNone">No Jar-in-Jar info found</sys:String>
-    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarSection">=== Jar-in-Jar info (enabled mods only) ===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateSection">=== Potentially duplicated mods (installed standalone and bundled via Jar-in-Jar) ===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarNone">No Jar-in-Jar information found</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarSection">=== Jar-in-Jar information (enabled mods only) ===</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.ModListDirectory">Directory: {0}</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.ModListSection">=== Mod list ===</sys:String>
 

--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -214,6 +214,18 @@
     <sys:String x:Key="Crash.Report.Environment.ProfileSection">- Profile information -</sys:String>
     <sys:String x:Key="Crash.Report.Environment.SelectedJava">Selected Java VM: {0}</sys:String>
 
+    <!-- Crash.Report.JarInJarMod -->
+
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateDescription">These mods may conflict with their bundled copies and cause crashes:</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateEntry">{0} [{1}] &lt;-&gt; bundled in {2} ({3})</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">(Matched by Mod ID; may include false positives.)</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateNone">None</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateSection">=== Potentially duplicated mods (installed standalone AND bundled via Jar-in-Jar) ===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarNone">No Jar-in-Jar info found</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarSection">=== Jar-in-Jar info (enabled mods only) ===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.ModListDirectory">Directory: {0}</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.ModListSection">=== Mod list ===</sys:String>
+
     <!-- Crash.Suggestion -->
 
     <sys:String x:Key="Crash.Suggestion.DisableTheseMods">Try disabling these mods one by one, then check whether the game still crashes.</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -218,7 +218,7 @@
 
     <sys:String x:Key="Crash.Report.JarInJarMod.ModListDirectory">目录：{0}</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateEntry">{0} [{1}] &lt;-&gt; 内嵌于 {2}（{3}）</sys:String>
-    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">（按 ModId 匹配，可能包含误报）</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">（按模组 ID 匹配，可能包含误报）</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateDescription">以下模组可能与内嵌副本冲突并导致崩溃：</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateNone">无</sys:String>
     <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateSection">=== 潜在重复模组===</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -214,6 +214,18 @@
     <sys:String x:Key="Crash.Report.Environment.ProfileSection">- 档案信息 -</sys:String>
     <sys:String x:Key="Crash.Report.Environment.SelectedJava">选定的 Java 虚拟机：{0}</sys:String>
 
+    <!-- Crash.Report.JarInJarMod -->
+
+    <sys:String x:Key="Crash.Report.JarInJarMod.ModListDirectory">目录：{0}</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateEntry">{0} [{1}] &lt;-&gt; 内嵌于 {2}（{3}）</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateHeuristic">（按 ModId 匹配，可能包含误报）</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateDescription">以下模组可能与内嵌副本冲突并导致崩溃：</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateNone">无</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.DuplicateSection">=== 潜在重复模组===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarNone">未发现 Jar-in-Jar 信息</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.JarInJarSection">=== Jar-in-Jar 信息（仅启用模组）===</sys:String>
+    <sys:String x:Key="Crash.Report.JarInJarMod.ModListSection">=== 模组列表 ===</sys:String>
+
     <!-- Crash.Suggestion -->
 
     <sys:String x:Key="Crash.Suggestion.DisableTheseMods">尝试逐个禁用这些模组，再观察游戏是否仍会崩溃。</sys:String>

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
@@ -264,26 +264,36 @@ internal sealed class CrashReportExporter
 
         try
         {
-            var modsFolder = instance.PathIndie +
-                             (instance.Info.HasLabyMod
-                                 ? Path.Combine("labymod-neo", "fabric", instance.Info.VanillaName)
-                                 : "") + ModLocalComp.GetPathNameByCompType(ModComp.CompType.Mod) + @"\";
+            var modsFolderName = ModLocalComp.GetPathNameByCompType(ModComp.CompType.Mod);
+            var modsFolder = instance.Info.HasLabyMod
+                ? Path.Combine(instance.PathIndie, "labymod-neo", "fabric", instance.Info.VanillaName, modsFolderName)
+                : Path.Combine(instance.PathIndie, modsFolderName);
 
             if (!Directory.Exists(modsFolder))
                 return;
 
-            var activeMods = new List<ModLocalComp.LocalCompFile>();
-            foreach (var file in Directory.GetFiles(modsFolder))
+            // 老 Forge（Drop < 130）的启用 Mod 位于 mods/<版本名> 子目录，需一并扫描
+            var scanFolders = new List<string> { modsFolder };
+            if (instance.Info.HasForge && instance.Info.Drop < 130)
             {
-                if (!ModLocalComp.LocalCompFile.IsModFile(file)
-                    || file.EndsWith(".disabled", StringComparison.OrdinalIgnoreCase)
-                    || file.EndsWith(".old", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                var mod = new ModLocalComp.LocalCompFile(file);
-                mod.Load();
-                if (mod.State == ModLocalComp.LocalCompFile.LocalFileStatus.Fine)
-                    activeMods.Add(mod);
+                var versionSubFolder = Path.Combine(modsFolder, instance.Info.VanillaName);
+                if (Directory.Exists(versionSubFolder))
+                    scanFolders.Add(versionSubFolder);
             }
+
+            var activeMods = new List<ModLocalComp.LocalCompFile>();
+            foreach (var folder in scanFolders)
+                foreach (var file in Directory.GetFiles(folder))
+                {
+                    if (!ModLocalComp.LocalCompFile.IsModFile(file)
+                        || file.EndsWith(".disabled", StringComparison.OrdinalIgnoreCase)
+                        || file.EndsWith(".old", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    var mod = new ModLocalComp.LocalCompFile(file);
+                    mod.Load();
+                    if (mod.State == ModLocalComp.LocalCompFile.LocalFileStatus.Fine)
+                        activeMods.Add(mod);
+                }
 
             activeMods = activeMods
                 .OrderBy(m => m.Name ?? m.FileName, StringComparer.OrdinalIgnoreCase)
@@ -291,18 +301,28 @@ internal sealed class CrashReportExporter
 
             var sb = new StringBuilder();
 
+            var modsByModId = new Dictionary<string, List<ModLocalComp.LocalCompFile>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var mod in activeMods)
+            {
+                if (string.IsNullOrEmpty(mod.ModId))
+                    continue;
+                if (!modsByModId.TryGetValue(mod.ModId, out var list))
+                    modsByModId[mod.ModId] = list = new List<ModLocalComp.LocalCompFile>();
+                list.Add(mod);
+            }
+
             var duplicates = new List<string>();
             foreach (var host in activeMods)
                 foreach (var embedded in host.EmbeddedMods)
                 {
-                    if (string.IsNullOrEmpty(embedded.ModId))
+                    if (string.IsNullOrEmpty(embedded.ModId)
+                        || !modsByModId.TryGetValue(embedded.ModId, out var matches))
                         continue;
-                    foreach (var other in activeMods)
+                    foreach (var other in matches)
                     {
                         if (ReferenceEquals(other, host))
                             continue;
-                        if (string.Equals(other.ModId, embedded.ModId, StringComparison.OrdinalIgnoreCase))
-                            duplicates.Add(Lang.Text("Crash.Report.JarInJarMod.DuplicateEntry", other.Name, other.FileName, host.Name, embedded.Name ?? embedded.ModId));
+                        duplicates.Add(Lang.Text("Crash.Report.JarInJarMod.DuplicateEntry", other.Name, other.FileName, host.Name, embedded.Name ?? embedded.ModId));
                     }
                 }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
@@ -313,7 +313,7 @@ internal sealed class CrashReportExporter
 
             var duplicates = new List<string>();
             foreach (var host in activeMods)
-                foreach (var embedded in host.EmbeddedMods)
+                foreach (var embedded in _FlattenEmbedded(host.EmbeddedMods))
                 {
                     if (string.IsNullOrEmpty(embedded.ModId)
                         || !modsByModId.TryGetValue(embedded.ModId, out var matches))
@@ -375,6 +375,17 @@ internal sealed class CrashReportExporter
         catch (Exception ex)
         {
             LogWrapper.Warn(ex, "Crash", "导出模组信息失败");
+        }
+    }
+
+    private static IEnumerable<ModLocalComp.LocalCompFile> _FlattenEmbedded(List<ModLocalComp.LocalCompFile> mods)
+    {
+        foreach (var mod in mods)
+        {
+            yield return mod;
+            if (mod.EmbeddedMods.Any())
+                foreach (var child in _FlattenEmbedded(mod.EmbeddedMods))
+                    yield return child;
         }
     }
 

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
@@ -18,6 +18,7 @@ internal sealed class CrashReportExporter
     private const string RawOutputFileName = "游戏崩溃前的输出.txt";
     private const string LauncherLogFileName = "PCL 启动器日志.txt";
     private const string EnvironmentFileName = "环境与启动信息.txt";
+    private const string ModInfoFileName = "模组列表.txt";
 
     public void Export(
         CrashAnalysisContext context,
@@ -45,6 +46,7 @@ internal sealed class CrashReportExporter
                 _CopyFileToReport(reportFolder, outputFile);
 
             _WriteEnvironmentInfo(reportFolder);
+            _WriteModInfo(reportFolder, context.Instance);
 
             ZipFile.CreateFromDirectory(reportFolder, targetZipPath);
         }
@@ -253,5 +255,120 @@ internal sealed class CrashReportExporter
         return File.Exists(filePath)
             ? CrashFileIo.ReadText(filePath)
             : "";
+    }
+
+    private static void _WriteModInfo(string reportFolder, McInstance? instance)
+    {
+        if (instance is null)
+            return;
+
+        try
+        {
+            var modsFolder = instance.PathIndie +
+                             (instance.Info.HasLabyMod
+                                 ? Path.Combine("labymod-neo", "fabric", instance.Info.VanillaName)
+                                 : "") + ModLocalComp.GetPathNameByCompType(ModComp.CompType.Mod) + @"\";
+
+            if (!Directory.Exists(modsFolder))
+                return;
+
+            var activeMods = new List<ModLocalComp.LocalCompFile>();
+            foreach (var file in Directory.GetFiles(modsFolder))
+            {
+                if (!ModLocalComp.LocalCompFile.IsModFile(file)
+                    || file.EndsWith(".disabled", StringComparison.OrdinalIgnoreCase)
+                    || file.EndsWith(".old", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var mod = new ModLocalComp.LocalCompFile(file);
+                mod.Load();
+                if (mod.State == ModLocalComp.LocalCompFile.LocalFileStatus.Fine)
+                    activeMods.Add(mod);
+            }
+
+            activeMods = activeMods
+                .OrderBy(m => m.Name ?? m.FileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var sb = new StringBuilder();
+
+            var duplicates = new List<string>();
+            foreach (var host in activeMods)
+                foreach (var embedded in host.EmbeddedMods)
+                {
+                    if (string.IsNullOrEmpty(embedded.ModId))
+                        continue;
+                    foreach (var other in activeMods)
+                    {
+                        if (ReferenceEquals(other, host))
+                            continue;
+                        if (string.Equals(other.ModId, embedded.ModId, StringComparison.OrdinalIgnoreCase))
+                            duplicates.Add(Lang.Text("Crash.Report.JarInJarMod.DuplicateEntry", other.Name, other.FileName, host.Name, embedded.Name ?? embedded.ModId));
+                    }
+                }
+
+            sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.DuplicateSection"));
+            if (duplicates.Count == 0)
+                sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.DuplicateNone"));
+            else
+            {
+                sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.DuplicateDescription"));
+                sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.DuplicateHeuristic"));
+                foreach (var line in duplicates.Distinct())
+                    sb.AppendLine("\t|-> " + line);
+            }
+
+            sb.AppendLine().AppendLine("----------------------------").AppendLine();
+
+            sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.ModListSection"));
+            sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.ModListDirectory", modsFolder));
+            sb.AppendLine("|-> mods");
+            foreach (var mod in activeMods)
+            {
+                var line = "|  |-> " + (mod.Name ?? mod.FileName);
+                if (!string.IsNullOrWhiteSpace(mod.Version))
+                    line += $" ({mod.Version})";
+                if (mod.Name != mod.FileName)
+                    line += $" [{mod.FileName}]";
+                sb.AppendLine(line);
+            }
+
+            sb.AppendLine().AppendLine("----------------------------").AppendLine();
+
+            sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.JarInJarSection"));
+            var hasJij = false;
+            foreach (var mod in activeMods)
+            {
+                if (!mod.EmbeddedMods.Any())
+                    continue;
+                hasJij = true;
+                sb.AppendLine(mod.Name ?? mod.FileName);
+                _AppendEmbeddedMods(sb, mod.EmbeddedMods, 1);
+                sb.AppendLine();
+            }
+
+            if (!hasJij)
+                sb.AppendLine(Lang.Text("Crash.Report.JarInJarMod.JarInJarNone"));
+
+            CrashFileIo.WriteText(Path.Combine(reportFolder, ModInfoFileName), sb.ToString(), Encoding.UTF8);
+            LogWrapper.Info("Crash", "已导出模组列表及 Jar-in-Jar 信息");
+        }
+        catch (Exception ex)
+        {
+            LogWrapper.Warn(ex, "Crash", "导出模组信息失败");
+        }
+    }
+
+    private static void _AppendEmbeddedMods(StringBuilder builder, List<ModLocalComp.LocalCompFile> mods, int depth)
+    {
+        var indent = new string('\t', depth);
+        foreach (var mod in mods)
+        {
+            var line = indent + "|-> " + (mod.Name ?? mod.ModId ?? "?");
+            if (!string.IsNullOrWhiteSpace(mod.Version))
+                line += $" ({mod.Version})";
+            builder.AppendLine(line);
+            if (mod.EmbeddedMods.Any())
+                _AppendEmbeddedMods(builder, mod.EmbeddedMods, depth + 1);
+        }
     }
 }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
@@ -40,6 +40,7 @@ public static class ModJarInJar
                 var childPath = parentPath + "!/" + nestedPath;
                 var child = new ModLocalComp.LocalCompFile(childPath);
                 child.LookupMetadata(nestedJar);
+                child.MarkLoaded(); 
                 child.EmbeddedMods = Resolve(childPath, nestedJar, depth + 1);
                 result.Add(child);
             }

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace PCL;
+
+/// <summary>
+///     Jar-in-Jar（内嵌模组）解析。
+/// </summary>
+public static class ModJarInJar
+{
+    private const int MaxDepth = 5;
+
+    /// <summary>
+    ///     解析 <paramref name="jar" /> 内嵌套的其它 Mod jar，返回内嵌 Mod 列表。
+    /// </summary>
+    public static List<ModLocalComp.LocalCompFile> Resolve(string parentPath, ZipArchive jar, int depth = 0)
+    {
+        var result = new List<ModLocalComp.LocalCompFile>();
+        if (depth >= MaxDepth) return result;
+
+        var nestedPaths = new List<string>();
+        _CollectFabricNestedJars(jar, nestedPaths);
+        _CollectForgeNestedJars(jar, nestedPaths);
+
+        foreach (var nestedPath in nestedPaths.Distinct())
+        {
+            try
+            {
+                var entry = jar.GetEntry(nestedPath);
+                if (entry is null) continue;
+                // 嵌套 jar 流不可 seek，需复制到 MemoryStream 后再作为独立 ZipArchive 打开
+                using var ms = new MemoryStream();
+                using (var es = entry.Open()) es.CopyTo(ms);
+                ms.Position = 0;
+                using var nestedJar = new ZipArchive(ms, ZipArchiveMode.Read);
+
+                var childPath = parentPath + "!/" + nestedPath;
+                var child = new ModLocalComp.LocalCompFile(childPath);
+                child.LookupMetadata(nestedJar);
+                child.EmbeddedMods = Resolve(childPath, nestedJar, depth + 1);
+                result.Add(child);
+            }
+            catch (Exception ex)
+            {
+                ModBase.Log(ex, "解析内嵌 Mod 失败（" + parentPath + " -> " + nestedPath + "）", ModBase.LogLevel.Developer);
+            }
+        }
+
+        return result;
+    }
+
+    private static void _CollectFabricNestedJars(ZipArchive jar, List<string> paths)
+    {
+        try
+        {
+            var entry = jar.GetEntry("fabric.mod.json");
+            if (entry is null) return;
+            var obj = (JsonObject)ModBase.GetJson(ModBase.ReadFile(entry.Open()));
+            if (obj.TryGetPropertyValue("jars", out var jars) && jars is JsonArray arr)
+                foreach (var j in arr)
+                    if (j is JsonObject jo && jo.TryGetPropertyValue("file", out var file) && file is not null)
+                        paths.Add(file.ToString());
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "解析 fabric.mod.json 内嵌清单失败", ModBase.LogLevel.Developer);
+        }
+    }
+
+    private static void _CollectForgeNestedJars(ZipArchive jar, List<string> paths)
+    {
+        try
+        {
+            var entry = jar.GetEntry("META-INF/jarjar/metadata.json");
+            if (entry is null) return;
+            var obj = (JsonObject)ModBase.GetJson(ModBase.ReadFile(entry.Open()));
+            if (obj.TryGetPropertyValue("jars", out var jars) && jars is JsonArray arr)
+                foreach (var j in arr)
+                    if (j is JsonObject jo && jo.TryGetPropertyValue("path", out var p) && p is not null)
+                        paths.Add(p.ToString());
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(ex, "解析 META-INF/jarjar/metadata.json 内嵌清单失败", ModBase.LogLevel.Developer);
+        }
+    }
+}

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJarInJar.cs
@@ -32,7 +32,6 @@ public static class ModJarInJar
             {
                 var entry = jar.GetEntry(nestedPath);
                 if (entry is null) continue;
-                // 嵌套 jar 流不可 seek，需复制到 MemoryStream 后再作为独立 ZipArchive 打开
                 using var ms = new MemoryStream();
                 using (var es = entry.Open()) es.CopyTo(ms);
                 ms.Position = 0;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -1090,6 +1090,7 @@ public static class ModLocalComp
                 jar = new ZipArchive(new FileStream(path, FileMode.Open));
                 // 信息获取
                 LookupMetadata(jar);
+                EmbeddedMods = ModJarInJar.Resolve(path, jar);
             }
             catch (UnauthorizedAccessException ex)
             {
@@ -1112,9 +1113,14 @@ public static class ModLocalComp
         }
 
         /// <summary>
+        ///     内嵌模组列表，由 <see cref="ModJarInJar" /> 解析填充。
+        /// </summary>
+        public List<LocalCompFile> EmbeddedMods = new();
+
+        /// <summary>
         ///     从 Jar 文件中获取 Mod 信息。
         /// </summary>
-        private void LookupMetadata(ZipArchive jar)
+        internal void LookupMetadata(ZipArchive jar)
         {
             #region 尝试使用 mcmod.info
 
@@ -1346,7 +1352,8 @@ public static class ModLocalComp
             try
             {
                 // 获取 mods.toml 文件
-                var tomlEntry = jar.GetEntry("META-INF/mods.toml");
+                var tomlEntry = jar.GetEntry("META-INF/mods.toml")
+                                ?? jar.GetEntry("META-INF/neoforge.mods.toml");
                 string tomlText = null;
                 if (tomlEntry is not null)
                 {

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -872,6 +872,12 @@ public static class ModLocalComp
         private bool isLoaded;
 
         /// <summary>
+        ///     标记为已加载。用于内嵌（Jar-in-Jar）子项——其元数据已由 <see cref="ModJarInJar" /> 通过
+        ///     LookupMetadata 从已打开的嵌套流读入，虚拟路径不是真实文件，须避免属性 getter 再触发 Load() 清空元数据。
+        /// </summary>
+        internal void MarkLoaded() => isLoaded = true;
+
+        /// <summary>
         ///     Mod 文件是否可被正常读取。
         /// </summary>
         public bool IsFileAvailable

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLocalComp.cs
@@ -1115,7 +1115,7 @@ public static class ModLocalComp
         /// <summary>
         ///     内嵌模组列表，由 <see cref="ModJarInJar" /> 解析填充。
         /// </summary>
-        public List<LocalCompFile> EmbeddedMods = new();
+        public List<LocalCompFile> EmbeddedMods { get; internal set; } = new();
 
         /// <summary>
         ///     从 Jar 文件中获取 Mod 信息。

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -1377,7 +1377,10 @@ public partial class PageInstanceCompResource : IRefreshable
             {
                 var exportContent = new List<string>();
                 foreach (var ModEntity in ModLocalComp.compResourceListLoader.output)
+                {
                     exportContent.Add(ModEntity.FileName);
+                    _AppendEmbeddedForExport(exportContent, ModEntity.EmbeddedMods, 1);
+                }
                 ExportText(exportContent.Join("\r\n"), PageInstanceLeft.McInstance.Name + "已安装的资源信息.txt");
                 break;
             }
@@ -1385,13 +1388,38 @@ public partial class PageInstanceCompResource : IRefreshable
             case 2: // CSV
             {
                 var exportContent = new List<string>();
-                exportContent.Add("文件名,资源名称,资源版本,此版本更新时间,Mod ID,对应平台工程 ID,文件大小（字节）,文件路径");
+                exportContent.Add("文件名,资源名称,资源版本,此版本更新时间,Mod ID,对应平台工程 ID,文件大小（字节）,文件路径,内嵌模组");
                 foreach (var ModEntity in ModLocalComp.compResourceListLoader.output)
                     exportContent.Add(
-                        $"{ModEntity.FileName},{ModEntity.Comp?.TranslatedName},{ModEntity.Version},{ModEntity.compFile?.ReleaseDate},{ModEntity.ModId},{ModEntity.Comp?.Id},{GetModFileInfo(ModEntity.path).Length},{ModEntity.path}");
+                        $"{ModEntity.FileName},{ModEntity.Comp?.TranslatedName},{ModEntity.Version},{ModEntity.compFile?.ReleaseDate},{ModEntity.ModId},{ModEntity.Comp?.Id},{GetModFileInfo(ModEntity.path).Length},{ModEntity.path},{string.Join(";", _FlattenEmbeddedNames(ModEntity.EmbeddedMods))}");
                 ExportText(exportContent.Join("\r\n"), PageInstanceLeft.McInstance.Name + "已安装的资源信息.csv");
                 break;
             }
+        }
+    }
+
+    private static void _AppendEmbeddedForExport(List<string> lines, List<ModLocalComp.LocalCompFile> mods, int depth)
+    {
+        var indent = new string('\t', depth);
+        foreach (var mod in mods)
+        {
+            var line = indent + "└ " + (mod.Name ?? mod.ModId ?? mod.FileName);
+            if (!string.IsNullOrWhiteSpace(mod.Version))
+                line += $" ({mod.Version})";
+            lines.Add(line);
+            if (mod.EmbeddedMods is { Count: > 0 })
+                _AppendEmbeddedForExport(lines, mod.EmbeddedMods, depth + 1);
+        }
+    }
+
+    private static IEnumerable<string> _FlattenEmbeddedNames(List<ModLocalComp.LocalCompFile> mods)
+    {
+        foreach (var mod in mods)
+        {
+            yield return mod.Name ?? mod.ModId ?? mod.FileName;
+            if (mod.EmbeddedMods is { Count: > 0 })
+                foreach (var child in _FlattenEmbeddedNames(mod.EmbeddedMods))
+                    yield return child;
         }
     }
 


### PR DESCRIPTION
为方便大夫排查内嵌模组的重复导致的崩溃，加入JIJ检测功能，移植自 HMCL#6230，仅保留检测与崩溃导出，不含展示 UI：

- 新增独立模块 ModJarInJar：Resolve() 读取 Fabric 的 fabric.mod.json 与 Forge/NeoForge 的 META-INF/jarjar/metadata.json，将嵌套 jar 复制到内存流后 作为独立 ZipArchive 递归解析（深度上限 5），复用 LocalCompFile 元数据解析 填充内嵌 Mod 完整信息。

- LocalCompFile 新增 EmbeddedMods 字段，Load() 中委托 ModJarInJar.Resolve 填充； LookupMetadata 由 private 改 internal 供新模块调用。非 JIJ 模组仅两次 GetEntry 即返回，开销可忽略。

- CrashReportExporter 生成 模组列表.txt，含潜在重复模组、模组列表、Jar-in-Jar 信息三段，参照 HMCL LogExporter。

本PR的信息生成由Claude Code Opus 4.8辅助完成，由Opus 4.8对代码进行了审查。

## Summary by Sourcery

添加自动检测 Jar-in-Jar 模组的功能，并在崩溃报告中导出详细模组信息，以便调查由重复或嵌入模组导致的崩溃。

新功能：
- 在崩溃报告压缩包中生成专用的模组列表文本文件，其中包括活动模组、潜在重复模组以及 Jar-in-Jar 结构。
- 引入 `ModJarInJar` 模块，从 Fabric 和 Forge/NeoForge 元数据中递归解析嵌入的模组 Jar，并在 `LocalCompFile` 上将其暴露为嵌入模组。

改进：
- 扩展模组元数据加载逻辑，以跟踪嵌入模组，并在现有格式基础上增加对 NeoForge `mods.toml` 元数据的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic Jar-in-Jar mod detection and export of detailed mod information to crash reports to aid investigation of crashes caused by duplicate or embedded mods.

New Features:
- Generate a dedicated mod list text file in crash report archives, including active mods, potential duplicates, and Jar-in-Jar structure.
- Introduce a ModJarInJar module to recursively resolve embedded mod jars from Fabric and Forge/NeoForge metadata and expose them as embedded mods on LocalCompFile.

Enhancements:
- Extend mod metadata loading to track embedded mods and support NeoForge mods.toml metadata in addition to existing formats.

</details>

新特性：
- 在崩溃报告中生成模组信息文件，列出活动模组、潜在重复模组以及 Jar-in-Jar 层级结构。
- 引入 ModJarInJar 工具，用于递归解析 Fabric 和 Forge/NeoForge 模组中的嵌入式模组 jar，并通过 LocalCompFile 对外暴露。

增强内容：
- 扩展模组元数据加载，以跟踪嵌入式模组，并在现有格式的基础上支持 NeoForge 的 `mods.toml` 元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加自动检测 Jar-in-Jar 模组的功能，并在崩溃报告中导出详细模组信息，以便调查由重复或嵌入模组导致的崩溃。

新功能：
- 在崩溃报告压缩包中生成专用的模组列表文本文件，其中包括活动模组、潜在重复模组以及 Jar-in-Jar 结构。
- 引入 `ModJarInJar` 模块，从 Fabric 和 Forge/NeoForge 元数据中递归解析嵌入的模组 Jar，并在 `LocalCompFile` 上将其暴露为嵌入模组。

改进：
- 扩展模组元数据加载逻辑，以跟踪嵌入模组，并在现有格式基础上增加对 NeoForge `mods.toml` 元数据的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic Jar-in-Jar mod detection and export of detailed mod information to crash reports to aid investigation of crashes caused by duplicate or embedded mods.

New Features:
- Generate a dedicated mod list text file in crash report archives, including active mods, potential duplicates, and Jar-in-Jar structure.
- Introduce a ModJarInJar module to recursively resolve embedded mod jars from Fabric and Forge/NeoForge metadata and expose them as embedded mods on LocalCompFile.

Enhancements:
- Extend mod metadata loading to track embedded mods and support NeoForge mods.toml metadata in addition to existing formats.

</details>

</details>