### PR TITLE
fix(game-crash): 修复崩溃报告中启动器日志无法正常输出的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/CrashFileIo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/CrashFileIo.cs
@@ -9,7 +9,18 @@ internal static class CrashFileIo
 {
     public static byte[] ReadBytes(string filePath)
     {
-        return Files.ReadAllBytesOrEmptyAsync(filePath).GetAwaiter().GetResult();
+        try
+        {
+            // 使用 FileShare.ReadWrite 以读取正在被 Logger 写入的文件
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var ms = new MemoryStream();
+            fs.CopyTo(ms);
+            return ms.ToArray();
+        }
+        catch (Exception)
+        {
+            return Files.ReadAllBytesOrEmptyAsync(filePath).GetAwaiter().GetResult();
+        }
     }
 
     public static string ReadText(string filePath, Encoding? encoding = null)

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/CrashFileIo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/CrashFileIo.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text;
 using PCL.Core.IO;
+using PCL.Core.Logging;
 using PCL.Core.Utils.Codecs;
 
 namespace PCL;
@@ -14,11 +15,12 @@ internal static class CrashFileIo
             // 使用 FileShare.ReadWrite 以读取正在被 Logger 写入的文件
             using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var ms = new MemoryStream();
-            fs.CopyTo(ms);
+            fs.CopyToAsync(ms).GetAwaiter().GetResult();
             return ms.ToArray();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogWrapper.Warn(ex, "Crash IO", "读取与游戏崩溃关联的日志文件时出错，");
             return Files.ReadAllBytesOrEmptyAsync(filePath).GetAwaiter().GetResult();
         }
     }


### PR DESCRIPTION
> Generated by Claude Opus 4.6, manually reviewed

## Summary by Sourcery

Bug Fixes:
- 修复在日志文件被锁定或仍在写入时，崩溃分析无法读取启动器日志输出的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve crash analysis failing to read launcher log output when the log file is locked or still being written.

</details>