### PR TITLE
fix: 修正服务器玩家列表 tooltip 触发位置

### DIFF
--- a/Plain Craft Launcher 2/Controls/MinecraftServer.xaml
+++ b/Plain Craft Launcher 2/Controls/MinecraftServer.xaml
@@ -15,6 +15,10 @@
     <TextBlock Grid.Column="1" Margin="6" x:Name="LabServerDesc" TextWrapping="Wrap" FontSize="15" Foreground="White" />
     <controls:MotdRenderer Grid.Column="1" x:Name="MotdRenderer" Margin="0,20,3,1"
                            IsHitTestVisible="False" Width="300" Height="Auto" VerticalAlignment="Center" />
-    <TextBlock Grid.Column="2" Margin="6" x:Name="LabServerPlayer" TextWrapping="Wrap" TextAlignment="Right"
-               FontSize="12" Foreground="White" />
+    <StackPanel Grid.Column="2" Margin="6" HorizontalAlignment="Right">
+        <TextBlock x:Name="LabServerPlayer" HorizontalAlignment="Right" TextAlignment="Right"
+                   FontSize="12" Foreground="White" />
+        <TextBlock x:Name="LabServerLatency" HorizontalAlignment="Right" TextAlignment="Right"
+                   FontSize="12" Foreground="White" />
+    </StackPanel>
 </Grid>

--- a/Plain Craft Launcher 2/Controls/MinecraftServer.xaml.cs
+++ b/Plain Craft Launcher 2/Controls/MinecraftServer.xaml.cs
@@ -45,6 +45,7 @@ public partial class MinecraftServer : Grid
         LabServerDesc.Text = Lang.Text("Tools.ServerQuery.State.Querying");
         LabServerPlayer.Text = "-/-";
         LabServerPlayer.ToolTip = null;
+        LabServerLatency.Text = string.Empty;
         ImageLoaderHelper.SetFallbackImage(ImgServerLogo, fallbackImageUri);
 
         try
@@ -86,8 +87,8 @@ public partial class MinecraftServer : Grid
         MotdRenderer.RenderCanvas();
 
         // 更新玩家信息
-        var playerText = $"{ret.Players.Online}/{ret.Players.Max}{"\r\n"}§{latencyColor}{ret.Latency}ms";
-        ModStyle.MinecraftFormatter.SetColorfulTextLab(playerText, LabServerPlayer, false);
+        LabServerPlayer.Text = $"{ret.Players.Online}/{ret.Players.Max}";
+        ModStyle.MinecraftFormatter.SetColorfulTextLab($"§{latencyColor}{ret.Latency}ms", LabServerLatency, false);
 
         // 玩家列表提示
         if (ret.Players.Samples.Any())


### PR DESCRIPTION
close #3420

## Summary by Sourcery

将服务器延迟显示从玩家数量标签中分离出来，以修正服务器玩家列表的工具提示行为。

Bug Fixes:
- 在开始新的服务器信息查询时重置服务器延迟标签，以避免延迟数值过期不更新的问题。

Enhancements:
- 使用独立的标签分别显示玩家数量和延迟，而不是将它们组合在一起，从而提升服务器状态 UI 的清晰度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate server latency display from the player count label to correct tooltip behavior for the server player list.

Bug Fixes:
- Reset the server latency label when starting a new server info query to avoid stale latency values.

Enhancements:
- Display player count and latency in dedicated labels instead of combining them, improving clarity of the server status UI.

</details>