### PR TITLE
chore(bump): 2.15.0 release

### DIFF
--- a/Plain Craft Launcher 2/metadata.json
+++ b/Plain Craft Launcher 2/metadata.json
@@ -3,15 +3,15 @@
   "version": {
     "base": "2.15.0",
     "upstream": "2.12.1",
-    "suffix": "beta.7",
-    "code": 521
+    "suffix": "",
+    "code": 522
   },
   "licenses": [
     {
       "name": "PCL.Core",
       "info": "Copyright © PCL Community",
-      "website": "https://github.com/PCL-Community/PCL2-CE/tree/dev/PCL.Core",
-      "license": "https://github.com/PCL-Community/PCL2-CE/blob/dev/LICENSE"
+      "website": "https://github.com/PCL-Community/PCL-CE/tree/dev/PCL.Core",
+      "license": "https://github.com/PCL-Community/PCL-CE/blob/dev/LICENSE"
     },
     {
       "name": "LegacyFix",


### PR DESCRIPTION
更新版本号，并顺手更新了一个链接

考虑到 CurseForge 对下载 API 的 Key 要求即将在 2026.07.14 生效，2.15.0 正式版将在 13 / 14 日推出，若有问题再后续跟进修复

## Summary by Sourcery

增强功能：
- 刷新启动器元数据，以反映 2.15.0 版本发布以及当前的下载链接要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refresh launcher metadata to reflect the 2.15.0 release and current download link requirements.

</details>