### PR TITLE
fix(color): MC 文本格式化时可能产生意外的 null 变量

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModStyle.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModStyle.cs
@@ -202,7 +202,10 @@ internal static class ModStyle
 
                 if (isColorCode)
                 {
+                    var prevColor = color;
                     if (!MotdRenderer.TryGetColorFromCode(c.ToString(), isDarkMode, out color))
+                    {
+                        color = prevColor; // out 会将 color 置为 null，统一恢复为之前的颜色
                         switch (c)
                         {
                             // 格式化代码
@@ -252,6 +255,7 @@ internal static class ModStyle
                                 break;
                             }
                         }
+                    }
 
                     if (!string.IsNullOrEmpty(curRun.Text) && c.ToString() != "k" && c.ToString() != "K") // 遇到格式代码但是有文本，重开一个Run
                     {


### PR DESCRIPTION
Resolves #3380 

> Generated by Claude Opus 4.6, manually reviewed

## Summary by Sourcery

Bug Fixes:
- 当颜色代码解析失败时，恢复之前的文本颜色，以避免在渲染 Minecraft MOTD 时出现空的颜色值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the previous text color when color code parsing fails to avoid null color values during Minecraft MOTD rendering.

</details>