### PR TITLE
chore(deps): 更新 Stun.Net 到 10.0.6

### DIFF
--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -64,7 +64,7 @@
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <!-- 网络 -->
         <PackageReference Include="Ae.Dns.Client" Version="3.1.0" />
-        <PackageReference Include="Stun.Net" Version="9.0.1" />
+        <PackageReference Include="Stun.Net" Version="10.0.6" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
         <PackageReference Include="Polly" Version="8.6.5" />
         <!-- 本地化 -->


### PR DESCRIPTION
## Summary by Sourcery

杂务：
- 刷新 PCL.Core 中的 NuGet 包引用以使用 Stun.Net 10.0.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Refresh NuGet package references in PCL.Core to use Stun.Net 10.0.6.

</details>