### PR TITLE
refactor: 重构 Mod Loader 合并安装提交部分

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLoaderType.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLoaderType.cs
@@ -1,0 +1,14 @@
+namespace PCL;
+
+/// <summary>
+///     实例安装流程中可互斥选择的主 Mod 加载器。
+/// </summary>
+internal enum ModLoaderType
+{
+    Forge,
+    NeoForge,
+    Cleanroom,
+    Fabric,
+    LegacyFabric,
+    LabyMod
+}

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -340,7 +340,7 @@ public partial class PageDownloadInstall
     /// <summary>
     ///     选定的主 Mod 加载器。
     /// </summary>
-    private ModLoaderType? selectedLoaderName;
+    private ModLoaderType? _selectedLoaderType;
 
     /// <summary>
     ///     选定的 Mod Loader API 名称，内容应为 Fabric API
@@ -785,7 +785,7 @@ public partial class PageDownloadInstall
         _vanillaIcon = null;
         selectedOptiFine = null;
         selectedLiteLoader = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         selectedForge = null;
         selectedNeoForge = null;
@@ -799,6 +799,49 @@ public partial class PageDownloadInstall
         selectedLabyModChannel = null;
         selectedLegacyFabric = null;
         selectedLegacyFabricApi = null;
+    }
+
+    /// <summary>
+    ///     选择主 Mod 加载器时，清除其它主加载器及其专属组件。
+    ///     OptiFine 与 LiteLoader 可与部分加载器共存，故不在此处清除。
+    /// </summary>
+    private void SelectModLoader(ModLoaderType loaderType)
+    {
+        if (loaderType != ModLoaderType.Forge)
+            selectedForge = null;
+
+        if (loaderType != ModLoaderType.NeoForge)
+            selectedNeoForge = null;
+
+        if (loaderType != ModLoaderType.Cleanroom)
+            selectedCleanroom = null;
+
+        if (loaderType != ModLoaderType.Fabric)
+        {
+            selectedFabric = null;
+            selectedFabricApi = null;
+            selectedOptiFabric = null;
+            autoSelectedFabricApi = false;
+            autoSelectedOptiFabric = false;
+        }
+
+        if (loaderType != ModLoaderType.LegacyFabric)
+        {
+            selectedLegacyFabric = null;
+            selectedLegacyFabricApi = null;
+            autoSelectedLegacyFabricApi = false;
+        }
+
+        if (loaderType != ModLoaderType.LabyMod)
+        {
+            selectedLabyModChannel = null;
+            selectedLabyModCommitRef = null;
+            selectedLabyModBaseVersion = null;
+            selectedLabyModVersion = null;
+        }
+
+        _selectedLoaderType = loaderType;
+        selectedAPIName = null;
     }
 
     // 信息栏动画
@@ -1083,18 +1126,18 @@ public partial class PageDownloadInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
             return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
-        if (selectedLoaderName == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
-            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
+            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Loader
         if (GetLoaderError(LoadOptiFine) is not null)
             return GetLoaderError(LoadOptiFine);
@@ -1118,7 +1161,7 @@ public partial class PageDownloadInstall
 
         if (hasRequiredVersion) return Lang.Text("Download.Install.Compat.CompatForgeSpecificOnly");
 
-        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
     }
 
     // 检查某个 OptiFine 是否与某个 Forge 兼容
@@ -1232,8 +1275,8 @@ public partial class PageDownloadInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
-        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
             ? null
@@ -1307,8 +1350,8 @@ public partial class PageDownloadInstall
         if (McVersionComparer.CompareVersionGe("1.5.1", _vanillaName) && McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
             return Lang.Text("Download.Install.State.NoVersion");
         
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Forge)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         
         // 检查 Loader
         if (GetLoaderError(LoadForge) is not null)
@@ -1322,7 +1365,7 @@ public partial class PageDownloadInstall
             if (Version.Category == "universal" || Version.Category == "client")
                 continue; // 跳过无法自动安装的版本
             if (selectedNeoForge is not null || selectedFabric is not null)
-                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
             if (selectedOptiFine is not null && McVersionComparer.CompareVersionGe(_vanillaName, "1.13") &&
                 McVersionComparer.CompareVersionGe("1.14.3", _vanillaName))
                 return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine"); // 1.13 ~ 1.14.3 OptiFine 检查
@@ -1388,8 +1431,8 @@ public partial class PageDownloadInstall
     // 选择与清除
     private void Forge_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.Forge);
         selectedForge = (ModDownload.DlForgeVersionEntry)(dynamic)sender.Tag;
-        selectedLoaderName = ModLoaderType.Forge;
         CardForge.IsSwapped = true;
         if (selectedOptiFine is not null &&
                                   !(bool)IsOptiFineSuitForForge(selectedOptiFine, selectedForge))
@@ -1401,7 +1444,7 @@ public partial class PageDownloadInstall
     private void Forge_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedForge = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         CardForge.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();
@@ -1419,8 +1462,8 @@ public partial class PageDownloadInstall
     {
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.NeoForge)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.NeoForge)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Loader
         if (GetLoaderError(LoadNeoForge) is not null)
             return GetLoaderError(LoadNeoForge);
@@ -1474,8 +1517,8 @@ public partial class PageDownloadInstall
     // 选择与清除
     private void NeoForge_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.NeoForge);
         selectedNeoForge = (ModDownload.DlNeoForgeListEntry)(dynamic)sender.Tag;
-        selectedLoaderName = ModLoaderType.NeoForge;
         CardNeoForge.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1484,7 +1527,7 @@ public partial class PageDownloadInstall
     private void NeoForge_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedNeoForge = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         CardNeoForge.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();
@@ -1504,8 +1547,8 @@ public partial class PageDownloadInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         // 检查 Loader
@@ -1560,8 +1603,8 @@ public partial class PageDownloadInstall
     // 选择与清除
     private void Cleanroom_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.Cleanroom);
         selectedCleanroom = (ModDownload.DlCleanroomListEntry)(dynamic)sender.Tag;
-        selectedLoaderName = ModLoaderType.Cleanroom;
         CardCleanroom.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1570,7 +1613,7 @@ public partial class PageDownloadInstall
     private void Cleanroom_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedCleanroom = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         CardCleanroom.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();
@@ -1597,8 +1640,8 @@ public partial class PageDownloadInstall
             if ((version["version"].ToString() ?? "") ==
                 (_vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3") ?? ""))
             {
-                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Fabric)
-                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+                if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Fabric)
+                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
                 return null;
             }
 
@@ -1650,9 +1693,9 @@ public partial class PageDownloadInstall
     // 选择与清除
     public void Fabric_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.Fabric);
         ModBase.Log(((dynamic)sender.Tag).ToString());
         selectedFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = ModLoaderType.Fabric;
         FabricApi_Loaded();
         OptiFabric_Loaded();
         CardFabric.IsSwapped = true;
@@ -1666,7 +1709,7 @@ public partial class PageDownloadInstall
         autoSelectedFabricApi = false;
         selectedOptiFabric = null;
         autoSelectedOptiFabric = false;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         CardFabric.IsSwapped = true;
         e.Handled = true;
@@ -1815,8 +1858,8 @@ public partial class PageDownloadInstall
             {
                 if (selectedLiteLoader is not null)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
-                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LegacyFabric)
-                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+                if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.LegacyFabric)
+                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
                 return null;
             }
 
@@ -1867,8 +1910,8 @@ public partial class PageDownloadInstall
     // 选择与清除
     public void LegacyFabric_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.LegacyFabric);
         selectedLegacyFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = ModLoaderType.LegacyFabric;
         LegacyFabricApi_Loaded();
         CardLegacyFabric.IsSwapped = true;
         ReloadSelected();
@@ -1879,7 +1922,7 @@ public partial class PageDownloadInstall
         selectedLegacyFabric = null;
         selectedLegacyFabricApi = null;
         autoSelectedLegacyFabricApi = false;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         CardLegacyFabric.IsSwapped = true;
         e.Handled = true;
@@ -2165,8 +2208,8 @@ public partial class PageDownloadInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LabyMod)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.LabyMod)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (selectedLiteLoader is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         foreach (JsonObject Version in ModDownload.dlLabyModListLoader.output.Value["production"]["minecraftVersions"].AsArray())
@@ -2244,12 +2287,12 @@ public partial class PageDownloadInstall
     // 选择与清除
     public void LabyMod_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader(ModLoaderType.LabyMod);
         selectedLabyModChannel = ((dynamic)sender.Tag)["channel"].ToString();
         selectedLabyModCommitRef = ((dynamic)sender.Tag)["commitReference"].ToString();
         selectedLabyModBaseVersion = ((dynamic)sender.Tag)["version"].ToString();
         selectedLabyModVersion =
             selectedLabyModBaseVersion + " " + (selectedLabyModChannel == "snapshot" ? Lang.Text("Download.Version.Type.Snapshot") : Lang.Text("Download.Version.Type.Stable"));
-        selectedLoaderName = ModLoaderType.LabyMod;
         CardLabyMod.IsSwapped = true;
         ReloadSelected();
     }
@@ -2261,9 +2304,9 @@ public partial class PageDownloadInstall
         selectedLabyModBaseVersion = null;
         selectedLabyModChannel = null;
         
-        if (selectedLoaderName == ModLoaderType.LabyMod)
+        if (_selectedLoaderType == ModLoaderType.LabyMod)
         {
-            selectedLoaderName = null;
+            _selectedLoaderType = null;
         }    
         
         selectedAPIName = null;
@@ -2285,7 +2328,7 @@ public partial class PageDownloadInstall
     private void BtnStart_Click()
     {
         // 确认版本隔离
-        if (selectedLoaderName is not null &&
+        if (_selectedLoaderType is not null &&
             (Config.Launch.IndieSolutionV2 == 0 ||
              Config.Launch.IndieSolutionV2 == 2))
             if (ModMain.MyMsgBox(

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.cs
@@ -338,9 +338,9 @@ public partial class PageDownloadInstall
     private ModDownload.DlOptiFineListEntry? selectedOptiFine;
 
     /// <summary>
-    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Cleanroom / LabyMod / LegacyFabric
+    ///     选定的主 Mod 加载器。
     /// </summary>
-    private string? selectedLoaderName;
+    private ModLoaderType? selectedLoaderName;
 
     /// <summary>
     ///     选定的 Mod Loader API 名称，内容应为 Fabric API
@@ -1083,14 +1083,14 @@ public partial class PageDownloadInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
             return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
-        if (selectedLoaderName == "Forge" && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
+        if (selectedLoaderName == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
             McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
@@ -1232,7 +1232,7 @@ public partial class PageDownloadInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LegacyFabric" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
@@ -1307,7 +1307,7 @@ public partial class PageDownloadInstall
         if (McVersionComparer.CompareVersionGe("1.5.1", _vanillaName) && McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
             return Lang.Text("Download.Install.State.NoVersion");
         
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Forge"))
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         
         // 检查 Loader
@@ -1389,7 +1389,7 @@ public partial class PageDownloadInstall
     private void Forge_Selected(MyListItem sender, EventArgs e)
     {
         selectedForge = (ModDownload.DlForgeVersionEntry)(dynamic)sender.Tag;
-        selectedLoaderName = "Forge";
+        selectedLoaderName = ModLoaderType.Forge;
         CardForge.IsSwapped = true;
         if (selectedOptiFine is not null &&
                                   !(bool)IsOptiFineSuitForForge(selectedOptiFine, selectedForge))
@@ -1419,7 +1419,7 @@ public partial class PageDownloadInstall
     {
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "NeoForge"))
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.NeoForge)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Loader
         if (GetLoaderError(LoadNeoForge) is not null)
@@ -1475,7 +1475,7 @@ public partial class PageDownloadInstall
     private void NeoForge_Selected(MyListItem sender, EventArgs e)
     {
         selectedNeoForge = (ModDownload.DlNeoForgeListEntry)(dynamic)sender.Tag;
-        selectedLoaderName = "NeoForge";
+        selectedLoaderName = ModLoaderType.NeoForge;
         CardNeoForge.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1504,7 +1504,7 @@ public partial class PageDownloadInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != "Cleanroom")
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
@@ -1561,7 +1561,7 @@ public partial class PageDownloadInstall
     private void Cleanroom_Selected(MyListItem sender, EventArgs e)
     {
         selectedCleanroom = (ModDownload.DlCleanroomListEntry)(dynamic)sender.Tag;
-        selectedLoaderName = "Cleanroom";
+        selectedLoaderName = ModLoaderType.Cleanroom;
         CardCleanroom.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1597,7 +1597,7 @@ public partial class PageDownloadInstall
             if ((version["version"].ToString() ?? "") ==
                 (_vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3") ?? ""))
             {
-                if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Fabric"))
+                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Fabric)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
                 return null;
             }
@@ -1652,7 +1652,7 @@ public partial class PageDownloadInstall
     {
         ModBase.Log(((dynamic)sender.Tag).ToString());
         selectedFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = "Fabric";
+        selectedLoaderName = ModLoaderType.Fabric;
         FabricApi_Loaded();
         OptiFabric_Loaded();
         CardFabric.IsSwapped = true;
@@ -1815,7 +1815,7 @@ public partial class PageDownloadInstall
             {
                 if (selectedLiteLoader is not null)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
-                if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "LegacyFabric"))
+                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LegacyFabric)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
                 return null;
             }
@@ -1868,7 +1868,7 @@ public partial class PageDownloadInstall
     public void LegacyFabric_Selected(MyListItem sender, EventArgs e)
     {
         selectedLegacyFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = "LegacyFabric";
+        selectedLoaderName = ModLoaderType.LegacyFabric;
         LegacyFabricApi_Loaded();
         CardLegacyFabric.IsSwapped = true;
         ReloadSelected();
@@ -2165,7 +2165,7 @@ public partial class PageDownloadInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != "LabyMod")
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LabyMod)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
@@ -2249,7 +2249,7 @@ public partial class PageDownloadInstall
         selectedLabyModBaseVersion = ((dynamic)sender.Tag)["version"].ToString();
         selectedLabyModVersion =
             selectedLabyModBaseVersion + " " + (selectedLabyModChannel == "snapshot" ? Lang.Text("Download.Version.Type.Snapshot") : Lang.Text("Download.Version.Type.Stable"));
-        selectedLoaderName = "LabyMod";
+        selectedLoaderName = ModLoaderType.LabyMod;
         CardLabyMod.IsSwapped = true;
         ReloadSelected();
     }
@@ -2261,7 +2261,7 @@ public partial class PageDownloadInstall
         selectedLabyModBaseVersion = null;
         selectedLabyModChannel = null;
         
-        if (selectedLoaderName == "LabyMod")
+        if (selectedLoaderName == ModLoaderType.LabyMod)
         {
             selectedLoaderName = null;
         }    

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -869,6 +869,54 @@ public partial class PageInstanceInstall
         selectedLegacyFabricApi = null;
     }
 
+    /// <summary>
+    ///     选择主 Mod 加载器时，清除其它主加载器及其专属组件。
+    ///     OptiFine 与 LiteLoader 可与部分加载器共存，故不在此处清除。
+    /// </summary>
+    private void SelectModLoader(string loaderName)
+    {
+        if (loaderName != "Forge")
+            selectedForge = null;
+
+        if (loaderName != "NeoForge")
+        {
+            selectedNeoForge = null;
+            selectedNeoForgeVersion = null;
+        }
+
+        if (loaderName != "Cleanroom")
+        {
+            selectedCleanroom = null;
+            selectedCleanroomVersion = null;
+        }
+
+        if (loaderName != "Fabric")
+        {
+            selectedFabric = null;
+            selectedFabricApi = null;
+            selectedOptiFabric = null;
+            autoSelectedFabricApi = false;
+            autoSelectedOptiFabric = false;
+        }
+
+        if (loaderName != "LegacyFabric")
+        {
+            selectedLegacyFabric = null;
+            selectedLegacyFabricApi = null;
+            autoSelectedLegacyFabricApi = false;
+        }
+
+        if (loaderName != "LabyMod")
+        {
+            selectedLabyModChannel = null;
+            selectedLabyModCommitRef = null;
+            selectedLabyModVersion = null;
+        }
+
+        selectedLoaderName = loaderName;
+        selectedAPIName = null;
+    }
+
     // 信息栏动画
     private void SetPanelVisibility(Grid panel, bool visible)
     {
@@ -1628,8 +1676,8 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void Forge_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("Forge");
         selectedForge = (ModDownload.DlForgeVersionEntry)sender.Tag;
-        selectedLoaderName = "Forge";
         CardForge.IsSwapped = true;
         if (selectedOptiFine is not null &&
                                   !(bool)IsOptiFineSuitForForge(selectedOptiFine, selectedForge))
@@ -1714,8 +1762,8 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void NeoForge_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("NeoForge");
         selectedNeoForge = (ModDownload.DlNeoForgeListEntry)sender.Tag;
-        selectedLoaderName = "NeoForge";
         CardNeoForge.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1800,8 +1848,8 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void Cleanroom_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("Cleanroom");
         selectedCleanroom = (ModDownload.DlCleanroomListEntry)sender.Tag;
-        selectedLoaderName = "Cleanroom";
         CardCleanroom.IsSwapped = true;
         OptiFine_Loaded();
         ReloadSelected();
@@ -1892,8 +1940,8 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void Fabric_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("Fabric");
         selectedFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = "Fabric";
         FabricApi_Loaded();
         OptiFabric_Loaded();
         CardFabric.IsSwapped = true;
@@ -2145,8 +2193,8 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void LegacyFabric_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("LegacyFabric");
         selectedLegacyFabric = ((dynamic)sender.Tag)["version"].ToString();
-        selectedLoaderName = "LegacyFabric";
         LegacyFabricApi_Loaded();
         CardLegacyFabric.IsSwapped = true;
         ReloadSelected();
@@ -2523,11 +2571,11 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void LabyMod_Selected(MyListItem sender, EventArgs e)
     {
+        SelectModLoader("LabyMod");
         selectedLabyModChannel = ((dynamic)sender.Tag)("channel").ToString();
         selectedLabyModCommitRef = ((dynamic)sender.Tag)("commitReference").ToString();
         selectedLabyModVersion =
             ((dynamic)sender.Tag)("version").ToString() + (selectedLabyModChannel == "snapshot" ? " " + Lang.Text("Download.Version.Type.Snapshot") : " " + Lang.Text("Download.Version.Type.Stable"));
-        selectedLoaderName = "LabyMod";
         CardLabyMod.IsSwapped = true;
         ReloadSelected();
     }

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -106,7 +106,7 @@ public partial class PageInstanceInstall
         }
 
         // 确认版本隔离
-        if (selectedLoaderName is not null &&
+        if (_selectedLoaderType is not null &&
             (Config.Launch.IndieSolutionV2 == 0 ||
              Config.Launch.IndieSolutionV2 == 2))
             if (ModMain.MyMsgBox(
@@ -385,7 +385,7 @@ public partial class PageInstanceInstall
     /// <summary>
     ///     选定的主 Mod 加载器。
     /// </summary>
-    private ModLoaderType? selectedLoaderName;
+    private ModLoaderType? _selectedLoaderType;
 
     /// <summary>
     ///     选定的 Mod Loader API 名称，内容应为 Fabric API
@@ -852,7 +852,7 @@ public partial class PageInstanceInstall
         _vanillaIcon = null;
         selectedOptiFine = null;
         selectedLiteLoader = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         selectedForge = null;
         selectedNeoForge = null;
@@ -873,24 +873,24 @@ public partial class PageInstanceInstall
     ///     选择主 Mod 加载器时，清除其它主加载器及其专属组件。
     ///     OptiFine 与 LiteLoader 可与部分加载器共存，故不在此处清除。
     /// </summary>
-    private void SelectModLoader(ModLoaderType loaderName)
+    private void SelectModLoader(ModLoaderType loaderType)
     {
-        if (loaderName != ModLoaderType.Forge)
+        if (loaderType != ModLoaderType.Forge)
             selectedForge = null;
 
-        if (loaderName != ModLoaderType.NeoForge)
+        if (loaderType != ModLoaderType.NeoForge)
         {
             selectedNeoForge = null;
             selectedNeoForgeVersion = null;
         }
 
-        if (loaderName != ModLoaderType.Cleanroom)
+        if (loaderType != ModLoaderType.Cleanroom)
         {
             selectedCleanroom = null;
             selectedCleanroomVersion = null;
         }
 
-        if (loaderName != ModLoaderType.Fabric)
+        if (loaderType != ModLoaderType.Fabric)
         {
             selectedFabric = null;
             selectedFabricApi = null;
@@ -899,21 +899,21 @@ public partial class PageInstanceInstall
             autoSelectedOptiFabric = false;
         }
 
-        if (loaderName != ModLoaderType.LegacyFabric)
+        if (loaderType != ModLoaderType.LegacyFabric)
         {
             selectedLegacyFabric = null;
             selectedLegacyFabricApi = null;
             autoSelectedLegacyFabricApi = false;
         }
 
-        if (loaderName != ModLoaderType.LabyMod)
+        if (loaderType != ModLoaderType.LabyMod)
         {
             selectedLabyModChannel = null;
             selectedLabyModCommitRef = null;
             selectedLabyModVersion = null;
         }
 
-        selectedLoaderName = loaderName;
+        _selectedLoaderType = loaderType;
         selectedAPIName = null;
     }
 
@@ -1096,14 +1096,14 @@ public partial class PageInstanceInstall
             };
         if (currentInstance.HasCleanroom)
         {
-            selectedLoaderName = ModLoaderType.Cleanroom;
+            _selectedLoaderType = ModLoaderType.Cleanroom;
             selectedAPIName = "Cleanroom";
             selectedCleanroomVersion = currentInstance.Cleanroom;
             selectedCleanroom = new ModDownload.DlCleanroomListEntry(selectedCleanroomVersion);
         }
         else if (currentInstance.HasForge)
         {
-            selectedLoaderName = ModLoaderType.Forge;
+            _selectedLoaderType = ModLoaderType.Forge;
             selectedForge =
                 new ModDownload.DlForgeVersionEntry(currentInstance.Forge, null, currentInstance.VanillaName)
                 {
@@ -1113,24 +1113,24 @@ public partial class PageInstanceInstall
         }
         else if (currentInstance.HasLegacyFabric)
         {
-            selectedLoaderName = ModLoaderType.LegacyFabric;
+            _selectedLoaderType = ModLoaderType.LegacyFabric;
             selectedLegacyFabric = currentInstance.LegacyFabric;
             selectedLegacyFabricApi = (ModComp.CompFile)GetCurrentLegacyFabricApi();
         }
         else if (currentInstance.HasFabric)
         {
-            selectedLoaderName = ModLoaderType.Fabric;
+            _selectedLoaderType = ModLoaderType.Fabric;
             selectedFabric = currentInstance.Fabric;
             selectedFabricApi = (ModComp.CompFile)GetCurrentFabricApi();
         }
         else if (currentInstance.HasLabyMod)
         {
-            selectedLoaderName = ModLoaderType.LabyMod;
+            _selectedLoaderType = ModLoaderType.LabyMod;
             selectedLabyModVersion = currentInstance.LabyMod;
         }
         else if (currentInstance.HasNeoForge)
         {
-            selectedLoaderName = ModLoaderType.NeoForge;
+            _selectedLoaderType = ModLoaderType.NeoForge;
             selectedNeoForgeVersion = currentInstance.NeoForge;
             selectedNeoForge = new ModDownload.DlNeoForgeListEntry(currentInstance.NeoForge)
             {
@@ -1371,18 +1371,18 @@ public partial class PageInstanceInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
             return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
-        if (selectedLoaderName == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
-            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
+            McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Loader
         if (GetLoaderError(LoadOptiFine) is not null)
             return GetLoaderError(LoadOptiFine);
@@ -1406,7 +1406,7 @@ public partial class PageInstanceInstall
 
         if (hasRequiredVersion) return Lang.Text("Download.Install.Compat.CompatForgeSpecificOnly");
 
-        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
     }
 
     // 检查某个 OptiFine 是否与某个 Forge 兼容
@@ -1520,8 +1520,8 @@ public partial class PageInstanceInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
-        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
             ? null
@@ -1595,8 +1595,8 @@ public partial class PageInstanceInstall
         if (McVersionComparer.CompareVersionGe("1.5.1", _vanillaName) && McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
             return Lang.Text("Download.Install.State.NoVersion");
                 
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Forge)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
 
         // 检查 Loader
         if (GetLoaderError(LoadForge) is not null)
@@ -1609,8 +1609,8 @@ public partial class PageInstanceInstall
         {
             if (Version.Category == "universal" || Version.Category == "client")
                 continue; // 跳过无法自动安装的版本
-            if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
-                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+            if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Forge)
+                return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
             if (selectedOptiFine is not null && McVersionComparer.CompareVersionGe(_vanillaName, "1.13") &&
                 McVersionComparer.CompareVersionGe("1.14.3", _vanillaName))
                 return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine"); // 1.13 ~ 1.14.3 OptiFine 检查
@@ -1689,7 +1689,7 @@ public partial class PageInstanceInstall
     private void Forge_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedForge = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         CardForge.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();
@@ -1707,8 +1707,8 @@ public partial class PageInstanceInstall
     {
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.NeoForge)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.NeoForge)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         // 检查 Loader
         if (GetLoaderError(LoadNeoForge) is not null)
             return GetLoaderError(LoadNeoForge);
@@ -1772,7 +1772,7 @@ public partial class PageInstanceInstall
     private void NeoForge_Clear(object sender, MouseButtonEventArgs e)
     {
         selectedNeoForge = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         CardNeoForge.IsSwapped = true;
         e.Handled = true;
         OptiFine_Loaded();
@@ -1792,8 +1792,8 @@ public partial class PageInstanceInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Cleanroom)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Cleanroom)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         // 检查 Loader
@@ -1859,7 +1859,7 @@ public partial class PageInstanceInstall
     {
         selectedCleanroom = null;
         selectedCleanroomVersion = null;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         CardCleanroom.IsSwapped = true;
         e.Handled = true;
@@ -1887,8 +1887,8 @@ public partial class PageInstanceInstall
             if ((version["version"].ToString() ?? "") ==
                 (_vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3") ?? ""))
             {
-                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Fabric)
-                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+                if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.Fabric)
+                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
                 return null;
             }
 
@@ -1955,7 +1955,7 @@ public partial class PageInstanceInstall
         autoSelectedFabricApi = false;
         selectedOptiFabric = null;
         autoSelectedOptiFabric = false;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         CardFabric.IsSwapped = true;
         e.Handled = true;
@@ -2141,8 +2141,8 @@ public partial class PageInstanceInstall
             {
                 if (selectedLiteLoader is not null)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
-                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LegacyFabric)
-                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+                if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.LegacyFabric)
+                    return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
                 return null;
             }
 
@@ -2205,7 +2205,7 @@ public partial class PageInstanceInstall
         selectedLegacyFabric = null;
         selectedLegacyFabricApi = null;
         autoSelectedLegacyFabricApi = false;
-        selectedLoaderName = null;
+        _selectedLoaderType = null;
         selectedAPIName = null;
         CardLegacyFabric.IsSwapped = true;
         e.Handled = true;
@@ -2492,8 +2492,8 @@ public partial class PageInstanceInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LabyMod)
-            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
+        if (_selectedLoaderType is not null && _selectedLoaderType != ModLoaderType.LabyMod)
+            return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", _selectedLoaderType);
         if (selectedLiteLoader is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
         foreach (JsonObject Version in ModDownload.dlLabyModListLoader.output.Value["production"]["minecraftVersions"].AsArray())
@@ -2586,9 +2586,9 @@ public partial class PageInstanceInstall
         selectedLabyModVersion = null;
         selectedLabyModChannel = null;
         
-        if (selectedLoaderName == ModLoaderType.LabyMod)
+        if (_selectedLoaderType == ModLoaderType.LabyMod)
         {
-            selectedLoaderName = null;
+            _selectedLoaderType = null;
         }    
 
         selectedAPIName = null;

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceInstall.xaml.cs
@@ -383,9 +383,9 @@ public partial class PageInstanceInstall
     private ModDownload.DlOptiFineListEntry? selectedOptiFine;
 
     /// <summary>
-    ///     选定的 Mod Loader 名称，内容应为 Forge / NeoForge / Fabric / Cleanroom / LabyMod / LegacyFabric
+    ///     选定的主 Mod 加载器。
     /// </summary>
-    private string? selectedLoaderName;
+    private ModLoaderType? selectedLoaderName;
 
     /// <summary>
     ///     选定的 Mod Loader API 名称，内容应为 Fabric API
@@ -873,24 +873,24 @@ public partial class PageInstanceInstall
     ///     选择主 Mod 加载器时，清除其它主加载器及其专属组件。
     ///     OptiFine 与 LiteLoader 可与部分加载器共存，故不在此处清除。
     /// </summary>
-    private void SelectModLoader(string loaderName)
+    private void SelectModLoader(ModLoaderType loaderName)
     {
-        if (loaderName != "Forge")
+        if (loaderName != ModLoaderType.Forge)
             selectedForge = null;
 
-        if (loaderName != "NeoForge")
+        if (loaderName != ModLoaderType.NeoForge)
         {
             selectedNeoForge = null;
             selectedNeoForgeVersion = null;
         }
 
-        if (loaderName != "Cleanroom")
+        if (loaderName != ModLoaderType.Cleanroom)
         {
             selectedCleanroom = null;
             selectedCleanroomVersion = null;
         }
 
-        if (loaderName != "Fabric")
+        if (loaderName != ModLoaderType.Fabric)
         {
             selectedFabric = null;
             selectedFabricApi = null;
@@ -899,14 +899,14 @@ public partial class PageInstanceInstall
             autoSelectedOptiFabric = false;
         }
 
-        if (loaderName != "LegacyFabric")
+        if (loaderName != ModLoaderType.LegacyFabric)
         {
             selectedLegacyFabric = null;
             selectedLegacyFabricApi = null;
             autoSelectedLegacyFabricApi = false;
         }
 
-        if (loaderName != "LabyMod")
+        if (loaderName != ModLoaderType.LabyMod)
         {
             selectedLabyModChannel = null;
             selectedLabyModCommitRef = null;
@@ -1096,14 +1096,14 @@ public partial class PageInstanceInstall
             };
         if (currentInstance.HasCleanroom)
         {
-            selectedLoaderName = "Cleanroom";
+            selectedLoaderName = ModLoaderType.Cleanroom;
             selectedAPIName = "Cleanroom";
             selectedCleanroomVersion = currentInstance.Cleanroom;
             selectedCleanroom = new ModDownload.DlCleanroomListEntry(selectedCleanroomVersion);
         }
         else if (currentInstance.HasForge)
         {
-            selectedLoaderName = "Forge";
+            selectedLoaderName = ModLoaderType.Forge;
             selectedForge =
                 new ModDownload.DlForgeVersionEntry(currentInstance.Forge, null, currentInstance.VanillaName)
                 {
@@ -1113,24 +1113,24 @@ public partial class PageInstanceInstall
         }
         else if (currentInstance.HasLegacyFabric)
         {
-            selectedLoaderName = "LegacyFabric";
+            selectedLoaderName = ModLoaderType.LegacyFabric;
             selectedLegacyFabric = currentInstance.LegacyFabric;
             selectedLegacyFabricApi = (ModComp.CompFile)GetCurrentLegacyFabricApi();
         }
         else if (currentInstance.HasFabric)
         {
-            selectedLoaderName = "Fabric";
+            selectedLoaderName = ModLoaderType.Fabric;
             selectedFabric = currentInstance.Fabric;
             selectedFabricApi = (ModComp.CompFile)GetCurrentFabricApi();
         }
         else if (currentInstance.HasLabyMod)
         {
-            selectedLoaderName = "LabyMod";
+            selectedLoaderName = ModLoaderType.LabyMod;
             selectedLabyModVersion = currentInstance.LabyMod;
         }
         else if (currentInstance.HasNeoForge)
         {
-            selectedLoaderName = "NeoForge";
+            selectedLoaderName = ModLoaderType.NeoForge;
             selectedNeoForgeVersion = currentInstance.NeoForge;
             selectedNeoForge = new ModDownload.DlNeoForgeListEntry(currentInstance.NeoForge)
             {
@@ -1371,14 +1371,14 @@ public partial class PageInstanceInstall
     /// </summary>
     private string LoadOptiFineGetError()
     {
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (LoadOptiFine is null || LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Run)
             return Lang.Text("Download.Install.State.Loading");
         if (LoadOptiFine.State.LoadingState == MyLoading.MyLoadingState.Error)
             return $"{Lang.Text("Download.Install.State.GetVersionListFailed")}{((ModLoader.LoaderBase)LoadOptiFine.State).Error.Message}";
         // 检查 Forge 1.13 - 1.14.3：全部不兼容
-        if (selectedLoaderName == "Forge" && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
+        if (selectedLoaderName == ModLoaderType.Forge && McVersionComparer.CompareVersion(_vanillaName, "1.13") >= 0 &&
             McVersionComparer.CompareVersion("1.14.3", _vanillaName) >= 0) return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Fabric 1.20.5+: 全部不兼容
         if (selectedFabric is not null && McVersionComparer.CompareVersion(_vanillaName, "1.20.4") > 0)
@@ -1520,7 +1520,7 @@ public partial class PageInstanceInstall
         // 检查 Loader
         if (GetLoaderError(LoadLiteLoader) is not null)
             return GetLoaderError(LoadLiteLoader);
-        if (selectedLoaderName == "NeoForge" || selectedLoaderName == "LegacyFabric" || selectedLoaderName == "LabyMod" || selectedLoaderName == "Cleanroom")
+        if (selectedLoaderName is ModLoaderType.NeoForge or ModLoaderType.LegacyFabric or ModLoaderType.LabyMod or ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查版本
         return ModDownload.dlLiteLoaderListLoader.output.Value.Any(v => (v.Inherit ?? "") == (_vanillaName ?? ""))
@@ -1595,7 +1595,7 @@ public partial class PageInstanceInstall
         if (McVersionComparer.CompareVersionGe("1.5.1", _vanillaName) && McVersionComparer.CompareVersionGe(_vanillaName, "1.1"))
             return Lang.Text("Download.Install.State.NoVersion");
                 
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Forge"))
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
 
         // 检查 Loader
@@ -1609,7 +1609,7 @@ public partial class PageInstanceInstall
         {
             if (Version.Category == "universal" || Version.Category == "client")
                 continue; // 跳过无法自动安装的版本
-            if (selectedLoaderName is not null && selectedLoaderName != "Forge")
+            if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Forge)
                 return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
             if (selectedOptiFine is not null && McVersionComparer.CompareVersionGe(_vanillaName, "1.13") &&
                 McVersionComparer.CompareVersionGe("1.14.3", _vanillaName))
@@ -1676,7 +1676,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void Forge_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("Forge");
+        SelectModLoader(ModLoaderType.Forge);
         selectedForge = (ModDownload.DlForgeVersionEntry)sender.Tag;
         CardForge.IsSwapped = true;
         if (selectedOptiFine is not null &&
@@ -1707,7 +1707,7 @@ public partial class PageInstanceInstall
     {
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "NeoForge"))
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.NeoForge)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         // 检查 Loader
         if (GetLoaderError(LoadNeoForge) is not null)
@@ -1762,7 +1762,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void NeoForge_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("NeoForge");
+        SelectModLoader(ModLoaderType.NeoForge);
         selectedNeoForge = (ModDownload.DlNeoForgeListEntry)sender.Tag;
         CardNeoForge.IsSwapped = true;
         OptiFine_Loaded();
@@ -1792,7 +1792,7 @@ public partial class PageInstanceInstall
             return Lang.Text("Download.Install.State.NoAvailableVersion");
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != "Cleanroom")
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Cleanroom)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null) 
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
@@ -1848,7 +1848,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     private void Cleanroom_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("Cleanroom");
+        SelectModLoader(ModLoaderType.Cleanroom);
         selectedCleanroom = (ModDownload.DlCleanroomListEntry)sender.Tag;
         CardCleanroom.IsSwapped = true;
         OptiFine_Loaded();
@@ -1887,7 +1887,7 @@ public partial class PageInstanceInstall
             if ((version["version"].ToString() ?? "") ==
                 (_vanillaName.Replace("∞", "infinite").Replace("Combat Test 7c", "1.16_combat-3") ?? ""))
             {
-                if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "Fabric"))
+                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.Fabric)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
                 return null;
             }
@@ -1940,7 +1940,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void Fabric_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("Fabric");
+        SelectModLoader(ModLoaderType.Fabric);
         selectedFabric = ((dynamic)sender.Tag)["version"].ToString();
         FabricApi_Loaded();
         OptiFabric_Loaded();
@@ -2141,7 +2141,7 @@ public partial class PageInstanceInstall
             {
                 if (selectedLiteLoader is not null)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
-                if (selectedLoaderName is not null && !ReferenceEquals(selectedLoaderName, "LegacyFabric"))
+                if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LegacyFabric)
                     return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
                 return null;
             }
@@ -2193,7 +2193,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void LegacyFabric_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("LegacyFabric");
+        SelectModLoader(ModLoaderType.LegacyFabric);
         selectedLegacyFabric = ((dynamic)sender.Tag)["version"].ToString();
         LegacyFabricApi_Loaded();
         CardLegacyFabric.IsSwapped = true;
@@ -2492,7 +2492,7 @@ public partial class PageInstanceInstall
             return GetLoaderError(LoadLabyMod);
         if (selectedOptiFine is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithOptiFine");
-        if (selectedLoaderName is not null && selectedLoaderName != "LabyMod")
+        if (selectedLoaderName is not null && selectedLoaderName != ModLoaderType.LabyMod)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLoader", selectedLoaderName);
         if (selectedLiteLoader is not null)
             return Lang.Text("Download.Install.Compat.IncompatibleWithLiteLoader");
@@ -2571,7 +2571,7 @@ public partial class PageInstanceInstall
     // 选择与清除
     public void LabyMod_Selected(MyListItem sender, EventArgs e)
     {
-        SelectModLoader("LabyMod");
+        SelectModLoader(ModLoaderType.LabyMod);
         selectedLabyModChannel = ((dynamic)sender.Tag)("channel").ToString();
         selectedLabyModCommitRef = ((dynamic)sender.Tag)("commitReference").ToString();
         selectedLabyModVersion =
@@ -2586,7 +2586,7 @@ public partial class PageInstanceInstall
         selectedLabyModVersion = null;
         selectedLabyModChannel = null;
         
-        if (selectedLoaderName == "LabyMod")
+        if (selectedLoaderName == ModLoaderType.LabyMod)
         {
             selectedLoaderName = null;
         }    


### PR DESCRIPTION
> Generated by GPT-5.6 Terra Medium

## Summary by Sourcery

在安装流程中重构模组加载器的选择逻辑，引入专用枚举并集中处理互斥的加载器。

增强内容：
- 引入 `ModLoaderType` 枚举，用于表示在实例安装过程中使用的主要、互斥的模组加载器。
- 更新实例安装和下载安装逻辑，通过 `ModLoaderType` 跟踪所选的主要模组加载器，而不是使用原始字符串。
- 添加辅助方法，在选择新加载器时重置存在冲突的主要模组加载器选择及其相关组件，同时保留与之兼容的附加组件，例如 OptiFine 和 LiteLoader。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor mod loader selection in the install flows to use a dedicated enum and centralize mutually exclusive loader handling.

Enhancements:
- Introduce a ModLoaderType enum representing the primary, mutually exclusive mod loaders used during instance installation.
- Update instance and download installation logic to track the selected primary mod loader via ModLoaderType instead of raw strings.
- Add a helper method to reset conflicting primary mod loader selections and their related components when choosing a new loader, while preserving compatible add-ons like OptiFine and LiteLoader.

</details>