### PR TITLE
fix(Install): 在26.x安装optifine时的若干问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.cs
@@ -32,7 +32,7 @@ public static class ModJava
     ///     必须在工作线程调用，且必须包括 SyncLock JavaLock。
     /// </summary>
     public static JavaEntry JavaSelect(string cancelException, Version minVersion = null, Version maxVersion = null,
-        McInstance relatedInstance = null)
+        McInstance relatedInstance = null, bool enforceVersionRange = false)
     {
         ModBase.Log(
             $"[Java] 要求选择合适 Java，要求最低版本 {(minVersion is not null ? minVersion.ToString() : "未指定")}，要求选择的最高版本 {(maxVersion is not null ? maxVersion.ToString() : "未指定")}，关联实例 {(relatedInstance is not null ? relatedInstance.Name : "未指定")}");
@@ -140,17 +140,27 @@ public static class ModJava
 
             if (candidate is not null && candidate.IsEnabled)
             {
-                if (!IsVersionSuitable(candidate.Installation.Version))
-                    HintService.Hint(_GetJavaRangeWarning(
-                        "Minecraft.Launch.Java.Compatibility.GlobalSelectedOutOfRange",
-                        candidate.Installation.Version,
-                        minVersion,
-                        maxVersion));
-                ModBase.Log($"[Java] 返回全局指定的 Java: {candidate}");
-                return candidate;
+                var versionSuitable = IsVersionSuitable(candidate.Installation.Version);
+                if (enforceVersionRange && !versionSuitable)
+                {
+                    ModBase.Log($"[Java] 全局指定的 Java 版本不满足强制范围要求，忽略并继续自动搜索: {candidate}");
+                }
+                else
+                {
+                    if (!versionSuitable)
+                        HintService.Hint(_GetJavaRangeWarning(
+                            "Minecraft.Launch.Java.Compatibility.GlobalSelectedOutOfRange",
+                            candidate.Installation.Version,
+                            minVersion,
+                            maxVersion));
+                    ModBase.Log($"[Java] 返回全局指定的 Java: {candidate}");
+                    return candidate;
+                }
             }
-
-            ModBase.Log($"[Java] 警告：全局指定的 Java 路径无效或不可用: {globalJavaPath}");
+            else
+            {
+                ModBase.Log($"[Java] 警告：全局指定的 Java 路径无效或不可用: {globalJavaPath}");
+            }
         }
         else
         {

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -709,14 +709,14 @@ public static class ModDownloadLib
         }
     }
 
-    private static void McDownloadOptiFineInstall(string baseMcFolderHome, string target, ModLoader.LoaderTask<List<DownloadFile>, bool> task, bool useJavaWrapper)
+    private static void McDownloadOptiFineInstall(string baseMcFolderHome, string target, ModLoader.LoaderTask<List<DownloadFile>, bool> task, bool useJavaWrapper, Version javaVersion)
     {
         // 选择 Java
         JavaEntry java;
         lock (ModJava.javaLock)
         {
             java = ModJava.JavaSelect(Lang.Text("Minecraft.Download.Error.InstallationCanceled"),
-                new Version(1, 8, 0, 0));
+                javaVersion);
             if (java is null)
             {
                 if (!ModJava.JavaDownloadConfirm(Lang.Text("Minecraft.Download.Error.JavaVersionRequired")))
@@ -736,7 +736,7 @@ public static class ModDownloadLib
 
                 // 检查下载结果
                 java = ModJava.JavaSelect(Lang.Text("Minecraft.Download.Error.InstallationCanceled"),
-                    new Version(1, 8, 0, 0));
+                        javaVersion);
                 if (task.IsAborted)
                     return;
                 if (java is null)
@@ -887,6 +887,9 @@ public static class ModDownloadLib
             ? $"{ModMain.RequestTaskTempFolder()}OptiFine.jar"
             : $@"{mcFolder}libraries\optifine\OptiFine\{downloadInfo.NameFile.Replace("OptiFine_", "").Replace(".jar", "").Replace("preview_", "")}\{downloadInfo.NameFile.Replace("OptiFine_", "OptiFine-").Replace("preview_", "")}";
         var loaders = new List<ModLoader.LoaderBase>();
+        var javaVersion = McVersionComparer.CompareVersionGe(downloadInfo.Inherit, "26.1.2")
+            ? new Version(21, 0, 0, 0)
+            : new Version(1, 8, 0, 0);
 
         // 获取下载地址
         loaders.Add(new ModLoader.LoaderTask<string, List<DownloadFile>>(
@@ -1015,7 +1018,7 @@ public static class ModDownloadLib
 
                     try
                     {
-                        McDownloadOptiFineInstall(baseMcFolderHome, target, task, useJavaWrapper);
+                        McDownloadOptiFineInstall(baseMcFolderHome, target, task, useJavaWrapper, javaVersion);
                     }
                     catch (Exception ex)
                     {

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -725,7 +725,7 @@ public static class ModDownloadLib
                 var javaLoader = ModJava.GetJavaDownloadLoader();
                 try
                 {
-                    javaLoader.Start(17, true);
+                    javaLoader.Start(21, true);
                     while (javaLoader.State == ModBase.LoadState.Loading && !task.IsAborted)
                         Thread.Sleep(10);
                 }

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -716,7 +716,7 @@ public static class ModDownloadLib
         lock (ModJava.javaLock)
         {
             java = ModJava.JavaSelect(Lang.Text("Minecraft.Download.Error.InstallationCanceled"),
-                javaVersion);
+                javaVersion, enforceVersionRange: true);
             if (java is null)
             {
                 if (!ModJava.JavaDownloadConfirm(Lang.Text("Minecraft.Download.Error.JavaVersionRequired")))
@@ -736,7 +736,7 @@ public static class ModDownloadLib
 
                 // 检查下载结果
                 java = ModJava.JavaSelect(Lang.Text("Minecraft.Download.Error.InstallationCanceled"),
-                        javaVersion);
+                        javaVersion, enforceVersionRange: true);
                 if (task.IsAborted)
                     return;
                 if (java is null)

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -722,10 +722,11 @@ public static class ModDownloadLib
                 if (!ModJava.JavaDownloadConfirm(Lang.Text("Minecraft.Download.Error.JavaVersionRequired")))
                     throw new Exception(Lang.Text("Minecraft.Download.Error.JavaNotFoundInstallCanceled"));
                 // 开始自动下载
+                var downloadJavaMajor = javaVersion.Major >= 9 ? javaVersion.Major : 8;
                 var javaLoader = ModJava.GetJavaDownloadLoader();
                 try
                 {
-                    javaLoader.Start(21, true);
+                    javaLoader.Start(downloadJavaMajor, true);
                     while (javaLoader.State == ModBase.LoadState.Loading && !task.IsAborted)
                         Thread.Sleep(10);
                 }

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -613,7 +613,7 @@ public static class ModDownloadLib
         {
             var id = downloadInfo.NameVersion;
             var versionFolder = Path.Combine(ModFolder.mcFolderSelected, "versions", id);
-            var isNewVersion = ModBase.Val(downloadInfo.Inherit.Split(".")[1]) >= 14d;
+            var isNewVersion = McVersionComparer.CompareVersionGe(downloadInfo.Inherit, "1.14");
             var target = isNewVersion
                 ? Path.Combine(ModBase.pathTemp, "Cache", "Code", downloadInfo.NameVersion + "_" + ModBase.GetUuid())
                 : Path.Combine(ModFolder.mcFolderSelected, "libraries", "optifine", "OptiFine",
@@ -882,7 +882,7 @@ public static class ModDownloadLib
         var isCustomFolder = (mcFolder ?? "") != (ModFolder.mcFolderSelected ?? "");
         var id = downloadInfo.NameVersion;
         var versionFolder = Path.Combine(mcFolder, "versions", id);
-        var isNewVersion = downloadInfo.Inherit.Contains("w") || ModBase.Val(downloadInfo.Inherit.Split(".")[1]) >= 14d;
+        var isNewVersion = downloadInfo.Inherit.Contains("w") || McVersionComparer.CompareVersionGe(downloadInfo.Inherit, "1.14");
         var target = isNewVersion
             ? $"{ModMain.RequestTaskTempFolder()}OptiFine.jar"
             : $@"{mcFolder}libraries\optifine\OptiFine\{downloadInfo.NameFile.Replace("OptiFine_", "").Replace(".jar", "").Replace("preview_", "")}\{downloadInfo.NameFile.Replace("OptiFine_", "OptiFine-").Replace("preview_", "")}";


### PR DESCRIPTION
修复了如下问题
- 无法正确判断26.x版本
- 在26.x错误地使用Java8，实际需要Java21

此外，为`ModJava.JavaSelect`添加了新的可选参数，声明其强制执行传入的版本要求，避免用户全局选择了旧Java导致安装崩溃

close #3470

## Summary by Sourcery

更新 OptiFine 安装逻辑，以正确处理 Minecraft 26.x 版本及其所需的 Java 版本。

Bug 修复：
- 通过使用共享的版本比较器（version comparer）而不是手动解析字符串，修正 OptiFine 安装的版本检测逻辑。
- 确保在 Minecraft 26.x 版本中安装 OptiFine 时使用 Java 21，而不是 Java 8。

增强项：
- 将 OptiFine 的版本检查统一到通用的 McVersionComparer 上，以便对现代版本进行一致的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update OptiFine installation logic to correctly handle Minecraft 26.x versions and required Java version.

Bug Fixes:
- Correct version detection for OptiFine installation by using the shared version comparer instead of manual string parsing.
- Ensure OptiFine installation for Minecraft 26.x uses Java 21 instead of Java 8.

Enhancements:
- Unify OptiFine version checks around the common McVersionComparer for consistent handling of modern versions.

</details>