### PR TITLE
imp: 使“打包 PCL CE”不再被默认勾选

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml
@@ -234,7 +234,7 @@
                                 <local:ExportOption
                                     Title="{DynamicResource Instance.Export.Option.Launcher}"
                                     Description="{DynamicResource Instance.Export.Option.Launcher.Desc}"
-                                    DefaultChecked="True" />
+                                    DefaultChecked="False" />
                             </local:MyCheckBox.Tag>
                         </local:MyCheckBox>
                         <StackPanel Margin="30,0,0,0"

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -837,10 +837,10 @@ public partial class PageInstanceExport : IRefreshable
         if (packPath is null)
         {
             var extensions = new List<string>();
-            if (CheckOptionsPcl.Checked == false)
-                extensions.Add(Lang.Text("Instance.Export.MrpackFilter"));
             if (CheckAdvancedModrinth.Checked == false)
                 extensions.Add(Lang.Text("Instance.Export.ZipFilter"));
+            if (CheckOptionsPcl.Checked == false)
+                extensions.Add(Lang.Text("Instance.Export.MrpackFilter"));
             packPath = SystemDialogs.SelectSaveFile(Lang.Text("Instance.Export.SelectSaveLocation"),
                 packName + (string.IsNullOrEmpty(TextExportVersion.Text) ? "" : " " + TextExportVersion.Text),
                 extensions.Join("|"));

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.cs
@@ -679,7 +679,7 @@ public partial class PageInstanceExport : IRefreshable
             TextExportName.Text = ini.GetOrDefault("Name", "");
             TextExportVersion.Text = ini.GetOrDefault("Version", "");
             CheckOptionsPcl.Checked =
-                Convert.ToBoolean(ini.GetOrDefault("IncludeLauncher", true.ToString()));
+                Convert.ToBoolean(ini.GetOrDefault("IncludeLauncher", false.ToString()));
             CheckOptionsPclCustom.Checked =
                 Convert.ToBoolean(ini.GetOrDefault("IncludeLauncherCustom", true.ToString()));
             CheckAdvancedModrinth.Checked =
@@ -837,10 +837,10 @@ public partial class PageInstanceExport : IRefreshable
         if (packPath is null)
         {
             var extensions = new List<string>();
-            if (CheckAdvancedModrinth.Checked == false)
-                extensions.Add(Lang.Text("Instance.Export.ZipFilter"));
             if (CheckOptionsPcl.Checked == false)
                 extensions.Add(Lang.Text("Instance.Export.MrpackFilter"));
+            if (CheckAdvancedModrinth.Checked == false)
+                extensions.Add(Lang.Text("Instance.Export.ZipFilter"));
             packPath = SystemDialogs.SelectSaveFile(Lang.Text("Instance.Export.SelectSaveLocation"),
                 packName + (string.IsNullOrEmpty(TextExportVersion.Text) ? "" : " " + TextExportVersion.Text),
                 extensions.Join("|"));


### PR DESCRIPTION
勾选此选项时，导出产物无法被非 PCL/PCLCE 启动器直接安装，即便使用 PCL/PCLCE 启动器导入，亦仅能安装至空文件夹，仍需手动将 .mrpack 文件从压缩包中单独解压出来后再进行安装才能正常安装，带来不必要的操作步骤。因此将该选项默认设为不勾选，以减少不必要的困扰

## Summary by Sourcery

增强内容：
- 调整实例导出界面的默认设置，使针对 PCL CE 的打包从默认启用改为需要用户主动选择（opt-in）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust instance export UI defaults so that packaging for PCL CE is opt-in instead of enabled by default.

</details>