### PR TITLE
feat: 带启动器的压缩包含 .mrpack 时自动提取并作为 MR 整合包安装

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -117,11 +117,18 @@ public static class ModModpack
                         break;
                     } // HMCL 整合包
 
-                    if (archive.GetEntry("modpack.zip") is not null || archive.GetEntry("modpack.mrpack") is not null)
+                    if (archive.GetEntry("modpack.zip") is not null)
                     {
                         packType = 9;
                         break;
                     } // 带启动器的压缩包
+
+                    if (archive.GetEntry("modpack.mrpack") is not null)
+                    {
+                        var tempFile = Path.Combine(Paths.Temp, Guid.NewGuid() + ".mrpack");
+                        archive.GetEntry("modpack.mrpack").ExtractToFile(tempFile, overwrite: true);
+                        return ModpackInstall(tempFile);
+                    }
 
                     // 从一级目录判断整合包类型
                     var exitTry = false;
@@ -178,12 +185,19 @@ public static class ModModpack
                             break;
                         } // HMCL 整合包
 
-                        if (fullNames[1] == "modpack.zip" || fullNames[1] == "modpack.mrpack")
+                        if (fullNames[1] == "modpack.zip")
                         {
                             packType = 9;
                             exitTry = true;
                             break;
                         } // 带启动器的压缩包
+
+                        if (fullNames[1] == "modpack.mrpack")
+                        {
+                            var tempFile = Path.Combine(Paths.Temp, Guid.NewGuid() + ".mrpack");
+                            Entry.ExtractToFile(tempFile, overwrite: true);
+                            return ModpackInstall(tempFile);
+                        }
                     }
 
                     if (exitTry) break;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -70,6 +70,7 @@ public static class ModModpack
 
             // 获取整合包种类与关键 Json
             var packType = -1;
+            ZipArchiveEntry nestedModpackEntry = null;
             do
             {
                 try
@@ -123,11 +124,10 @@ public static class ModModpack
                         break;
                     } // 带启动器的压缩包
 
-                    if (archive.GetEntry("modpack.mrpack") is not null)
+                    nestedModpackEntry = archive.GetEntry("modpack.mrpack");
+                    if (nestedModpackEntry is not null)
                     {
-                        var tempFile = Path.Combine(Paths.Temp, Guid.NewGuid() + ".mrpack");
-                        archive.GetEntry("modpack.mrpack").ExtractToFile(tempFile, overwrite: true);
-                        return ModpackInstall(tempFile);
+                        break;
                     }
 
                     // 从一级目录判断整合包类型
@@ -194,9 +194,9 @@ public static class ModModpack
 
                         if (fullNames[1] == "modpack.mrpack")
                         {
-                            var tempFile = Path.Combine(Paths.Temp, Guid.NewGuid() + ".mrpack");
-                            Entry.ExtractToFile(tempFile, overwrite: true);
-                            return ModpackInstall(tempFile);
+                            nestedModpackEntry = Entry;
+                            exitTry = true;
+                            break;
                         }
                     }
 
@@ -212,6 +212,15 @@ public static class ModModpack
                         throw new Exception(Lang.Text("Minecraft.Download.Modpack.UnsupportedArchive"), ex);
                 }
             } while (false);
+
+            if (nestedModpackEntry is not null)
+            {
+                var tempFile = Path.Combine(ModMain.RequestTaskTempFolder(), "modpack.mrpack");
+                nestedModpackEntry.ExtractToFile(tempFile, overwrite: true);
+                archive.Dispose();
+                archive = null;
+                return ModpackInstall(tempFile, instanceName, logo, resourceId, isOnlineInstall);
+            }
 
             // 执行对应的安装方法
             switch (packType)


### PR DESCRIPTION
此 PR 旨在使打包了启动器且包含 .mrpack 的整合包绕过问题重重的 InstallPackLauncherPack 方法直接提取 .mrpack 并作为正常的 MR 整合包进行安装（modpack.zip 因为无法完整确定其具体情况不敢贸然进行修改故仍然保持原样）

## Summary by Sourcery

增强功能：
- 在启动器包中将对 `modpack.zip` 的检测与对 `modpack.mrpack` 的检测分离，当存在 `modpack.mrpack` 时，直接采用正常的 MR 整合包安装流程进行短路处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Separate detection of modpack.zip from modpack.mrpack in launcher bundles and short-circuit to normal MR modpack installation when a modpack.mrpack is present.

</details>