### PR TITLE
feat(minecraft): 针对 Modrinth 添加下载原因追踪功能

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3660,7 +3660,12 @@ public static class ModComp
         var loaders = new List<ModLoader.LoaderBase>
         {
             new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadFile"),
-                new List<DownloadFile> { file.ToNetFile(target) })
+                new List<DownloadFile>
+                {
+                    file.Type == CompType.Mod
+                        ? file.ToNetFile(target)
+                        : file.ToNetFile(target, DownloadReason.Standalone, null)
+                })
             {
                 ProgressWeight = 6,
                 block = true

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3136,7 +3136,7 @@ public static class ModComp
         /// <returns>下载信息。</returns>
         public DownloadFile ToNetFile(string localAddress, DownloadReason reason = DownloadReason.Standalone)
         {
-            return ToNetFile(localAddress, reason, RawGameVersions[0], ModLoaders[0]);
+            return ToNetFile(localAddress, reason, RawGameVersions.FirstOrDefault(), ModLoaders.FirstOrDefault());
         }
         
         /// <summary>
@@ -3153,6 +3153,11 @@ public static class ModComp
             string? version,
             CompLoaderType modLoader = CompLoaderType.Any)
         {
+            if (DownloadUrls is null)
+            {
+                throw new InvalidCastException("DownloadUrls 为空");
+            }
+            
             return new DownloadFile(HandleModrinthDownloadUrls(DownloadUrls, reason, version, modLoader),
                 localAddress + (localAddress.EndsWithF(@"\") ? CompFileNameSanitize(FileName) : ""),
                 new ModBase.FileChecker(hash: Hash), true);

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -3183,11 +3183,15 @@ public static class ModComp
         {
             foreach (var url in urls)
             {
-                if (!url.Contains("modrinth", StringComparison.InvariantCultureIgnoreCase)) yield return url;
+                if (!url.Contains("modrinth", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    yield return url;
+                    continue;
+                }
 
                 var sb = new StringBuilder(url);
             
-                sb.Append("?mr_download_reason=");
+                sb.Append(url.Contains('?') ? "&mr_download_reason=" : "?mr_download_reason=");
                 sb.Append(reason.ToString().ToLowerInvariant());
 
                 if (version is not null)

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.IO;
 using System.IO.Compression;
@@ -206,6 +206,14 @@ public static class ModComp
         ///     用户取消安装
         /// </summary>        
         Cancel = 3,
+    }
+    
+    public enum DownloadReason
+    {
+        Standalone,
+        Dependency,
+        ModPack,
+        Update
     }
 
     public static string GetCompTypeName(CompType type) => Lang.Text(type switch
@@ -3121,12 +3129,32 @@ public static class ModComp
         public bool Available => FileName is not null && DownloadUrls is not null;
 
         /// <summary>
-        ///     获取下载信息。
+        /// 获取下载信息。
         /// </summary>
         /// <param name="localAddress">目标本地文件夹，或完整的文件路径。会自动判断类型。</param>
-        public DownloadFile ToNetFile(string localAddress)
+        /// <param name="reason">下载原因。</param>
+        /// <returns>下载信息。</returns>
+        public DownloadFile ToNetFile(string localAddress, DownloadReason reason = DownloadReason.Standalone)
         {
-            return new DownloadFile(DownloadUrls, localAddress + (localAddress.EndsWithF(@"\") ? CompFileNameSanitize(FileName) : ""),
+            return ToNetFile(localAddress, reason, RawGameVersions[0], ModLoaders[0]);
+        }
+        
+        /// <summary>
+        /// 获取下载信息。
+        /// </summary>
+        /// <param name="localAddress">目标本地文件夹，或完整的文件路径。会自动判断类型。</param>
+        /// <param name="reason">下载原因。</param>
+        /// <param name="version">实例版本。</param>
+        /// <param name="modLoader">实例的模组加载器。</param>
+        /// <returns>下载信息。</returns>
+        public DownloadFile ToNetFile(
+            string localAddress,
+            DownloadReason reason,
+            string? version,
+            CompLoaderType modLoader = CompLoaderType.Any)
+        {
+            return new DownloadFile(HandleModrinthDownloadUrls(DownloadUrls, reason, version, modLoader),
+                localAddress + (localAddress.EndsWithF(@"\") ? CompFileNameSanitize(FileName) : ""),
                 new ModBase.FileChecker(hash: Hash), true);
         }
 
@@ -3137,6 +3165,45 @@ public static class ModComp
         {
             return url.Replace("-service.overwolf.wtf", ".forgecdn.net").Replace("://media.", "://edge.")
                 .Replace("://mediafilez.", "://edge.");
+        }
+
+        /// <summary>
+        /// 对 Modrinth 下载链接添加上报参数。
+        /// </summary>
+        /// <param name="urls">下载链接。</param>
+        /// <param name="reason">下载原因。</param>
+        /// <param name="version">实例版本。</param>
+        /// <param name="modLoader">实例的模组加载器。</param>
+        /// <returns>处理后的下载链接。</returns>
+        public static IEnumerable<string> HandleModrinthDownloadUrls(
+            IEnumerable<string> urls,
+            DownloadReason reason = DownloadReason.Standalone,
+            string? version = null,
+            CompLoaderType modLoader = CompLoaderType.Any)
+        {
+            foreach (var url in urls)
+            {
+                if (!url.Contains("modrinth", StringComparison.InvariantCultureIgnoreCase)) yield return url;
+
+                var sb = new StringBuilder(url);
+            
+                sb.Append("?mr_download_reason=");
+                sb.Append(reason.ToString().ToLowerInvariant());
+
+                if (version is not null)
+                {
+                    sb.Append("&mr_game_version=");
+                    sb.Append(version);
+                }
+
+                if (modLoader != CompLoaderType.Any)
+                {
+                    sb.Append("&mr_loader=");
+                    sb.Append(modLoader.ToString().ToLowerInvariant());
+                }
+
+                yield return sb.ToString();
+            }
         }
 
         /// <summary>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModCompDependency.cs
@@ -205,7 +205,7 @@ public static class ModCompDependency
 
             var depFileName = ModComp.CompFileNameGet(depProject, depCompFile);
             var targetPath = Path.Combine(targetModsFolder ?? string.Empty, depFileName);
-            downloads.Add((depFileName, depCompFile.ToNetFile(targetPath)));
+            downloads.Add((depFileName, depCompFile.ToNetFile(targetPath, ModComp.DownloadReason.Dependency)));
         }
 
         return downloads;

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -379,6 +379,7 @@ public static class ModModpack
         string forgeVersion = null;
         string neoForgeVersion = null;
         string fabricVersion = null;
+        var modLoader = ModComp.CompLoaderType.Any;
         foreach (var Entry in (dynamic)json["minecraft"]["modLoaders"] ?? Array.Empty<JsonNode>())
         {
             string id = (Entry["id"] ?? "").ToString().ToLower();
@@ -389,12 +390,14 @@ public static class ModModpack
                     throw new Exception(Lang.Text("Minecraft.Download.Modpack.TooOldUnsupported"));
                 ModBase.Log("[ModPack] 整合包 Forge 版本：" + id);
                 forgeVersion = id.Replace("forge-", "");
+                modLoader = ModComp.CompLoaderType.Forge;
             }
             else if (id.StartsWithF("neoforge-"))
             {
                 // NeoForge 指定
                 ModBase.Log("[ModPack] 整合包 NeoForge 版本：" + id);
                 neoForgeVersion = id.Replace("neoforge-", "");
+                modLoader = ModComp.CompLoaderType.NeoForge;
             }
             else if (id.StartsWithF("fabric-"))
             {
@@ -403,6 +406,7 @@ public static class ModModpack
                 {
                     ModBase.Log("[ModPack] 整合包 Fabric 版本：" + id);
                     fabricVersion = id.Replace("fabric-", "");
+                    modLoader = ModComp.CompLoaderType.Fabric;
                     break;
                 }
                 catch (Exception ex)
@@ -543,7 +547,8 @@ public static class ModModpack
                         continue;
                     // 实际的添加
                     fileList.Add(id,
-                        file.ToNetFile($@"{ModFolder.mcFolderSelected}versions\{instanceName}\{targetFolder}\"));
+                        file.ToNetFile($@"{ModFolder.mcFolderSelected}versions\{instanceName}\{targetFolder}\",
+                            ModComp.DownloadReason.ModPack, json["minecraft"]!["version"]!.ToString(), modLoader));
                     task.Progress += 1d / (1 + modList.Count);
                 }
 
@@ -676,6 +681,7 @@ public static class ModModpack
         string forgeVersion = null;
         string neoForgeVersion = null;
         string fabricVersion = null;
+        var modLoader = ModComp.CompLoaderType.Any;
         foreach (var Entry in json["dependencies"]?.AsObject() ?? new JsonObject())
             switch (Entry.Key.ToLower() ?? "")
             {
@@ -687,6 +693,7 @@ public static class ModModpack
                 case "forge": // eg. 14.23.5.2859 / 1.19-41.1.0
                 {
                     forgeVersion = Entry.Value?.ToObject<string>();
+                    modLoader = ModComp.CompLoaderType.Forge;
                     ModBase.Log("[ModPack] 整合包 Forge 版本：" + forgeVersion);
                     break;
                 }
@@ -694,12 +701,14 @@ public static class ModModpack
                 case "neo-forge": // eg. 20.6.98-beta
                 {
                     neoForgeVersion = Entry.Value?.ToObject<string>();
+                    modLoader = ModComp.CompLoaderType.NeoForge;
                     ModBase.Log("[ModPack] 整合包 NeoForge 版本：" + neoForgeVersion);
                     break;
                 }
                 case "fabric-loader": // eg. 0.14.14
                 {
                     fabricVersion = Entry.Value?.ToObject<string>();
+                    modLoader = ModComp.CompLoaderType.Fabric;
                     ModBase.Log("[ModPack] 整合包 Fabric 版本：" + fabricVersion);
                     break;
                 }
@@ -788,7 +797,9 @@ public static class ModModpack
                 throw new ModBase.CancelledException();
             }
 
-            fileList.Add(new DownloadFile(urls, targetPath,
+            fileList.Add(new DownloadFile(
+                ModComp.CompFile.HandleModrinthDownloadUrls(urls, ModComp.DownloadReason.ModPack, minecraftVersion,
+                    modLoader), targetPath,
                 new ModBase.FileChecker(actualSize: ((JsonNode)File["fileSize"]).ToObject<long>(),
                     hash: File["hashes"]["sha1"].ToString()), true));
         }

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -227,7 +227,11 @@ public partial class PageDownloadCompDetail
             var targetPath = target.BeforeLast(@"\");
             var logoFileAddress = MyImage.GetTempPath(_compItem.Logo);
             loaders.Add(new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadWorldFile"),
-                new List<DownloadFile> { file.ToNetFile(target) }) { ProgressWeight = 10d, block = true });
+                    new List<DownloadFile>
+                    {
+                        file.ToNetFile(target, ModComp.DownloadReason.Standalone, file.RawGameVersions.FirstOrDefault())
+                    })
+                { ProgressWeight = 10d, block = true });
             loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Download.Comp.Detail.InstallWorld"),
                 _ => ModBase.ExtractFile(target, targetPath, Encoding.UTF8)) { ProgressWeight = 0.1d, block = true });
             loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Download.Comp.Detail.CleanCache"),
@@ -537,7 +541,12 @@ public partial class PageDownloadCompDetail
                     var loaders = new List<ModLoader.LoaderBase>
                     {
                         new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadFile"),
-                            new List<DownloadFile> { file.ToNetFile(target) })
+                            new List<DownloadFile>
+                            {
+                                file.Type == ModComp.CompType.Mod
+                                    ? file.ToNetFile(target)
+                                    : file.ToNetFile(target, ModComp.DownloadReason.Standalone, null)
+                            })
                         {
                             ProgressWeight = 6,
                             block = true

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageDownloadCompDetail.xaml.cs
@@ -85,7 +85,8 @@ public partial class PageDownloadCompDetail
             var target =
                 $@"{ModFolder.mcFolderSelected}versions\{instanceName}\原始整合包.{(_project.FromCurseForge ? "zip" : "mrpack")}";
             var logoFileAddress = MyImage.GetTempPath(_compItem.Logo);
-            loaders.Add(new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadModpackFile"), new List<DownloadFile> { file.ToNetFile(target) })
+            loaders.Add(new LoaderDownload(Lang.Text("Download.Comp.Detail.DownloadModpackFile"),
+                    new List<DownloadFile> { file.ToNetFile(target, ModComp.DownloadReason.ModPack) })
                 { ProgressWeight = 10d, block = true });
             loaders.Add(new ModLoader.LoaderTask<int, int>(Lang.Text("Download.Comp.Detail.PrepareModpackInstall"),
                 _ => ModModpack.ModpackInstall(target, instanceName,

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -3896,17 +3896,29 @@ public static class ModDownloadLib
         // Fabric API
         if (request.fabricApi is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadFabricApi"),
-                    new List<DownloadFile> { request.fabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
+                    new List<DownloadFile>
+                    {
+                        request.fabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency, null,
+                            ModComp.CompLoaderType.Fabric)
+                    })
                 { ProgressWeight = 3d, block = false });
         // LegacyFabric API
         if (request.legacyFabricApi is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadLegacyFabricApi"),
-                    new List<DownloadFile> { request.legacyFabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
+                    new List<DownloadFile>
+                    {
+                        request.legacyFabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency, null,
+                            ModComp.CompLoaderType.Fabric)
+                    })
                 { ProgressWeight = 3d, block = false });
         // OptiFabric
         if (request.optiFabric is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadOptiFabric"),
-                    new List<DownloadFile> { request.optiFabric.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
+                    new List<DownloadFile>
+                    {
+                        request.optiFabric.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency, null,
+                            ModComp.CompLoaderType.Fabric)
+                    })
                 { ProgressWeight = 3d, block = false });
         // LabyMod
         if (request.labyModCommitRef is not null)

--- a/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/ModDownloadLib.cs
@@ -3896,17 +3896,17 @@ public static class ModDownloadLib
         // Fabric API
         if (request.fabricApi is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadFabricApi"),
-                    new List<DownloadFile> { request.fabricApi.ToNetFile(modsTempFolder) })
+                    new List<DownloadFile> { request.fabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
                 { ProgressWeight = 3d, block = false });
         // LegacyFabric API
         if (request.legacyFabricApi is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadLegacyFabricApi"),
-                    new List<DownloadFile> { request.legacyFabricApi.ToNetFile(modsTempFolder) })
+                    new List<DownloadFile> { request.legacyFabricApi.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
                 { ProgressWeight = 3d, block = false });
         // OptiFabric
         if (request.optiFabric is not null)
             loaderList.Add(new LoaderDownload(Lang.Text("Minecraft.Download.Stage.DownloadOptiFabric"),
-                    new List<DownloadFile> { request.optiFabric.ToNetFile(modsTempFolder) })
+                    new List<DownloadFile> { request.optiFabric.ToNetFile(modsTempFolder, ModComp.DownloadReason.Dependency) })
                 { ProgressWeight = 3d, block = false });
         // LabyMod
         if (request.labyModCommitRef is not null)

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceCompResource.xaml.cs
@@ -2096,7 +2096,7 @@ public partial class PageInstanceCompResource : IRefreshable
                                   Entry.FileName.Replace(currentReplaceName, newestReplaceName);
                 var realAddress = ModBase.GetPathFromFullPath(Entry.path) +
                                   Entry.FileName.Replace(currentReplaceName, newestReplaceName);
-                fileList.Add(file.ToNetFile(tempAddress));
+                fileList.Add(file.ToNetFile(tempAddress, ModComp.DownloadReason.Update));
                 fileCopyList[tempAddress] = realAddress;
             }
 

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -1253,7 +1253,8 @@ public partial class PageInstanceSavesDatapack : IRefreshable
                 }
 
                 // 添加到下载列表
-                fileList.Add(file.ToNetFile(tempAddress, ModComp.DownloadReason.Update));
+                fileList.Add(file.ToNetFile(tempAddress, ModComp.DownloadReason.Update,
+                    file.RawGameVersions.FirstOrDefault()));
                 fileCopyList[tempAddress] = realAddress;
                 updateEntryList.Add(Entry);
             }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSaves/PageInstanceSavesDatapack.xaml.cs
@@ -1253,7 +1253,7 @@ public partial class PageInstanceSavesDatapack : IRefreshable
                 }
 
                 // 添加到下载列表
-                fileList.Add(file.ToNetFile(tempAddress));
+                fileList.Add(file.ToNetFile(tempAddress, ModComp.DownloadReason.Update));
                 fileCopyList[tempAddress] = realAddress;
                 updateEntryList.Add(Entry);
             }


### PR DESCRIPTION
## Summary by Sourcery

为 Modrinth 模组下载添加下载原因追踪，并在模组、依赖项、整合包以及更新的下载流程中传递这些元数据。

新功能：
- 引入 `DownloadReason` 枚举，用于对独立下载、依赖项下载、整合包下载以及更新下载进行分类。
- 为 Modrinth 下载 URL 增加查询参数，用于描述下载原因、游戏版本以及模组加载器。

增强改进：
- 扩展模组下载创建 API，使其接受下载原因、实例版本以及模组加载器，并更新依赖项、整合包以及资源更新相关调用方以提供这些上下文信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add download reason tracking for Modrinth mod downloads and propagate this metadata through mod, dependency, modpack, and update download flows.

New Features:
- Introduce a DownloadReason enum to classify standalone, dependency, modpack, and update downloads.
- Augment Modrinth download URLs with query parameters describing download reason, game version, and mod loader.

Enhancements:
- Extend mod download creation APIs to accept download reason, instance version, and mod loader, and update callers across dependencies, modpacks, and resource updates to supply this context.

</details>