### PR TITLE
chore(deps): 更新 Humanizer.Core.zh-CN 到 3.0.10

### DIFF
--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -68,7 +68,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
         <PackageReference Include="Polly" Version="8.6.5" />
         <!-- 本地化 -->
-        <PackageReference Include="Humanizer.Core.zh-CN" Version="3.0.1" />
+        <PackageReference Include="Humanizer.Core.zh-CN" Version="3.0.10" />
         <!-- 日志与遥测 -->
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />


### PR DESCRIPTION
## Summary by Sourcery

杂项：
- 更新 PCL.Core 中的 NuGet 包引用，以使用最新发布的 Humanizer.Core.zh-CN。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Refresh NuGet package references in PCL.Core to use the latest Humanizer.Core.zh-CN release.

</details>