### PR TITLE
chore(deps): 更新 Dapper 到 2.1.79

### DIFF
--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.csproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.csproj
@@ -65,7 +65,7 @@
         <DefineConstants>BETA</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.66" />
+        <PackageReference Include="Dapper" Version="2.1.79" />
         <PackageReference Include="DotNet.Glob" Version="3.1.3" />
         <PackageReference Include="Downloader" Version="5.5.0" />
         <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />


### PR DESCRIPTION
## Summary by Sourcery

杂务：
- 刷新 Plain Craft Launcher 2 项目的 NuGet 包引用，以使用更新版本的依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Refresh NuGet package references for the Plain Craft Launcher 2 project to use newer versions of dependencies.

</details>