### PR TITLE
fix: 使用 UseShellExecute 打开目录

### DIFF
--- a/PCL.Core/Utils/OS/ProcessInterop.cs
+++ b/PCL.Core/Utils/OS/ProcessInterop.cs
@@ -43,6 +43,8 @@ public class ProcessInterop {
             psi.UseShellExecute = true;
             psi.Verb = "runas";
         }
+        if (Directory.Exists(path))
+            psi.UseShellExecute = true;
 
         return Process.Start(psi);
     }


### PR DESCRIPTION
close #3379

## Summary by Sourcery

Bug Fixes:
- 在为现有目录路径启动进程时强制使用 shell 执行，以正确打开该文件夹，而不是尝试将其作为可执行文件运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Force shell execution when starting a process for an existing directory path to correctly open the folder instead of attempting to run it as an executable.

</details>