### PR TITLE
chore(deps): 更新 Sentry 到 6.6.0

### DIFF
--- a/PCL.Core/PCL.Core.csproj
+++ b/PCL.Core/PCL.Core.csproj
@@ -72,7 +72,7 @@
         <!-- 日志与遥测 -->
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Sentry" Version="6.3.1" />
+        <PackageReference Include="Sentry" Version="6.6.0" />
         <!-- 身份认证 -->
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
         <!-- 验证 -->


### PR DESCRIPTION
## Summary by Sourcery

构建：
- 将 `PCL.Core.csproj` 中的 Sentry NuGet 依赖版本提升到 `6.6.0`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump Sentry NuGet dependency version in PCL.Core.csproj to 6.6.0.

</details>