### PR TITLE
feat(i18n-banner): 添加 i18n 贡献标语横幅

### DIFF
--- a/PCL.Core/App/Localization/Languages/en-US.xaml
+++ b/PCL.Core/App/Localization/Languages/en-US.xaml
@@ -2706,7 +2706,13 @@
     <sys:String x:Key="Setup.Language.FormatCulture">Regional format</sys:String>
     <sys:String x:Key="Setup.Language.FormatCulture.Auto">Follow system regional format</sys:String>
     <sys:String x:Key="Setup.Language.FormatCulture.FollowLanguage">Follow UI language</sys:String>
-    <sys:String x:Key="Setup.Language.Hint">Multi-language support is currently limited to certain new interfaces. Others will be updated in upcoming migrations.&#xA;&#xA;To ensure work efficiency and convenience, only "English (US)" and "简体中文（中国大陆）" are guaranteed to be partially available during the migration process. Other languages will be opened up to the community for translation contributions on the translation platform once the future migration work is fully completed.</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.TitlePrefix">Let</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.TitleSuffix">Go Internationalized.</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine1">With the support of the community, PCL CE is entering a new chapter in its journey toward internationalization.</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine2">You can help shape that journey by submitting pull requests to our GitHub repository and making PCL CE more accessible to users around the world.</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine3">Thank you to everyone who contributes translations, reviews, and improvements—your support makes PCL CE better for everyone.</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.SubmitPullRequest">Submit pull request</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.ViewDeveloperDocs">View developer docs</sys:String>
     <sys:String x:Key="Setup.Language.Reset.Success">Language page settings initialized!</sys:String>
     <sys:String x:Key="Setup.Language.Title">Language</sys:String>
     <sys:String x:Key="Setup.Language.UiLanguage">Display language</sys:String>

--- a/PCL.Core/App/Localization/Languages/zh-CN.xaml
+++ b/PCL.Core/App/Localization/Languages/zh-CN.xaml
@@ -2706,7 +2706,13 @@
     <sys:String x:Key="Setup.Language.FormatCulture">区域格式</sys:String>
     <sys:String x:Key="Setup.Language.FormatCulture.Auto">跟随系统区域格式</sys:String>
     <sys:String x:Key="Setup.Language.FormatCulture.FollowLanguage">同步界面语言</sys:String>
-    <sys:String x:Key="Setup.Language.Hint">目前仅部分新增界面支持多语言功能，其余界面将在后续迁移中逐步完成生效。&#xA;&#xA;为确保工作效率与便捷性，迁移过程中仅确保“English (US)”与“简体中文（中国大陆）”部分可用。其余语言将在未来迁移工作完成后，交由社区于翻译平台进行翻译贡献。</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.TitlePrefix">让</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.TitleSuffix">走向国际化。</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine1">在社区的共同助力下，PCL CE 正迈向国际化的新篇章。</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine2">欢迎向我们的 GitHub 仓库提交 Pull Request，与我们一同完善多语言支持，为 PCL CE 更好地服务全球用户的目标添砖加瓦。</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.DescriptionLine3">感谢每一位参与翻译、校对与改进的贡献者，让 PCL CE 因你们而更加完善。</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.SubmitPullRequest">提交 Pull Request</sys:String>
+    <sys:String x:Key="Setup.Language.Banner.ViewDeveloperDocs">查看开发文档</sys:String>
     <sys:String x:Key="Setup.Language.Reset.Success">已初始化语言页设置！</sys:String>
     <sys:String x:Key="Setup.Language.Title">语言</sys:String>
     <sys:String x:Key="Setup.Language.UiLanguage">界面语言</sys:String>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherLanguage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherLanguage.xaml
@@ -178,7 +178,7 @@
                             SvgIcon="lucide/book-marked"
                             ToolTip="{DynamicResource Setup.Language.Banner.ViewDeveloperDocs}"
                             local:CustomEventService.EventType="OpenUrl"
-                            local:CustomEventService.EventData="https://github.com/PCL-Community/PCL-CE/wiki/开发指南" />
+                            local:CustomEventService.EventData="https://docs.pclc.cc/ce/developers/" />
                     </StackPanel>
                 </StackPanel>
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherLanguage.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLauncherLanguage.xaml
@@ -2,13 +2,24 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:PCL"
+    xmlns:svgIcon="clr-namespace:PCL.Core.UI.Controls.SvgIcon;assembly=PCL.Core"
+    xmlns:coreControls="clr-namespace:PCL.Core.UI.Controls;assembly=PCL.Core"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d" x:Class="PCL.PageSetupLauncherLanguage"
+    mc:Ignorable="d"
+    x:Class="PCL.PageSetupLauncherLanguage"
     PanScroll="{Binding ElementName=PanBack}">
-    <local:MyScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
+
+    <local:MyScrollViewer
+        x:Name="PanBack"
+        VerticalScrollBarVisibility="Auto"
+        HorizontalScrollBarVisibility="Disabled">
+
         <StackPanel x:Name="PanMain" Margin="25,10">
-            <local:MyCard Margin="0,15" Title="{DynamicResource Setup.Language.CardTitle}">
+            <local:MyCard
+                Margin="0,15,0,10"
+                Title="{DynamicResource Setup.Language.CardTitle}">
+
                 <StackPanel Margin="25,40,25,15">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -16,24 +27,159 @@
                             <ColumnDefinition Width="1*" />
                             <ColumnDefinition Width="60" />
                         </Grid.ColumnDefinitions>
+
                         <Grid.RowDefinitions>
                             <RowDefinition Height="28" />
                             <RowDefinition Height="9" />
                             <RowDefinition Height="28" />
-                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.Language.UiLanguage}"
-                                   Margin="0,0,25,0" Grid.Row="0" />
-                        <local:MyComboBox x:Name="ComboUiLanguage" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
-                                          SelectionChanged="ComboUiLanguage_SelectionChanged" />
-                        <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left"
-                                   Text="{DynamicResource Setup.Language.FormatCulture}"
-                                   Margin="0,0,25,0" Grid.Row="2" />
-                        <local:MyComboBox x:Name="ComboUiFormatCulture" Grid.Row="2" Grid.Column="1"
-                                          Grid.ColumnSpan="2" SelectionChanged="ComboUiFormatCulture_SelectionChanged" />
+
+                        <TextBlock
+                            Grid.Row="0"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Left"
+                            Margin="0,0,25,0"
+                            Text="{DynamicResource Setup.Language.UiLanguage}" />
+
+                        <local:MyComboBox
+                            x:Name="ComboUiLanguage"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            SelectionChanged="ComboUiLanguage_SelectionChanged" />
+
+                        <TextBlock
+                            Grid.Row="2"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Left"
+                            Margin="0,0,25,0"
+                            Text="{DynamicResource Setup.Language.FormatCulture}" />
+
+                        <local:MyComboBox
+                            x:Name="ComboUiFormatCulture"
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            SelectionChanged="ComboUiFormatCulture_SelectionChanged" />
                     </Grid>
-                    <local:MyHint Text="{DynamicResource Setup.Language.Hint}" Margin="0,10,0,0" />
+
+                    <coreControls:BlurBorder
+                        x:Name="BannerInternationalization"
+                        Margin="0,10,0,0"
+                        Padding="25"
+                        MinHeight="230"
+                        CornerRadius="5"
+                        ClipToBounds="True"
+                        Background="{DynamicResource ColorBrush7}">
+
+                        <Grid>
+                            <Canvas
+                                Width="205"
+                                Height="145"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Margin="0,-43,-25,0"
+                                Panel.ZIndex="0"
+                                IsHitTestVisible="False">
+
+                                <svgIcon:SvgIcon
+                                    Width="215"
+                                    Height="215"
+                                    Canvas.Left="5"
+                                    Canvas.Top="-56"
+                                    Icon="lucide/earth"
+                                    IconBrush="{DynamicResource ColorBrush5}"
+                                    StrokeThickness="2.4"
+                                    Opacity="0.62"
+                                    Stretch="Uniform" />
+                            </Canvas>
+
+                            <Grid Panel.ZIndex="1">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
+                                <StackPanel Grid.Row="0" Margin="0,0,170,0" HorizontalAlignment="Left">
+                                    <TextBlock
+                                        FontSize="22"
+                                        FontWeight="Bold"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="{DynamicResource Setup.Language.Banner.TitlePrefix}"
+                                        TextWrapping="Wrap" />
+
+                                    <TextBlock
+                                        Margin="0,2,0,2"
+                                        FontFamily="Bahnschrift"
+                                        FontSize="42"
+                                        FontWeight="Bold"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="PCL CE"
+                                        TextWrapping="Wrap" />
+
+                                    <TextBlock
+                                        FontSize="22"
+                                        FontWeight="Bold"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="{DynamicResource Setup.Language.Banner.TitleSuffix}"
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+
+                                <StackPanel Grid.Row="1" Margin="0,20,0,0">
+                                    <TextBlock
+                                        FontSize="14"
+                                        LineHeight="23"
+                                        LineStackingStrategy="BlockLineHeight"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="{DynamicResource Setup.Language.Banner.DescriptionLine1}"
+                                        TextWrapping="Wrap" />
+
+                                    <TextBlock
+                                        Margin="0,5,0,0"
+                                        FontSize="14"
+                                        LineHeight="23"
+                                        LineStackingStrategy="BlockLineHeight"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="{DynamicResource Setup.Language.Banner.DescriptionLine2}"
+                                        TextWrapping="Wrap" />
+
+                                    <TextBlock
+                                        Margin="0,5,0,0"
+                                        FontSize="14"
+                                        LineHeight="23"
+                                        LineStackingStrategy="BlockLineHeight"
+                                        Foreground="{DynamicResource ColorBrush1}"
+                                        Text="{DynamicResource Setup.Language.Banner.DescriptionLine3}"
+                                        TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Grid>
+                        </Grid>
+                    </coreControls:BlurBorder>
+
+                    <StackPanel
+                        Margin="0,10,0,0"
+                        HorizontalAlignment="Right"
+                        Orientation="Horizontal">
+
+                        <local:MyIconTextButton
+                            x:Name="BtnSubmitPullRequest"
+                            Margin="0,0,7,0"
+                            Text="{DynamicResource Setup.Language.Banner.SubmitPullRequest}"
+                            SvgIcon="lucide/upload"
+                            ColorType="Highlight"
+                            ToolTip="{DynamicResource Setup.Language.Banner.SubmitPullRequest}"
+                            local:CustomEventService.EventType="OpenUrl"
+                            local:CustomEventService.EventData="https://github.com/PCL-Community/PCL-CE/pulls" />
+
+                        <local:MyIconTextButton
+                            x:Name="BtnViewDeveloperDocs"
+                            Text="{DynamicResource Setup.Language.Banner.ViewDeveloperDocs}"
+                            SvgIcon="lucide/book-marked"
+                            ToolTip="{DynamicResource Setup.Language.Banner.ViewDeveloperDocs}"
+                            local:CustomEventService.EventType="OpenUrl"
+                            local:CustomEventService.EventData="https://github.com/PCL-Community/PCL-CE/wiki/开发指南" />
+                    </StackPanel>
                 </StackPanel>
             </local:MyCard>
         </StackPanel>


### PR DESCRIPTION
> Generated by GPT-5.6 Sol and revised manually

|   \   | Light                                                                                                                                | Dark                                                                                                                                 |
|:-----:|--------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
| zh-CN | <img width="1991" height="1395" alt="image" src="https://github.com/user-attachments/assets/c126f346-ad17-484e-ab79-f92235bdb2ec" /> | <img width="1991" height="1395" alt="image" src="https://github.com/user-attachments/assets/53f9919a-2e97-431f-8154-9ff945f90e51" /> |
| en-US | <img width="1991" height="1395" alt="image" src="https://github.com/user-attachments/assets/105e79cc-6819-4651-b6e5-6ebbb52b81c4" /> | <img width="1991" height="1395" alt="image" src="https://github.com/user-attachments/assets/cbbc437b-9d94-48bd-89fd-cf189ef2dd8e" /> |

## Summary by Sourcery

在启动器的语言设置页面中添加国际化贡献横幅，并为中文和英文进行本地化。

新功能：
- 在语言选择/设置页面中加入 i18n 贡献横幅。
- 在本地化文件中为 zh-CN 和 en-US 添加横幅文案/资源的本地化内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an internationalization contribution banner to the launcher language setup page, localized for Chinese and English.

New Features:
- Introduce an i18n contribution banner on the language selection/setup page.
- Add localized banner text/resources for zh-CN and en-US in the localization files.

</details>