### PR TITLE
fix: 26.x版本mc启动时，缺失Java提示的弹窗始终为Java1

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.cs
@@ -1876,7 +1876,7 @@ public static class ModLaunch
         if (recommendedCode >= 22)
         {
             McLaunchLog("Mojang 要求至少使用 Java " + recommendedCode);
-            minVer = new Version(1, recommendedCode, 0, 0);
+            minVer = new Version(recommendedCode, 0, 0, 0);
             recommendedComponent =
                 ModInstanceList.McMcInstanceSelected.JsonObject?["javaVersion"]?["component"]?.ToString() ??
                 ModInstanceList.McMcInstanceSelected.JsonVersion?["java_component"]?.ToString();


### PR DESCRIPTION
close #3425

## Summary by Sourcery

Bug Fixes:
- 修复最低 Java 版本计算逻辑，使其使用所需的 Java 主版本号，而不是始终假定为 Java 1.x。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix minimum Java version calculation so the required Java major version is used instead of always assuming Java 1.x.

</details>