### PR TITLE
feat(instance-export): 支持导出未被规则覆盖的文件夹

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -900,6 +900,8 @@
     <sys:String x:Key="Instance.Export.Option.Saves">Singleplayer saves</sys:String>
     <sys:String x:Key="Instance.Export.Option.Saves.Desc">Worlds / maps</sys:String>
     <sys:String x:Key="Instance.Export.Option.Screenshots">Screenshots</sys:String>
+    <sys:String x:Key="Instance.Export.Option.OtherFolders">Other folders</sys:String>
+    <sys:String x:Key="Instance.Export.Option.OtherFolders.Desc">Other folders not covered by the options above</sys:String>
     <sys:String x:Key="Instance.Export.Option.Servers">Multiplayer server list</sys:String>
     <sys:String x:Key="Instance.Export.Option.ShaderPacks">Shader packs</sys:String>
     <sys:String x:Key="Instance.Export.Option.Structures">Exported structures</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -900,6 +900,8 @@
     <sys:String x:Key="Instance.Export.Option.Saves">单人游戏存档</sys:String>
     <sys:String x:Key="Instance.Export.Option.Saves.Desc">世界/地图</sys:String>
     <sys:String x:Key="Instance.Export.Option.Screenshots">截图</sys:String>
+    <sys:String x:Key="Instance.Export.Option.OtherFolders">其他文件夹</sys:String>
+    <sys:String x:Key="Instance.Export.Option.OtherFolders.Desc">未被上方选项覆盖的文件夹</sys:String>
     <sys:String x:Key="Instance.Export.Option.Servers">多人游戏服务器列表</sys:String>
     <sys:String x:Key="Instance.Export.Option.ShaderPacks">光影包</sys:String>
     <sys:String x:Key="Instance.Export.Option.Structures">导出的结构</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
@@ -219,6 +219,16 @@
                                     DefaultChecked="False" />
                             </local:MyCheckBox.Tag>
                         </local:MyCheckBox>
+                        <local:MyCheckBox x:Name="CheckOptionsOtherFolders" Change="CheckOptionsOtherFolders_Change">
+                            <local:MyCheckBox.Tag>
+                                <local:ExportOption
+                                    Title="{DynamicResource Instance.Export.Option.OtherFolders}"
+                                    Description="{DynamicResource Instance.Export.Option.OtherFolders.Desc}"
+                                    DefaultChecked="False" />
+                            </local:MyCheckBox.Tag>
+                        </local:MyCheckBox>
+                        <StackPanel Margin="30,0,0,0" x:Name="PanOptionsOtherFolders"
+                                    Visibility="{Binding Checked, ElementName=CheckOptionsOtherFolders, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         <local:MyCheckBox x:Name="CheckOptionsPcl">
                             <local:MyCheckBox.Tag>
                                 <local:ExportOption

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -115,6 +115,15 @@ public partial class PageInstanceExport : IRefreshable
         CheckOptionsPcl.IsEnabled = (bool)!CheckAdvancedModrinth.Checked;
     }
 
+    // 勾选"其他文件夹"时，同步勾选/取消所有子选项
+    private void CheckOptionsOtherFolders_Change(object sender, bool user)
+    {
+        if (!user) return;
+        foreach (var child in PanOptionsOtherFolders.Children)
+            if (child is MyCheckBox childBox)
+                childBox.Checked = CheckOptionsOtherFolders.Checked;
+    }
+
     // 勾选打包资源文件时，禁止开启 Modrinth 上传模式
     private void CheckAdvancedInclude_Change(object sender, bool user)
     {
@@ -135,6 +144,82 @@ public partial class PageInstanceExport : IRefreshable
         ReloadSubOptions(PanOptionsResourcePacks, true, true, "resourcepacks", "texturepacks");
         ReloadSubOptions(PanOptionsSaves, false, true, "saves");
         ReloadSubOptions(PanOptionsShaderPacks, true, true, "shaderpacks");
+        ReloadOtherFolders();
+    }
+
+    /// <summary>
+    ///     扫描实例根目录下未被已有选项覆盖的文件夹，生成独立的复选框。
+    /// </summary>
+    private void ReloadOtherFolders()
+    {
+        PanOptionsOtherFolders.Children.Clear();
+
+        var pathIndie = PageInstanceLeft.McInstance.PathIndie;
+        var rootDir = new DirectoryInfo(pathIndie);
+        if (!rootDir.Exists)
+        {
+            CheckOptionsOtherFolders.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        var coveredFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // 模组
+            "mods", "coremods", "lib",
+            // 整合包重要数据
+            "addons", "multiblocked", "modpack-update-checker", "global_packs",
+            "global_resource_packs", "global_data_packs", "optional_data_packs", "maps",
+            "mods-resourcepacks", "matmos", "resource_assorts",
+            "patchouli_books", "datapacks",
+            "openloader", "worldshape", "resources", "scripts", "structures",
+            "fontfiles", "oresources", "packmenu", "craftpresence", "pointblanks",
+            // 模组设置
+            "config", "defaultconfigs", "journeymap", "local", "essential", "gg.essential.mod",
+            "CustomSkinLoader",
+            // 地图
+            "xaero", "XaeroWaypoints", "XaeroWorldMap",
+            // 资源包
+            "resourcepacks", "texturepacks",
+            // 光影
+            "shaderpacks",
+            // 截图 / 结构 / 录像
+            "screenshots", "schematics",
+            "replay_recordings", "replay_videos",
+            // 存档 / 设置文件夹
+            "saves", "configureddefaults",
+            // 始终跳过（大量文件或无用缓存）
+            "assets", "versions", "libraries", "structureCacheV1",
+            ".fabric", ".git", "avatar-cache", "cosmetic-cache",
+            // PCL 单独处理
+            "PCL",
+        };
+
+        var coveredPrefixes = new[] { "kubejs", "template" };
+        var coveredSuffixes = new[] { "-natives" };
+
+        foreach (var subDir in rootDir.EnumerateDirectories())
+        {
+            if (coveredFolders.Contains(subDir.Name))
+                continue;
+            if (coveredPrefixes.Any(p => subDir.Name.StartsWithF(p)))
+                continue;
+            if (coveredSuffixes.Any(s => subDir.Name.EndsWithF(s, true)))
+                continue;
+
+            PanOptionsOtherFolders.Children.Add(new MyCheckBox
+            {
+                Tag = new ExportOption
+                {
+                    Title = subDir.Name,
+                    DefaultChecked = false,
+                    Rules = ModBase.EscapeLikePattern($"{subDir.Name}/")
+                }
+            });
+        }
+
+        CheckOptionsOtherFolders.Visibility = PanOptionsOtherFolders.Children.Count > 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     private void ReloadSubOptions(StackPanel panel, bool acceptCompressedFile, bool acceptFolder,


### PR DESCRIPTION
> Parly Generated By Deepseek-v4-pro

close #3242

## Summary by Sourcery

为导出当前导出规则未覆盖的额外实例文件夹提供支持，并在实例导出界面中展示这些文件夹。

New Features:
- 自动检测并列出实例根目录中未分类的文件夹，作为可单独选择的导出选项。
- 在导出设置中通过单个 “Other folders” 复选框，允许统一切换所有未分类文件夹选项。

Enhancements:
- 当没有可额外导出的文件夹时，隐藏 “Other folders” 选项。
- 从自动检测到的文件夹列表中排除已知的系统目录、缓存目录，以及已处理的 Minecraft/模组包 目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for exporting additional instance folders that are not covered by existing export rules and surface them in the instance export UI.

New Features:
- Automatically detect and list uncategorized folders in the instance root as individually selectable export options.
- Allow toggling all uncategorized folder options via a single "Other folders" checkbox in the export settings.

Enhancements:
- Hide the "Other folders" option when no extra folders are available for export.
- Exclude known system, cache, and already-handled Minecraft/modpack directories from the auto-detected folder list.

</details>