### PR TITLE
imp(game-crash): 修改启动器日志文件名称以增加区分度

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Export/CrashReportExporter.cs
@@ -16,7 +16,7 @@ internal sealed class CrashReportExporter
 
     private const string LaunchScriptFileName = "启动脚本.bat";
     private const string RawOutputFileName = "游戏崩溃前的输出.txt";
-    private const string LauncherLogFileName = "PCL 启动器日志.txt";
+    private const string LauncherLogFileName = "PCL CE 启动器日志.txt";
     private const string EnvironmentFileName = "环境与启动信息.txt";
 
     public void Export(

--- a/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/CrashAnalysis/Logs/CrashLogPreparer.cs
@@ -25,6 +25,7 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
         "启动器日志.txt",
         "PCL2 启动器日志.txt",
         "PCL 启动器日志.txt",
+        "PCL CE 启动器日志.txt",
         "log1.txt",
         "log-ce1.log"
     };
@@ -189,6 +190,7 @@ internal sealed class CrashLogPreparer(CrashAnalysisContext context)
                      "log1.txt",
                      "log-ce1.log",
                      "游戏崩溃前的输出.txt",
+                     "PCL CE 启动器日志.txt",
                      "PCL2 启动器日志.txt",
                      "PCL 启动器日志.txt"
                  })


### PR DESCRIPTION
## Summary by Sourcery

更新崩溃分析日志处理逻辑，改为使用更具体的启动器日志文件名 `"PCL CE 启动器日志.txt"`。

改进内容：
- 调整崩溃报告导出流程，在导出启动器日志时使用新的 `"PCL CE 启动器日志.txt"` 文件名，以便将其与其他日志区分开来。
- 扩展崩溃日志准备逻辑，将新的 `"PCL CE 启动器日志.txt"` 文件名识别为标准启动器日志，而不是额外日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update crash analysis log handling to use the more specific "PCL CE 启动器日志.txt" launcher log filename.

Enhancements:
- Adjust crash report export to generate launcher logs under the new "PCL CE 启动器日志.txt" filename to distinguish them from other logs.
- Extend crash log preparation logic to recognize the new "PCL CE 启动器日志.txt" filename as a standard launcher log rather than an extra log.

</details>