### PR TITLE
fix: 将内存与下载限速的单位标签更正为 IEC 单位

### DIFF
--- a/Plain Craft Launcher 2/Modules/Base/ModBase.cs
+++ b/Plain Craft Launcher 2/Modules/Base/ModBase.cs
@@ -3603,7 +3603,7 @@ public static class ModBase
             var info = $"""
                 [System] Diagnostic Information:
                 OS: {RuntimeInformation.OSDescription} (32-bit: {SystemInfo.Is32BitSystem})
-                Memory: {availableMb} MB / {totalMb} MB
+                Memory: {availableMb} MiB / {totalMb} MiB
                 DPI: {dpi} ({dpiScale * 100}%)
                 MC Folder: {ModFolder.mcFolderSelected ?? "Nothing"}
                 Executable Path: {exePath}

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -3566,8 +3566,8 @@ public static class ModLaunch
         var launchRamGb = PageInstanceSetup.GetRam(ModInstanceList.McMcInstanceSelected,
             !mcLaunchJavaSelected.Installation.Is64Bit);
         McLaunchLog("分配的内存：" +
-                    launchRamGb.ToString("N1", CultureInfo.InvariantCulture) + " GB（" +
-                    Math.Round(launchRamGb * 1024d).ToString("N0", CultureInfo.InvariantCulture) + " MB）");
+                    launchRamGb.ToString("N1", CultureInfo.InvariantCulture) + " GiB（" +
+                    Math.Round(launchRamGb * 1024d).ToString("N0", CultureInfo.InvariantCulture) + " MiB）");
         McLaunchLog("MC 文件夹：" + ModFolder.mcFolderSelected);
         McLaunchLog("实例文件夹：" + ModInstanceList.McMcInstanceSelected.PathInstance);
         McLaunchLog("版本隔离：" + ((ModInstanceList.McMcInstanceSelected.PathIndie ?? "") ==

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupGameManage.xaml.cs
@@ -131,11 +131,11 @@ public partial class PageSetupGameManage
             switch (value)
             {
                 case <= 14:
-                    return Lang.Number((value + 1) * 0.1d, "N1") + " M/s";
+                    return Lang.Number((value + 1) * 0.1d, "N1") + " MiB/s";
                 case <= 31:
-                    return Lang.Number((value - 11) * 0.5d, "N1") + " M/s";
+                    return Lang.Number((value - 11) * 0.5d, "N1") + " MiB/s";
                 case <= 41:
-                    return Lang.Number(value - 21, "N0") + " M/s";
+                    return Lang.Number(value - 21, "N0") + " MiB/s";
                 default:
                     return Lang.Text("Setup.GameManage.Download.Unlimited");
             }

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUpdate.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUpdate.xaml
@@ -153,7 +153,7 @@
                         <!--<local:MyImage x:Name="ImgUpdateIcon" FallbackSource="pack://application:,,,/images/icon.ico" Source="https://www.pclc.cc/img/pcl-ce/icon.webp" Grid.Column="0" Grid.Row="0" Grid.RowSpan="3" Height="50" Width="50" HorizontalAlignment="Left" VerticalAlignment="Center"/>-->
                         <TextBlock x:Name="TextOptionalUpdateName" Text="AquaCL 3.0.0" FontWeight="Bold" FontSize="20"
                                    Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
-                        <TextBlock x:Name="TextOptionalUpdateDesc" Text="20.0 MB" FontSize="14" Grid.Row="2"
+                        <TextBlock x:Name="TextOptionalUpdateDesc" Text="20.0 MiB" FontSize="14" Grid.Row="2"
                                    Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Top" />
                         <local:MyButton x:Name="BtnOptionalUpdate" Text="{DynamicResource Setup.Update.Install}" ColorType="Highlight" Grid.Row="0"
                                         Grid.RowSpan="2" Grid.Column="3" HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Summary by Sourcery

在启动器中，纠正用于显示内存和下载速度的 IEC 单位标签。

Bug Fixes:
- 将启动日志和诊断信息中误标的内存大小单位从十进制（GB/MB）修正为 IEC 单位（GiB/MiB）。
- 将设置页面中误标的下载速度单位从通用的每秒兆字节修正为 MiB/s。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct IEC unit labels used for memory and download speed displays across the launcher.

Bug Fixes:
- Fix mislabeled memory size units in launch logs and diagnostic information from decimal (GB/MB) to IEC (GiB/MiB).
- Fix mislabeled download speed units on the setup page from generic megabytes per second to MiB/s.

</details>