### PR TITLE
fix(tooltip): 修复部分情况下 ToolTip 不显示的问题，并调整了偏移量

### DIFF
--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -260,8 +260,20 @@ public static class Tooltip
             _Hush();
             return;
         }
+        
+        if (fe.IsEnabled)
+        {
+            if (ReferenceEquals(_target, fe) && _flyout is { IsOpen: true })
+                return;
 
-        if (fe.IsEnabled) return;
+            if (!ReferenceEquals(_target, fe)) _Hush();
+            _target = fe;
+            _latch?.Stop();
+            _latch = null;
+            _cursor = Mouse.GetPosition(fe);
+            _PopUp(fe, _cursor);
+            return;
+        }
 
         if (!ReferenceEquals(_target, fe)) _Hush();
         _target = fe;
@@ -307,9 +319,7 @@ public static class Tooltip
             _Hush();
             return;
         }
-
-        if (_closing) return;
-
+        
         _StartCycle(candidate, Mouse.GetPosition(candidate));
     }
 
@@ -354,6 +364,14 @@ public static class Tooltip
     private static bool _ShareAncestor(DependencyObject a, DependencyObject b)
     {
         if (ReferenceEquals(a, b)) return true;
+        
+        if (a is ComboBox comboA && b is ComboBoxItem itemB &&
+            ItemsControl.ItemsControlFromItemContainer(itemB) == comboA)
+            return true;
+        if (b is ComboBox comboB && a is ComboBoxItem itemA &&
+            ItemsControl.ItemsControlFromItemContainer(itemA) == comboB)
+            return true;
+
         for (var cur = VisualTreeHelper.GetParent(b); cur is not null; cur = VisualTreeHelper.GetParent(cur))
             if (ReferenceEquals(cur, a)) return true;
         for (var cur = VisualTreeHelper.GetParent(a); cur is not null; cur = VisualTreeHelper.GetParent(cur))

--- a/PCL.Core/UI/Controls/Tooltip.cs
+++ b/PCL.Core/UI/Controls/Tooltip.cs
@@ -583,10 +583,10 @@ public static class Tooltip
 
         if (mode is PlacementMode.Mouse)
         {
-            _flyout.Placement = PlacementMode.Relative;
+            _flyout.Placement = PlacementMode.Left;
             _flyout.PlacementRectangle = default;
             _flyout.HorizontalOffset = Math.Round(pt.X + 15 + ToolTipService.GetHorizontalOffset(target));
-            _flyout.VerticalOffset = Math.Round(pt.Y + 25 + ToolTipService.GetVerticalOffset(target));
+            _flyout.VerticalOffset = Math.Round(pt.Y + 15 + ToolTipService.GetVerticalOffset(target));
         }
         else if (mode is PlacementMode.MousePoint)
         {

--- a/Plain Craft Launcher 2/Application.xaml
+++ b/Plain Craft Launcher 2/Application.xaml
@@ -567,11 +567,6 @@
             </Style>
             <Style TargetType="ComboBoxItem" x:Key="MyComboBoxItem">
                 <Setter Property="OverridesDefaultStyle" Value="True" />
-                <Setter Property="ToolTipService.Placement" Value="Relative" />
-                <Setter Property="ToolTipService.VerticalOffset" Value="-2" />
-                <Setter Property="ToolTipService.HorizontalOffset" Value="200" />
-                <Setter Property="ToolTipService.InitialShowDelay" Value="150" />
-                <Setter Property="ToolTipService.BetweenShowDelay" Value="150" />
                 <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                 <Setter Property="Background" Value="{DynamicResource ColorBrushTransparent}" />
                 <Setter Property="Template">

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/MyCompItem.xaml
@@ -49,9 +49,7 @@
     </StackPanel>
     <TextBlock x:Name="LabInfo" Grid.Row="2" Grid.Column="4" VerticalAlignment="Center" Margin="0,0,3,0.5"
                TextTrimming="CharacterEllipsis" FontSize="12" Foreground="{StaticResource ColorBrushGray3}"
-               IsHitTestVisible="True" SnapsToDevicePixels="False" UseLayoutRounding="False"
-               ToolTipService.InitialShowDelay="100" ToolTipService.BetweenShowDelay="100"
-               ToolTipService.Placement="Relative" ToolTipService.PlacementRectangle="-16,-10,500,10000">
+               IsHitTestVisible="True" SnapsToDevicePixels="False" UseLayoutRounding="False">
         <TextBlock.ToolTip>
             <ToolTip x:Name="ToolTipInfo" />
         </TextBlock.ToolTip>

--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml
@@ -126,9 +126,9 @@
                             Tag="VersionRamType/0"
                             Margin="0,0,20,0"
                             ToolTip="{DynamicResource Setup.Launch.Memory.Auto.ToolTip}"
-                            ToolTipService.Placement="Right"
+                            ToolTipService.Placement="Left"
                             ToolTipService.HorizontalOffset="-10"
-                            ToolTipService.VerticalOffset="-3" />
+                            ToolTipService.VerticalOffset="-10" />
 
                         <local:MyRadioBox
                             Grid.Row="3" Grid.Column="0"
@@ -363,40 +363,33 @@
                                           Text="{DynamicResource Instance.Setup.Advanced.IgnoreJavaCompatibility}"
                                           x:Name="CheckAdvanceJava"
                                           Tag="VersionAdvanceJava"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Instance.Setup.Advanced.IgnoreJavaCompatibility.ToolTip}" />
                         <local:MyCheckBox Height="28"
                                           Text="{DynamicResource Instance.Setup.Advanced.DisableFileVerification}"
                                           x:Name="CheckAdvanceAssetsV2"
                                           Tag="VersionAdvanceAssetsV2" Margin="0,0,60,0"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Instance.Setup.Advanced.DisableFileVerification.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Instance.Setup.Advanced.UseGlobalProxy}"
                                           x:Name="CheckAdvanceUseProxyV2"
                                           Tag="VersionAdvanceUseProxyV2"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Instance.Setup.Advanced.UseGlobalProxy.ToolTip}" />
                         <local:MyCheckBox Height="28"
                                           Text="{DynamicResource Setup.Launch.Advanced.DisableJlw}"
                                           x:Name="CheckAdvanceDisableJLW"
                                           Tag="VersionAdvanceDisableJLW"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Setup.Launch.Advanced.DisableJlw.ToolTip}" />
                         <local:MyCheckBox Height="28"
                                           Text="{DynamicResource Setup.Launch.Advanced.DisableLF}"
                                           x:Name="CheckAdvanceDisableLF"
                                           Tag="VersionAdvanceDisableLF"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLF.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Instance.Setup.Advanced.UseDebugLog4j}"
                                           x:Name="CheckUseDebugLog4j2Config"
-                                          Tag="VersionUseDebugLog4j2Config"
-                                          ToolTipService.Placement="Right" />
+                                          Tag="VersionUseDebugLog4j2Config" />
                         <local:MyCheckBox Height="28"
                                           Text="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent}"
                                           x:Name="CheckAdvanceDisableLwjglUnsafeAgent"
                                           Tag="VersionAdvanceDisableLwjglUnsafeAgent"
-                                          ToolTipService.Placement="Right"
                                           ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip}" />
                     </StackPanel>
                 </Grid>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -183,8 +183,8 @@
                         </Grid.RowDefinitions>
                         <local:MyRadioBox Text="{DynamicResource Setup.Launch.Memory.Auto}" Width="110" Checked="True" x:Name="RadioRamType0"
                                           Tag="LaunchRamType/0" Margin="0,0,20,0" Check="RadioBoxChange"
-                                          ToolTip="{DynamicResource Setup.Launch.Memory.Auto.ToolTip}" ToolTipService.Placement="Right"
-                                          ToolTipService.HorizontalOffset="-10" ToolTipService.VerticalOffset="-3" />
+                                          ToolTip="{DynamicResource Setup.Launch.Memory.Auto.ToolTip}" ToolTipService.Placement="Left"
+                                          ToolTipService.HorizontalOffset="-10" ToolTipService.VerticalOffset="-10" />
                         <local:MyRadioBox Grid.Row="2" Text="{DynamicResource Common.Option.Customize}" x:Name="RadioRamType1" Tag="LaunchRamType/1"
                                           Margin="0,0,20,0" Check="RadioBoxChange" />
                         <local:MySlider Grid.Row="2" Grid.Column="1" IsEnabled="False" x:Name="SliderRamCustom"
@@ -263,7 +263,7 @@
                         <TextBlock Text="{DynamicResource Setup.Launch.Advanced.JvmHead}" VerticalAlignment="Center" />
                         <local:MyIconButton Height="23" Margin="0,1,0,0" x:Name="BtnAdvanceJvmReset"
                                             VerticalAlignment="Center" Click="BtnAdvanceJvmReset_Click"
-                                            ToolTip="{DynamicResource Setup.Launch.Advanced.JvmHead.Restore}" ToolTipService.Placement="Right"
+                                            ToolTip="{DynamicResource Setup.Launch.Advanced.JvmHead.Restore}" ToolTipService.Placement="Left"
                                             ToolTipService.InitialShowDelay="200" ToolTipService.VerticalOffset="-1"
                                             SvgIcon="lucide/rotate-ccw"
                                             LogoScale="0.9" />
@@ -291,19 +291,19 @@
                                       Text="{DynamicResource Setup.Launch.Advanced.PreLaunchCommand.Wait}" Margin="0,8,0,7" />
                     <StackPanel Margin="0,12,0,4" Grid.Row="8" Grid.ColumnSpan="2" HorizontalAlignment="Left">
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableJlw}" x:Name="CheckAdvanceDisableJLW" Tag="LaunchAdvanceDisableJLW"  Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableJlw.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.DisableJlw.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableLF}" x:Name="CheckAdvanceDisableLF" Tag="LaunchAdvanceDisableLF"  Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLF.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLF.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.GpuPreference}" x:Name="CheckAdvanceGraphicCard" Tag="LaunchAdvanceGraphicCard"  Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.GpuPreference.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.GpuPreference.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.UseJavaExe}" x:Name="CheckAdvanceNoJavaw" Tag="LaunchAdvanceNoJavaw"  Change="CheckBoxChange"
-                            ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.UseJavaExe.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.UseJavaExe.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent}" x:Name="CheckAdvanceDisableLwjglUnsafeAgent" Tag="LaunchAdvanceDisableLwjglUnsafeAgent"  Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.DisableLwjglUnsafeAgent.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.DisableCrashAnalysis}" x:Name="CheckAdvanceDisableCrashAnalysis" Tag="LaunchAdvanceDisableCrashAnalysis" Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.DisableCrashAnalysis.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.DisableCrashAnalysis.ToolTip}" />
                         <local:MyCheckBox Height="28" Text="{DynamicResource Setup.Launch.Advanced.LockMemory}" x:Name="CheckAdvanceLockMemory" Tag="LaunchAdvanceLockMemory" Change="CheckBoxChange"
-                                          ToolTipService.Placement="Right" ToolTip="{DynamicResource Setup.Launch.Advanced.LockMemory.ToolTip}" />
+                                          ToolTip="{DynamicResource Setup.Launch.Advanced.LockMemory.ToolTip}" />
                     </StackPanel>
                     <local:MyHint Text="{DynamicResource Setup.Launch.Advanced.MoreInInstanceSetup}" Margin="0,5,0,10" Theme="Blue" Grid.Row="9"
                                   Grid.ColumnSpan="2"


### PR DESCRIPTION
> Co-worked with GPT-5.6 Sol xHigh

## Summary by Sourcery

改进各类 UI 元素的工具提示显示行为和定位。

错误修复：
- 确保工具提示能正确显示在已启用的元素上，不会被之前的目标或关闭状态所抑制。
- 将 ComboBox 和 ComboBoxItem 视为共享同一祖先元素，这样在它们之间移动时工具提示能够保持激活状态。

增强：
- 调整基于鼠标的工具提示放置模式和偏移，使工具提示显示在更靠近、并始终位于光标左侧的位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve tooltip display behavior and positioning across various UI elements.

Bug Fixes:
- Ensure tooltips appear correctly for enabled elements without being suppressed by previous targets or closing state.
- Treat ComboBox and ComboBoxItem as sharing an ancestor so tooltips remain active when moving between them.

Enhancements:
- Adjust mouse-based tooltip placement mode and offsets so tooltips appear closer and consistently to the left of the cursor.

</details>