### PR TITLE
fix(download): 修复 Minecraft 更新提示弹窗按 ESC 打开 Wiki

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.cs
@@ -2477,11 +2477,12 @@ public static class ModDownload
                                  ? Lang.Text("Minecraft.Update.UpdateTime") + Lang.Date(time)
                                  : Lang.Text("Minecraft.Update.UpdatedAt") + Lang.TimeSpan(time - DateTime.Now));
             var msgResult = ModMain.MyMsgBox(msgBoxText, Lang.Text("Minecraft.Update.Title"),
-                Lang.Text("Common.Action.Confirm"), Lang.Text("Common.Action.Download"),
+                Lang.Text("Common.Action.Download"),
                 (DateTime.Now - time).TotalHours > 3d ? Lang.Text("Common.Action.UpdateLog") : "",
-                button3Action: () => ModDownloadLib.McUpdateLogShow(version));
+                Lang.Text("Common.Action.Cancel"),
+                button2Action: () => ModDownloadLib.McUpdateLogShow(version));
             // 弹窗结果
-            if (msgResult == 2)
+            if (msgResult == 1)
                 // 下载
                 ModBase.RunInUi(() =>
                 {


### PR DESCRIPTION
更新提示弹窗原按钮顺序为 [确认, 下载, 更新日志]。
将按钮重排为 [下载, 更新日志, 取消] 以解决 ESC 触发问题。
resolves #2626 

本PR由Opus 4.8对代码进行了审查。

## Summary by Sourcery

Bug Fixes:
- 修复 Minecraft 更新提示，使按下 ESC 键时关闭对话框，而不是打开更新日志/维基。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the Minecraft update prompt so that pressing ESC dismisses the dialog instead of opening the update log/wiki.

</details>