### PR TITLE
fix(modpack): 安装 MCBBS 整合包时 JVM 参数处理有误

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -977,6 +977,20 @@ public static class ModModpack
 
     #region MCBBS
 
+    private static string HandleLaunchArguments(JsonNode? argumentNode)
+    {
+        IEnumerable<string> arguments = argumentNode switch
+        {
+            JsonArray array => array.OfType<JsonValue>()
+                .Where(argument => argument.GetValueKind() == JsonValueKind.String)
+                .Select(argument => argument.GetValue<string>()),
+            JsonValue argument when argument.GetValueKind() == JsonValueKind.String =>
+                [argument.GetValue<string>()],
+            _ => []
+        };
+        return string.Join(" ", arguments.Where(argument => !string.IsNullOrWhiteSpace(argument)));
+    }
+
     private static LoaderCombo<string> InstallPackMCBBS(string fileAddress, ZipArchive archive,
         string archiveBaseFolder, string instanceName = null)
     {
@@ -1031,12 +1045,8 @@ public static class ModModpack
             if (json["launchInfo"] is not null)
             {
                 var launchInfo = (JsonObject)json["launchInfo"];
-                Config.Instance.JvmArgs[versionFolder] = launchInfo["javaArgument"] is JsonArray jvmArguments
-                    ? string.Join(" ", jvmArguments.Select(argument => argument?.ToString()))
-                    : launchInfo["javaArgument"]?.ToString() ?? "";
-                Config.Instance.GameArgs[versionFolder] = launchInfo["launchArgument"] is JsonArray gameArguments
-                    ? string.Join(" ", gameArguments.Select(argument => argument?.ToString()))
-                    : launchInfo["launchArgument"]?.ToString() ?? "";
+                Config.Instance.JvmArgs[versionFolder] = HandleLaunchArguments(launchInfo["javaArgument"]);
+                Config.Instance.GameArgs[versionFolder] = HandleLaunchArguments(launchInfo["launchArgument"]);
             }
 
             // 整合包版本

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModModpack.cs
@@ -1031,8 +1031,12 @@ public static class ModModpack
             if (json["launchInfo"] is not null)
             {
                 var launchInfo = (JsonObject)json["launchInfo"];
-                Config.Instance.JvmArgs[versionFolder] = string.Join(" ", launchInfo["javaArgument"]);
-                Config.Instance.GameArgs[versionFolder] = string.Join(" ", launchInfo["launchArgument"]);
+                Config.Instance.JvmArgs[versionFolder] = launchInfo["javaArgument"] is JsonArray jvmArguments
+                    ? string.Join(" ", jvmArguments.Select(argument => argument?.ToString()))
+                    : launchInfo["javaArgument"]?.ToString() ?? "";
+                Config.Instance.GameArgs[versionFolder] = launchInfo["launchArgument"] is JsonArray gameArguments
+                    ? string.Join(" ", gameArguments.Select(argument => argument?.ToString()))
+                    : launchInfo["launchArgument"]?.ToString() ?? "";
             }
 
             // 整合包版本


### PR DESCRIPTION
> Generated by GPT-5.6 Terra xHigh

## Summary by Sourcery

错误修复：
- 修复在安装 MCBBS 整合包时对 JVM 和游戏参数解析不正确的问题，方式是支持非数组类型的 `launchInfo` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect JVM and game argument parsing when installing MCBBS modpacks by supporting non-array launchInfo values.

</details>