### PR TITLE
fix: 修复正版验证更改皮肤后头像不显示

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
@@ -336,8 +336,7 @@ public partial class MySkin
                 ModBase.WriteIni(ModBase.pathTemp + @"Cache\Skin\IndexMs.ini", ModProfile.selectedProfile.Uuid,
                     skinAddress);
                 ModBase.Log($"[Skin] 已写入皮肤地址缓存 {ModProfile.selectedProfile.Uuid} -> {skinAddress}");
-                foreach (var SkinLoader in new[] { PageLaunchLeft.skinMs, PageLaunchLeft.skinLegacy })
-                    SkinLoader.WaitForExit(isForceRestart: true);
+                PageLaunchLeft.skinMs.WaitForExit(isForceRestart: true);
                 HintService.Hint(Lang.Text("Launch.Skin.ChangeSuccess"), HintType.Success);
             }
             catch (Exception ex)


### PR DESCRIPTION
## 修改内容

- 修复MySkin.xaml.cs中更改皮肤后重启 skinMs，又重启 skinLegacy导致头像消失的问题
- 更改了MySkin.xaml.cs，不重启 skinLegacy
Close #3305 
## 测试情况

- 已运行 `dotnet build`
- 已在本地验证更换皮肤

## 其他说明

- 我的文件不含BOM

## Summary by Sourcery

Bug Fixes:
- 通过在更换皮肤后避免不必要地重启旧版皮肤进程，防止头像消失。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent avatar disappearance by avoiding unnecessary restart of the legacy skin process after changing skins.

</details>