### PR TITLE
Fix/skin

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
@@ -307,7 +307,7 @@ namespace PCL;
 
             //XXwYY的快照
             // 按年份估算
-            if (segments.Length == 1 && segments[0].Length >= 3
+            if (allowSnapshot && segments.Length == 1 && segments[0].Length >= 3
                 && segments[0][2] == 'w'
                 && char.IsDigit(segments[0][0]) && char.IsDigit(segments[0][1]))
             {

--- a/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/McInstanceInfo.cs
@@ -287,24 +287,45 @@ namespace PCL;
 
         /// <summary>
         ///     尝试将版本字符串转换为 Drop 序数。
-        ///     若无法转换则返回 0。
+        ///     若无法转换则返回 -1。
         /// </summary>
         public static int VersionToDrop(string? version, bool allowSnapshot = false)
         {
-            if (!allowSnapshot && version.Contains("-"))
-                return 0;
-            if (version is null)
-                return 0;
-            var segments = version.BeforeFirst("-").Split(".");
+            if (string.IsNullOrEmpty(version))
+                return -1;
+
+            var lower = version.ToLowerInvariant();
+
+            if (lower.StartsWith("1.rv")) return 90;           // 1.rv-pre1,约1.9
+            if (lower.StartsWith("3d shareware")) return 140;  // 3d shareware v1.34,约1.14
+
+            if (!allowSnapshot && lower.Contains('-'))
+                return -1;
+
+            var baseVer = lower.BeforeFirst("-");
+            var segments = baseVer.Split('.');
+
+            //XXwYY的快照
+            // 按年份估算
+            if (segments.Length == 1 && segments[0].Length >= 3
+                && segments[0][2] == 'w'
+                && char.IsDigit(segments[0][0]) && char.IsDigit(segments[0][1]))
+            {
+                var year = int.Parse(segments[0][..2]);
+                if (year <= 16) return Math.Max(year * 10 - 70, 20);
+                if (year == 17) return 120;
+                return Math.Min(130 + (year - 18) * 10, 210);
+            }
+
             if (segments.Length < 2)
-                return 0;
+                return -1;
             var major = (int)Math.Round(ModBase.Val(segments[0]));
             var minor = (int)Math.Round(ModBase.Val(segments[1]));
             if (major == 1) return minor * 10;
+            if (major >= 25) return major * 10 + minor;
+            if (major == 2) return 50; //2.0愚人节
 
-            if (major < 25) return 0;
-
-            return major * 10 + minor;
+            return -1;
         }
 
         /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Eventing.Reader;
 using System.IO;
@@ -1157,7 +1157,12 @@ public partial class PageDownloadCompDetail
         if (foldOld && McInstanceInfo.VersionToDrop(name, true) < 120)
             return Lang.Text("Download.Comp.Detail.VersionGroup.Old");
         if (groupedByDrop)
-            return McInstanceInfo.DropToVersion(McInstanceInfo.VersionToDrop(name, true));
+        {
+            var drop = McInstanceInfo.VersionToDrop(name, true);
+            if (drop >= 0)
+                return McInstanceInfo.DropToVersion(drop);
+            return name;
+        }
 
         return name;
     }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -394,28 +394,37 @@ public partial class PageDownloadInstall
         SelectNameUpdate();
         ImgLogo.Source = GetSelectLogo();
         // OptiFine
-        var optiFineError = LoadOptiFineGetError();
-        CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
-        if (optiFineError is not null)
-            CardOptiFine.IsSwapped = true; // 例如在同时展开卡片时选择了不兼容项则强制折叠
-        SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
-        if (selectedOptiFine is null)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.7.2"))
         {
-            BtnOptiFineClear.Visibility = Visibility.Collapsed;
-            ImgOptiFine.Visibility = Visibility.Collapsed;
-            LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
-            LabOptiFine.Foreground = ThemeManager.colorGray4;
+            CardOptiFine.Visibility = Visibility.Collapsed;
         }
         else
         {
-            BtnOptiFineClear.Visibility = Visibility.Visible;
-            ImgOptiFine.Visibility = Visibility.Visible;
-            LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
-            LabOptiFine.Foreground = ThemeManager.colorGray1;
+            var optiFineError = LoadOptiFineGetError();
+            CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
+            if (optiFineError is not null)
+                CardOptiFine.IsSwapped = true;
+            SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
+            if (selectedOptiFine is null)
+            {
+                BtnOptiFineClear.Visibility = Visibility.Collapsed;
+                ImgOptiFine.Visibility = Visibility.Collapsed;
+                LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
+                LabOptiFine.Foreground = ThemeManager.colorGray4;
+            }
+            else
+            {
+                BtnOptiFineClear.Visibility = Visibility.Visible;
+                ImgOptiFine.Visibility = Visibility.Visible;
+                LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
+                LabOptiFine.Foreground = ThemeManager.colorGray1;
+            }
         }
 
         // LiteLoader
-        if (VanillaDrop >= 130)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.5.2")
+            || !McVersionComparer.CompareVersionGe("1.12.2", _vanillaName))
         {
             CardLiteLoader.Visibility = Visibility.Collapsed;
         }
@@ -444,7 +453,8 @@ public partial class PageDownloadInstall
         }
 
         // Forge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName))
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
         {
             CardForge.Visibility = Visibility.Collapsed;
         }
@@ -502,7 +512,8 @@ public partial class PageDownloadInstall
         }
 
         // NeoForge
-        if (VanillaDrop is > 0 and < 200) // 匹配 1.20.1+ 与一些愚人节版本
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }
@@ -531,7 +542,8 @@ public partial class PageDownloadInstall
         }
 
         // Fabric
-        if (VanillaDrop < 0 || VanillaDrop <= 130)
+        if (VanillaDrop < 130 
+            || (VanillaDrop == 130 && !McVersionComparer.CompareVersionGe(_vanillaName, "18w43b")))
         {
             CardFabric.Visibility = Visibility.Collapsed;
         }
@@ -590,7 +602,7 @@ public partial class PageDownloadInstall
         }
 
         // LegacyFabric
-        if (VanillaDrop > 130)
+        if (VanillaDrop < 30 || VanillaDrop > 130)
         {
             CardLegacyFabric.Visibility = Visibility.Collapsed;
         }
@@ -650,7 +662,8 @@ public partial class PageDownloadInstall
         }
 
         // LabyMod
-        if (VanillaDrop < 80)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName) 
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
         {
             CardLabyMod.Visibility = Visibility.Collapsed;
         }

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -391,6 +391,8 @@ public partial class PageDownloadInstall
             return;
         _ReloadSelected_Ongoing = true;
         // 主预览
+        try
+        {
         SelectNameUpdate();
         ImgLogo.Source = GetSelectLogo();
         // OptiFine
@@ -766,7 +768,11 @@ public partial class PageDownloadInstall
         else
             HintModOptiFine.Visibility = Visibility.Collapsed;
         // 结束
-        _ReloadSelected_Ongoing = false;
+        }
+        finally
+        {
+            _ReloadSelected_Ongoing = false;
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -436,6 +436,8 @@ public partial class PageInstanceInstall
         if (_vanillaName is null || _ReloadSelected_Ongoing)
             return;
         _ReloadSelected_Ongoing = true;
+        try
+        {
         var selectedInfo = GetSelectInfo();
         // 主预览
         ItemSelect.Title = PageInstanceLeft.McInstance.Name;
@@ -461,28 +463,37 @@ public partial class PageInstanceInstall
         LabMinecraft.Text = _vanillaName;
         LabMinecraft.Foreground = ThemeManager.colorGray1;
         // OptiFine
-        var optiFineError = LoadOptiFineGetError();
-        CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
-        if (optiFineError is not null)
-            CardOptiFine.IsSwapped = true; // 例如在同时展开卡片时选择了不兼容项则强制折叠
-        SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
-        if (selectedOptiFine is null)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.7.2"))
         {
-            BtnOptiFineClear.Visibility = Visibility.Collapsed;
-            ImgOptiFine.Visibility = Visibility.Collapsed;
-            LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
-            LabOptiFine.Foreground = ThemeManager.colorGray4;
+            CardOptiFine.Visibility = Visibility.Collapsed;
         }
         else
         {
-            BtnOptiFineClear.Visibility = Visibility.Visible;
-            ImgOptiFine.Visibility = Visibility.Visible;
-            LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
-            LabOptiFine.Foreground = ThemeManager.colorGray1;
+            var optiFineError = LoadOptiFineGetError();
+            CardOptiFine.MainSwap.Visibility = optiFineError is null ? Visibility.Visible : Visibility.Collapsed;
+            if (optiFineError is not null)
+                CardOptiFine.IsSwapped = true;
+            SetPanelVisibility(PanOptiFineInfo, CardOptiFine.IsSwapped);
+            if (selectedOptiFine is null)
+            {
+                BtnOptiFineClear.Visibility = Visibility.Collapsed;
+                ImgOptiFine.Visibility = Visibility.Collapsed;
+                LabOptiFine.Text = optiFineError ?? Lang.Text("Download.Install.State.CanAdd");
+                LabOptiFine.Foreground = ThemeManager.colorGray4;
+            }
+            else
+            {
+                BtnOptiFineClear.Visibility = Visibility.Visible;
+                ImgOptiFine.Visibility = Visibility.Visible;
+                LabOptiFine.Text = selectedOptiFine.DisplayName.Replace(_vanillaName + " ", "");
+                LabOptiFine.Foreground = ThemeManager.colorGray1;
+            }
         }
 
         // LiteLoader
-        if (VanillaDrop >= 130)
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.5.2")
+            || !McVersionComparer.CompareVersionGe("1.12.2", _vanillaName))
         {
             CardLiteLoader.Visibility = Visibility.Collapsed;
         }
@@ -511,7 +522,8 @@ public partial class PageInstanceInstall
         }
 
         // Forge
-        if (!McInstanceInfo.IsFormatFit(_vanillaName))
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
         {
             CardForge.Visibility = Visibility.Collapsed;
         }
@@ -569,7 +581,8 @@ public partial class PageInstanceInstall
         }
 
         // NeoForge
-        if (VanillaDrop is > 0 and < 200) // 匹配 1.20.1+ 与一些愚人节版本
+        if (!McInstanceInfo.IsFormatFit(_vanillaName)
+            || !McVersionComparer.CompareVersionGe(_vanillaName, "1.20.1"))
         {
             CardNeoForge.Visibility = Visibility.Collapsed;
         }
@@ -598,7 +611,8 @@ public partial class PageInstanceInstall
         }
 
         // Fabric
-        if (VanillaDrop < 0 || VanillaDrop <= 130)
+        if (VanillaDrop < 130
+            || (VanillaDrop == 130 && !McVersionComparer.CompareVersionGe(_vanillaName, "18w43b")))
         {
             CardFabric.Visibility = Visibility.Collapsed;
         }
@@ -657,7 +671,7 @@ public partial class PageInstanceInstall
         }
 
         // LegacyFabric
-        if (VanillaDrop > 130)
+        if (VanillaDrop < 30 || VanillaDrop > 130)
         {
             CardLegacyFabric.Visibility = Visibility.Collapsed;
         }
@@ -717,7 +731,7 @@ public partial class PageInstanceInstall
         }
 
         // LabyMod
-        if (VanillaDrop < 80)
+        if (!McVersionComparer.CompareVersionGe(_vanillaName, "1.8.9"))
         {
             CardLabyMod.Visibility = Visibility.Collapsed;
         }
@@ -820,7 +834,11 @@ public partial class PageInstanceInstall
         else
             HintModOptiFine.Visibility = Visibility.Collapsed;
         // 结束
-        _ReloadSelected_Ongoing = false;
+        }
+        finally
+        {
+            _ReloadSelected_Ongoing = false;
+        }
     }
 
     /// <summary>

--- a/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
@@ -336,8 +336,7 @@ public partial class MySkin
                 ModBase.WriteIni(ModBase.pathTemp + @"Cache\Skin\IndexMs.ini", ModProfile.selectedProfile.Uuid,
                     skinAddress);
                 ModBase.Log($"[Skin] 已写入皮肤地址缓存 {ModProfile.selectedProfile.Uuid} -> {skinAddress}");
-                foreach (var SkinLoader in new[] { PageLaunchLeft.skinMs, PageLaunchLeft.skinLegacy })
-                    SkinLoader.WaitForExit(isForceRestart: true);
+                PageLaunchLeft.skinMs.WaitForExit(isForceRestart: true);
                 HintService.Hint(Lang.Text("Launch.Skin.ChangeSuccess"), HintType.Success);
             }
             catch (Exception ex)


### PR DESCRIPTION
## 修改内容

- 修复MySkin.xaml.cs中更改皮肤后重启 skinMs，又重启 skinLegacy导致头像消失的问题
- 更改了MySkin.xaml.cs，不重启 skinLegacy

## 测试情况

- 已运行 `dotnet build`
- 已在本地验证更换皮肤
Close #3305

## Summary by Sourcery

优化 Minecraft 版本处理和安装器 UI 逻辑，并修复更换皮肤后皮肤重新加载的问题。

Bug 修复：
- 通过仅重启现代皮肤加载器而不是同时重启现代和旧版加载器，防止玩家头像在更换皮肤时消失。
- 在下载页面和实例安装页面中使用 `try/finally` 确保重置标志，避免 `ReloadSelected` 长时间处于进行中状态。
- 通过让 `VersionToDrop` 返回哨兵值，并在分组版本标签中回退到原始名称，更安全地处理无效或不受支持的 Minecraft 版本。

功能增强：
- 基于精确的版本范围和实例格式检查，收紧 OptiFine、LiteLoader、Forge、NeoForge、Fabric、LegacyFabric 和 LabyMod 卡片的可见性条件。
- 改进 `VersionToDrop`，以更好地支持快照版本和诸如愚人节版、共享软件版等特殊版本。
- 调整分组版本命名，以符合新的 `VersionToDrop` 约定，并避免错误分组不受支持的版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Minecraft version handling and installer UI logic while fixing a skin reload issue after changing skins.

Bug Fixes:
- Prevent player avatar disappearance when changing skins by only restarting the modern skin loader instead of both modern and legacy loaders.
- Avoid leaving ReloadSelected in an ongoing state by ensuring the flag is reset with try/finally in download and instance install pages.
- Handle invalid or unsupported Minecraft versions more safely by returning a sentinel value from VersionToDrop and falling back to the raw name in grouped version labels.

Enhancements:
- Tighten visibility conditions for OptiFine, LiteLoader, Forge, NeoForge, Fabric, LegacyFabric, and LabyMod cards based on precise version ranges and instance format checks.
- Improve VersionToDrop to better support snapshots and special versions such as April Fools and shareware builds.
- Adjust grouped version naming to respect the new VersionToDrop contract and avoid misgrouping unsupported versions.

</details>