### PR TITLE
fix(network): 限制下载分块数与内存缓冲区上限，防止大文件下载导致内存溢出

### DIFF
--- a/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Downloader/FileDownloader.cs
@@ -78,11 +78,13 @@ public static class FileDownloader
         CleanupTempFiles(localPath);
 
         var perFileThreadLimit = enableParallelChunks ? Math.Max(1, ModNet.NetTaskThreadLimit) : 1;
+        // 限制最大分块数，防止大文件下载时内存爆炸
+        var chunkCount = Math.Min(perFileThreadLimit, 4);
         var configuration = new DownloadConfiguration
         {
-            ChunkCount = perFileThreadLimit,
-            ParallelCount = perFileThreadLimit,
-            ParallelDownload = perFileThreadLimit > 1,
+            ChunkCount = chunkCount,
+            ParallelCount = chunkCount,
+            ParallelDownload = chunkCount > 1,
             MaximumBytesPerSecond = ModNet.NetTaskSpeedLimitHigh > 0 ? ModNet.NetTaskSpeedLimitHigh : 0,
             MaxTryAgainOnFailure = 2,
             BlockTimeout = 60000,
@@ -90,6 +92,7 @@ public static class FileDownloader
             EnableAutoResumeDownload = false,
             CustomHttpClientFactory = () => GetHttpClient(url),
             MinimumSizeOfChunking = 1024 * 1024L,
+            MaximumMemoryBufferBytes = 256L * 1024 * 1024,
         };
 
         using var downloader = new DownloadService(configuration);

--- a/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
+++ b/Plain Craft Launcher 2/Modules/Network/Http/Requester.cs
@@ -145,14 +145,16 @@ public static class Requester
 
     public static DownloadService CreateDownloadService(string url, bool useBrowserUserAgent = false)
     {
+        var chunkCount = Math.Min(Math.Max(1, ModNet.NetTaskThreadLimit), 4);
         return new DownloadService(new DownloadConfiguration
         {
-            ChunkCount = Math.Max(1, ModNet.NetTaskThreadLimit),
-            ParallelCount = Math.Max(1, ModNet.NetTaskThreadLimit),
-            ParallelDownload = ModNet.NetTaskThreadLimit > 1,
+            ChunkCount = chunkCount,
+            ParallelCount = chunkCount,
+            ParallelDownload = chunkCount > 1,
             MaximumBytesPerSecond = ModNet.NetTaskSpeedLimitHigh > 0 ? ModNet.NetTaskSpeedLimitHigh : 0,
             DownloadFileExtension = ModNet.netDownloadEnd,
             EnableAutoResumeDownload = false,
+            MaximumMemoryBufferBytes = 256L * 1024 * 1024,
             RequestConfiguration = DownloadRequestFactory.Create(url, useBrowserUserAgent)
         });
     }


### PR DESCRIPTION
## 问题
  Downloader 库在下载大文件时，每个分块的数据会完全缓冲在内存中才刷入磁盘。
  默认配置下 ChunkCount 最高可达 16，对于 100GB 的文件（使用者反馈中的案例），内存和分页文件会被同时填满（~100GB）。

  ## 修复
  - ChunkCount/ParallelCount 上限由 16 降为 4
  - 新增 MaximumMemoryBufferBytes = 256MB，强制每个分块缓冲达到 256MB 时刷入磁盘
  - 理论最大内存占用：4 × 256MB = 1GB

  ## 修改文件
  - `Modules/Network/Downloader/FileDownloader.cs`
  - `Modules/Network/Http/Requester.cs`

## Summary by Sourcery

限制并行下载分块和内存缓冲，以防止在大文件下载过程中出现过度的 RAM 使用。

Bug 修复：
- 将每个文件的分块数和并行下载数上限设为 4，以减少大文件下载时的内存使用。
- 在下载器的 HTTP 配置中，为每个分块引入 256MB 的最大内存缓冲区，上限达到后会将数据刷新写入磁盘。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit parallel download chunking and memory buffering to prevent excessive RAM usage during large file downloads.

Bug Fixes:
- Cap per-file chunk and parallel download counts at 4 to reduce memory usage for large downloads.
- Introduce a 256MB maximum in-memory buffer per chunk before flushing data to disk in downloader HTTP configuration.

</details>

Closes #3457