### PR TITLE
fix(launch-right): 改用 Path.Combine 拼接 hints.txt 路径

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.cs
@@ -283,7 +283,7 @@ public partial class PageLaunchRight : IRefreshable
         string[]? lines = null;
 
         // 外部文件
-        var externalPath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) + "\\PCL\\hints.txt";
+        var externalPath = Path.Combine(ModBase.exePath, "PCL", "hints.txt");
         if (File.Exists(externalPath))
         {
             try


### PR DESCRIPTION
close #3474

## Summary by Sourcery

Bug Fixes:
- 通过基于可执行文件路径使用 `Path.Combine` 替换手动字符串拼接，防止错误解析 `hints.txt` 的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect hints.txt path resolution by replacing manual string concatenation with Path.Combine based on the executable path.

</details>