### PR TITLE
fix: Cleanroom实例下载模组不会自动选择当前实例

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3654,6 +3654,8 @@ public static class ModComp
         // 加载器判定
         if (allowedLoaders.Count == 0) return true; // 无要求
         if (allowedLoaders.Contains(CompLoaderType.Forge) && version.Info.HasForge) return true;
+        if (allowedLoaders.Contains(CompLoaderType.Forge) && version.Info.HasCleanroom) 
+            return true;
         if (allowedLoaders.Contains(CompLoaderType.Fabric) &&
             (version.Info.HasFabric || version.Info.HasLegacyFabric)) return true;
         if (allowedLoaders.Contains(CompLoaderType.NeoForge) && version.Info.HasNeoForge) return true;

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -429,7 +429,7 @@ public partial class PageDownloadCompDetail
                             var targetLoaders = new List<ModComp.CompLoaderType>();
                             if (targetInstance is not null)
                             {
-                                if (targetInstance.Info.HasForge)
+                                if (targetInstance.Info.HasForge || targetInstance.Info.HasCleanroom)
                                     targetLoaders.Add(ModComp.CompLoaderType.Forge);
                                 if (targetInstance.Info.HasFabric || targetInstance.Info.HasLegacyFabric)
                                     targetLoaders.Add(ModComp.CompLoaderType.Fabric);

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -314,6 +314,8 @@ public partial class PageDownloadCompDetail
                         // 加载器判定
                         if (!allowedLoaders.Any()) return true; // 无要求
                         if (allowedLoaders.Contains(ModComp.CompLoaderType.Forge) && version.Info.HasForge) return true;
+                        if (allowedLoaders.Contains(ModComp.CompLoaderType.Forge) && version.Info.HasCleanroom) 
+                            return true;
                         if (allowedLoaders.Contains(ModComp.CompLoaderType.Fabric) &&
                             (version.Info.HasFabric || version.Info.HasLegacyFabric)) return true;
                         if (allowedLoaders.Contains(ModComp.CompLoaderType.NeoForge) && version.Info.HasNeoForge)


### PR DESCRIPTION
在下载forge模组时，将Cleanroom也作为允许的加载器
这是因为Cleanroom本就兼容forge模组，并且由于CF/MR没有为Cleanroom提供单独选项，所以专有模组也可能标记为forge

## Summary by Sourcery

错误修复：
- 修复实例选择逻辑，使 Cleanroom 实例在 Forge 标记的模组中被视为有效，从而体现它们的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix instance selection logic so Cleanroom instances are treated as valid for Forge-marked mods, reflecting their compatibility.

</details>