### PR TITLE
imp(game-crash): 在游戏崩溃弹窗点击查看日志时打开最新的日志文件

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
@@ -39,6 +39,12 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
 
         var classifiedFiles = _ClassifyFiles();
 
+        context.DirectOpenFile = classifiedFiles
+            .Where(item => item.Kind is not null)
+            .Select(item => item.File)
+            .OrderByDescending(_GetLastWriteTime)
+            .FirstOrDefault();
+
         var analyzable = classifiedFiles
             .Where(item => item.Kind is not null)
             .ToList();
@@ -121,9 +127,6 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
                 LogWrapper.Info("Crash", $"{name} 分类为 Ignore");
                 continue;
             }
-
-            if (kind is not null && context.DirectOpenFile is null)
-                context.DirectOpenFile = file;
 
             result.Add(new ClassifiedCrashLog(file, kind));
             LogWrapper.Info("Crash", $"{name} 分类为 {kind?.ToString() ?? "Extra"}");

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
@@ -44,7 +44,7 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
             .ToList();
 
         context.DirectOpenFile = analyzable
-            .OrderByDescending(item => _KindPriority(item.Kind!.Value))
+            .OrderBy(item => _IsGeneratedLog(item.File))
             .ThenByDescending(item => _GetLastWriteTime(item.File))
             .Select(item => item.File)
             .FirstOrDefault();
@@ -349,14 +349,8 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
         }
     }
 
-    private static int _KindPriority(CrashLogKind kind) => kind switch
-    {
-        CrashLogKind.CrashReport => 4,
-        CrashLogKind.HsErr       => 3,
-        CrashLogKind.Game         => 2,
-        CrashLogKind.Debug        => 1,
-        _                         => 0
-    };
+    private bool _IsGeneratedLog(CrashLogEntry file) =>
+        file.FullPath.StartsWith(context.TempFolder, StringComparison.OrdinalIgnoreCase);
 
     private static string _GetHeadTailLines(
         IReadOnlyList<string> raw,

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
@@ -39,15 +39,15 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
 
         var classifiedFiles = _ClassifyFiles();
 
-        context.DirectOpenFile = classifiedFiles
-            .Where(item => item.Kind is not null)
-            .Select(item => item.File)
-            .OrderByDescending(_GetLastWriteTime)
-            .FirstOrDefault();
-
         var analyzable = classifiedFiles
             .Where(item => item.Kind is not null)
             .ToList();
+
+        context.DirectOpenFile = analyzable
+            .OrderByDescending(item => _KindPriority(item.Kind!.Value))
+            .ThenByDescending(item => _GetLastWriteTime(item.File))
+            .Select(item => item.File)
+            .FirstOrDefault();
 
         var extraFiles = classifiedFiles
             .Where(item => item.Kind is null)
@@ -348,6 +348,15 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
             return new DateTime(1900, 1, 1);
         }
     }
+
+    private static int _KindPriority(CrashLogKind kind) => kind switch
+    {
+        CrashLogKind.CrashReport => 4,
+        CrashLogKind.HsErr       => 3,
+        CrashLogKind.Game         => 2,
+        CrashLogKind.Debug        => 1,
+        _                         => 0
+    };
 
     private static string _GetHeadTailLines(
         IReadOnlyList<string> raw,


### PR DESCRIPTION
> Generated by Claude Opus 4.6, manually reviewed

## Summary by Sourcery

增强：
- 更新崩溃日志的准备流程，以在崩溃对话框中直接打开时选择最新的相关日志文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update crash log preparation to select the latest relevant log file for direct opening from the crash dialog.

</details>