### PR TITLE
fix: 版本识别功能修复

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
@@ -307,7 +307,7 @@ namespace PCL;
 
             //XXwYY的快照
             // 按年份估算
-            if (segments.Length == 1 && segments[0].Length >= 3
+            if (allowSnapshot && segments.Length == 1 && segments[0].Length >= 3
                 && segments[0][2] == 'w'
                 && char.IsDigit(segments[0][0]) && char.IsDigit(segments[0][1]))
             {

--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
@@ -287,24 +287,45 @@ namespace PCL;
 
         /// <summary>
         ///     尝试将版本字符串转换为 Drop 序数。
-        ///     若无法转换则返回 0。
+        ///     若无法转换则返回 -1。
         /// </summary>
         public static int VersionToDrop(string? version, bool allowSnapshot = false)
         {
-            if (!allowSnapshot && version.Contains("-"))
-                return 0;
-            if (version is null)
-                return 0;
-            var segments = version.BeforeFirst("-").Split(".");
+            if (string.IsNullOrEmpty(version))
+                return -1;
+
+            var lower = version.ToLowerInvariant();
+
+            if (lower.StartsWith("1.rv")) return 90;           // 1.rv-pre1,约1.9
+            if (lower.StartsWith("3d shareware")) return 140;  // 3d shareware v1.34,约1.14
+
+            if (!allowSnapshot && lower.Contains('-'))
+                return -1;
+
+            var baseVer = lower.BeforeFirst("-");
+            var segments = baseVer.Split('.');
+
+            //XXwYY的快照
+            // 按年份估算
+            if (segments.Length == 1 && segments[0].Length >= 3
+                && segments[0][2] == 'w'
+                && char.IsDigit(segments[0][0]) && char.IsDigit(segments[0][1]))
+            {
+                var year = int.Parse(segments[0][..2]);
+                if (year <= 16) return Math.Max(year * 10 - 70, 20);
+                if (year == 17) return 120;
+                return Math.Min(130 + (year - 18) * 10, 210);
+            }
+
             if (segments.Length < 2)
-                return 0;
+                return -1;
             var major = (int)Math.Round(ModBase.Val(segments[0]));
             var minor = (int)Math.Round(ModBase.Val(segments[1]));
             if (major == 1) return minor * 10;
+            if (major >= 25) return major * 10 + minor;
+            if (major == 2) return 50; //2.0愚人节
 
-            if (major < 25) return 0;
-
-            return major * 10 + minor;
+            return -1;
         }
 
         /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
@@ -1157,7 +1157,12 @@ public partial class PageDownloadCompDetail
         if (foldOld && McInstanceInfo.VersionToDrop(name, true) < 120)
             return Lang.Text("Download.Comp.Detail.VersionGroup.Old");
         if (groupedByDrop)
-            return McInstanceInfo.DropToVersion(McInstanceInfo.VersionToDrop(name, true));
+        {
+            var drop = McInstanceInfo.VersionToDrop(name, true);
+            if (drop >= 0)
+                return McInstanceInfo.DropToVersion(drop);
+            return name;
+        }
 
         return name;
     }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -515,8 +515,7 @@ public partial class PageDownloadInstall
         }
 
         // NeoForge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName)
-            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -402,6 +402,7 @@ public partial class PageDownloadInstall
         }
         else
         {
+            CardOptiFine.Visibility = Visibility.Visible;
             var optiFineError = LoadOptiFineGetError();
             CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
             if (optiFineError is not null)

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -394,28 +394,37 @@ public partial class PageDownloadInstall
         SelectNameUpdate();
         ImgLogo.Source = GetSelectLogo();
         // OptiFine
-        var optiFineError = LoadOptiFineGetError();
-        CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
-        if (optiFineError is not null)
-            CardOptiFine.IsSwapped = true; // 例如在同时展开卡片时选择了不兼容项则强制折叠
-        SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
-        if (selectedOptiFine is null)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.7.2"))
         {
-            BtnOptiFineClear.Visibility = Visibility.Collapsed;
-            ImgOptiFine.Visibility = Visibility.Collapsed;
-            LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
-            LabOptiFine.Foreground = ThemeManager.colorGray4;
+            CardOptiFine.Visibility = Visibility.Collapsed;
         }
         else
         {
-            BtnOptiFineClear.Visibility = Visibility.Visible;
-            ImgOptiFine.Visibility = Visibility.Visible;
-            LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
-            LabOptiFine.Foreground = ThemeManager.colorGray1;
+            var optiFineError = LoadOptiFineGetError();
+            CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
+            if (optiFineError is not null)
+                CardOptiFine.IsSwapped = true;
+            SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
+            if (selectedOptiFine is null)
+            {
+                BtnOptiFineClear.Visibility = Visibility.Collapsed;
+                ImgOptiFine.Visibility = Visibility.Collapsed;
+                LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
+                LabOptiFine.Foreground = ThemeManager.colorGray4;
+            }
+            else
+            {
+                BtnOptiFineClear.Visibility = Visibility.Visible;
+                ImgOptiFine.Visibility = Visibility.Visible;
+                LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
+                LabOptiFine.Foreground = ThemeManager.colorGray1;
+            }
         }
 
         // LiteLoader
-        if (VanillaDrop >= 130)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.5.2")
+            || !McVersionComparer.CompareVersionGe("1.12.2", _vanillaName))
         {
             CardLiteLoader.Visibility = Visibility.Collapsed;
         }
@@ -444,7 +453,8 @@ public partial class PageDownloadInstall
         }
 
         // Forge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName))
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
         {
             CardForge.Visibility = Visibility.Collapsed;
         }
@@ -502,7 +512,8 @@ public partial class PageDownloadInstall
         }
 
         // NeoForge
-        if (VanillaDrop is > 0 and < 200) // 匹配 1.20.1+ 与一些愚人节版本
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }
@@ -531,7 +542,8 @@ public partial class PageDownloadInstall
         }
 
         // Fabric
-        if (VanillaDrop < 0 || VanillaDrop <= 130)
+        if (VanillaDrop < 130 
+            || (VanillaDrop == 130 && !McVersionComparer.CompareVersionGe(_vanillaName, "18w43b")))
         {
             CardFabric.Visibility = Visibility.Collapsed;
         }
@@ -590,7 +602,7 @@ public partial class PageDownloadInstall
         }
 
         // LegacyFabric
-        if (VanillaDrop > 130)
+        if (VanillaDrop < 30 || VanillaDrop > 130)
         {
             CardLegacyFabric.Visibility = Visibility.Collapsed;
         }
@@ -650,7 +662,8 @@ public partial class PageDownloadInstall
         }
 
         // LabyMod
-        if (VanillaDrop < 80)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName) 
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
         {
             CardLabyMod.Visibility = Visibility.Collapsed;
         }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -391,6 +391,8 @@ public partial class PageDownloadInstall
             return;
         _ReloadSelected_Ongoing = true;
         // 主预览
+        try
+        {
         SelectNameUpdate();
         ImgLogo.Source = GetSelectLogo();
         // OptiFine
@@ -766,7 +768,11 @@ public partial class PageDownloadInstall
         else
             HintModOptiFine.Visibility = Visibility.Collapsed;
         // 结束
-        _ReloadSelected_Ongoing = false;
+        }
+        finally
+        {
+            _ReloadSelected_Ongoing = false;
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -436,6 +436,8 @@ public partial class PageInstanceInstall
         if (_vanillaName is null || _ReloadSelected_Ongoing)
             return;
         _ReloadSelected_Ongoing = true;
+        try
+        {
         var selectedInfo = GetSelectInfo();
         // 主预览
         ItemSelect.Title = PageInstanceLeft.McInstance.Name;
@@ -461,28 +463,37 @@ public partial class PageInstanceInstall
         LabMinecraft.Text = _vanillaName;
         LabMinecraft.Foreground = ThemeManager.colorGray1;
         // OptiFine
-        var optiFineError = LoadOptiFineGetError();
-        CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
-        if (optiFineError is not null)
-            CardOptiFine.IsSwapped = true; // 例如在同时展开卡片时选择了不兼容项则强制折叠
-        SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
-        if (selectedOptiFine is null)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.7.2"))
         {
-            BtnOptiFineClear.Visibility = Visibility.Collapsed;
-            ImgOptiFine.Visibility = Visibility.Collapsed;
-            LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
-            LabOptiFine.Foreground = ThemeManager.colorGray4;
+            CardOptiFine.Visibility = Visibility.Collapsed;
         }
         else
         {
-            BtnOptiFineClear.Visibility = Visibility.Visible;
-            ImgOptiFine.Visibility = Visibility.Visible;
-            LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
-            LabOptiFine.Foreground = ThemeManager.colorGray1;
+            var optiFineError = LoadOptiFineGetError();
+            CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
+            if (optiFineError is not null)
+                CardOptiFine.IsSwapped = true;
+            SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
+            if (selectedOptiFine is null)
+            {
+                BtnOptiFineClear.Visibility = Visibility.Collapsed;
+                ImgOptiFine.Visibility = Visibility.Collapsed;
+                LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
+                LabOptiFine.Foreground = ThemeManager.colorGray4;
+            }
+            else
+            {
+                BtnOptiFineClear.Visibility = Visibility.Visible;
+                ImgOptiFine.Visibility = Visibility.Visible;
+                LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
+                LabOptiFine.Foreground = ThemeManager.colorGray1;
+            }
         }
 
         // LiteLoader
-        if (VanillaDrop >= 130)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.5.2")
+            || !McVersionComparer.CompareVersionGe("1.12.2", _vanillaName))
         {
             CardLiteLoader.Visibility = Visibility.Collapsed;
         }
@@ -511,7 +522,8 @@ public partial class PageInstanceInstall
         }
 
         // Forge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName))
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
         {
             CardForge.Visibility = Visibility.Collapsed;
         }
@@ -569,7 +581,8 @@ public partial class PageInstanceInstall
         }
 
         // NeoForge
-        if (VanillaDrop is > 0 and < 200) // 匹配 1.20.1+ 与一些愚人节版本
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }
@@ -598,7 +611,8 @@ public partial class PageInstanceInstall
         }
 
         // Fabric
-        if (VanillaDrop < 0 || VanillaDrop <= 130)
+        if (VanillaDrop < 130
+            || (VanillaDrop == 130 && !McVersionComparer.CompareVersionGe(_vanillaName, "18w43b")))
         {
             CardFabric.Visibility = Visibility.Collapsed;
         }
@@ -657,7 +671,7 @@ public partial class PageInstanceInstall
         }
 
         // LegacyFabric
-        if (VanillaDrop > 130)
+        if (VanillaDrop < 30 || VanillaDrop > 130)
         {
             CardLegacyFabric.Visibility = Visibility.Collapsed;
         }
@@ -717,7 +731,7 @@ public partial class PageInstanceInstall
         }
 
         // LabyMod
-        if (VanillaDrop < 80)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
         {
             CardLabyMod.Visibility = Visibility.Collapsed;
         }
@@ -820,7 +834,11 @@ public partial class PageInstanceInstall
         else
             HintModOptiFine.Visibility = Visibility.Collapsed;
         // 结束
-        _ReloadSelected_Ongoing = false;
+        }
+        finally
+        {
+            _ReloadSelected_Ongoing = false;
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -731,7 +731,8 @@ public partial class PageInstanceInstall
         }
 
         // LabyMod
-        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
         {
             CardLabyMod.Visibility = Visibility.Collapsed;
         }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -469,6 +469,7 @@ public partial class PageInstanceInstall
         }
         else
         {
+            CardOptiFine.Visibility = Visibility.Visible;
             var optiFineError = LoadOptiFineGetError();
             CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
             if (optiFineError is not null)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -582,8 +582,7 @@ public partial class PageInstanceInstall
         }
 
         // NeoForge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName)
-            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }


### PR DESCRIPTION
## 修改内容

- 修复VersionToDrop，ReloadSelected的版本识别逻辑
- 调整GetGroupedVersionName使它适配现在VersionToDrop识别失败时的return -1

## 测试情况

- 已运行 `dotnet build`
- 已在本地验证下载界面的功能，模组加载器选项正常显示，正常安装
Close #3437

## Summary by Sourcery

修复 Minecraft 安装和下载页面中的版本识别以及加载器可见性逻辑。

Bug 修复：
- 修正版本到“drop”的转换逻辑：对于无法识别或不受支持的版本字符串返回 -1，并正确处理特殊的快照版本和整蛊版本。
- 调整分组版本命名：当“drop”转换失败时回退到原始名称，而不是生成无效的分组名称。
- 修复 OptiFine、LiteLoader、Forge、NeoForge、Fabric、LegacyFabric 和 LabyMod 的可见性条件，使其依赖于明确的版本比较和格式检查，而不是错误的“drop”范围。
- 防止 `ReloadSelected` 在执行完成后仍保持“进行中”状态标志：通过使用 try/finally 包装其逻辑来确保状态被正确清理。

增强功能：
- 对齐功能可用性阈值（例如，最低支持的 Minecraft 版本），通过集中化的版本比较工具来实现更健壮的版本处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix version recognition and loader visibility logic for Minecraft installation and download pages.

Bug Fixes:
- Correct version-to-drop conversion to return -1 for unrecognized or unsupported version strings and handle special snapshot and joke versions.
- Adjust grouped version naming to fall back to the original name when drop conversion fails instead of producing invalid groups.
- Fix OptiFine, LiteLoader, Forge, NeoForge, Fabric, LegacyFabric, and LabyMod visibility conditions to rely on explicit version comparisons and format checks rather than incorrect drop ranges.
- Prevent ReloadSelected from leaving its ongoing-state flag set by wrapping its logic in a try/finally block.

Enhancements:
- Align feature availability thresholds (e.g., minimum supported Minecraft versions) using centralized version comparison utilities for more robust version handling.

</details>