### PR TITLE
fix(custom-page): 修复自定义主页不能正常跳转的问题

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.cs
+++ b/Plain Craft Launcher 2/FormMain.xaml.cs
@@ -7,7 +7,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
-using System.Windows.Media.Effects;
 using PCL.Core.App;
 using PCL.Core.App.IoC;
 using PCL.Core.App.Localization;
@@ -1403,6 +1402,11 @@ public partial class FormMain
         CompDetail = 8,
 
         /// <summary>
+        ///     帮助详情。这是一个副页面。
+        /// </summary>
+        HelpDetail = 9,
+
+        /// <summary>
         ///     游戏实时日志。这是一个副页面。
         /// </summary>
         GameLog = 10,
@@ -1495,6 +1499,10 @@ public partial class FormMain
             case PageType.CompDetail:
             {
                 return Lang.Text("Main.Title.ResourceDownload", stack.additional.Value.CompProject.TranslatedName);
+            }
+            case PageType.HelpDetail:
+            {
+                return stack.helpPage?.Title ?? "";
             }
             case PageType.VersionSaves:
             {
@@ -1595,6 +1603,11 @@ public partial class FormMain
             string SavePath
         )? additional;
 
+        /// <summary>
+        ///     帮助详情页实例。仅在 <see cref="PageType.HelpDetail"/> 中使用。
+        /// </summary>
+        public PageHelpDetail? helpPage;
+
         public PageType page;
 
         public override bool Equals(object other)
@@ -1606,6 +1619,8 @@ public partial class FormMain
                 var pageOther = (PageStackData)other;
                 if (page != pageOther.page)
                     return false;
+                if (helpPage is not null || pageOther.helpPage is not null)
+                    return ReferenceEquals(helpPage, pageOther.helpPage);
                 if (additional is null) return pageOther.additional is null;
 
                 return pageOther.additional is not null && additional.Equals(pageOther.additional);
@@ -1897,6 +1912,13 @@ public partial class FormMain
                         if (ModMain.frmDownloadCompDetail is null)
                             ModMain.frmDownloadCompDetail = new PageDownloadCompDetail();
                         PageChangeAnim(new MyPageLeft(), ModMain.frmDownloadCompDetail);
+                        break;
+                    }
+                case PageType.HelpDetail: // 帮助详情
+                    {
+                        if (stack.helpPage is null)
+                            throw new InvalidOperationException("帮助详情页面未初始化");
+                        PageChangeAnim(new MyPageLeft(), stack.helpPage);
                         break;
                     }
                 case PageType.VersionSaves: // 存档管理

--- a/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
+++ b/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
+using System.Runtime.InteropServices;
 using PCL.Core.App;
 using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
 using PCL.Core.Utils.OS;
+using PCL.Network;
 
 namespace PCL
 {
@@ -94,7 +96,7 @@ namespace PCL
             [EventType.WriteSetting] = _WriteSetting,
             [EventType.ModifyVariable] = _WriteVariable,
             [EventType.WriteVariable] = _WriteVariable,
-            [EventType.OpenHelp] = (_, __) => ModBase.OpenWebsite("https://docs.pclc.cc/ce"),
+            [EventType.OpenHelp] = _OpenHelp,
         };
 
         /// <summary>
@@ -318,17 +320,75 @@ namespace PCL
                 HintService.Hint(Lang.Text("Event.Variable.Written", args[0], args[1]), HintType.Success);
         }
 
+        /// <summary>
+        /// 打开帮助或自定义主页页面
+        /// </summary>
+        private static void _OpenHelp(string arg, EventType type)
+        {
+            var args = SplitArgs(arg);
+            if (!args[0].StartsWithF("http", true))
+            {
+                ModBase.OpenWebsite("https://docs.pclc.cc/ce");
+                return;
+            }
+            var actualPaths = GetAbsoluteUrls(args[0], type);
+            var location = actualPaths.FirstOrDefault();
+            
+            
+        }
+
         public static string[] GetAbsoluteUrls(string relativeUrl, EventType type)
         {
+            if (relativeUrl.StartsWithF("http", true))
+            {
+                if (ModBase.RunInUi()) throw new Exception("能打开联网帮助页面的 MyListItem 必须手动设置 Title、Info 属性！");
+                
+                // 获取文件名
+                string rawFileName;
+                try
+                {
+                    rawFileName = relativeUrl.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).BeforeFirst("#").BeforeFirst("?");
+                    if (!rawFileName.EndsWithF(".json", true)) throw new Exception("未指向 .json 后缀的文件");
+                }
+                catch (Exception e)
+                {
+                    throw new Exception("联网帮助页面须指向一个帮助 JSON 文件，并在同路径下包含相应 XAML 文件！\n" +
+                                        "例如：\n" +
+                                        " - https://www.baidu.com/test.json（填写这个路径）\n" +
+                                        " - https://www.baidu.com/test.xaml（同时也需要包含这个文件）", e);
+                }
+                
+                // 下载文件
+                string temp = ModMain.RequestTaskTempFolder() + rawFileName;
+                ModBase.Log($"转换网络资源: {relativeUrl} -> {temp}");
+                try
+                {
+                    ModNet.NetDownloadByClient(relativeUrl, temp);
+                    ModNet.NetDownloadByClient(relativeUrl.Replace(".json", ".xaml"), temp.Replace(".json", ".xaml"));
+                }
+                catch (Exception e)
+                {
+                    throw new Exception("下载指定的文件失败！\n" +
+                                        "注意，联网帮助页面须指向一个帮助 JSON 文件，并在同路径下包含相应 XAML 文件！\n" +
+                                        "例如：\n" +
+                                        " - https://www.baidu.com/test.json（填写这个路径）\n" +
+                                        " - https://www.baidu.com/test.xaml（同时也需要包含这个文件）", e);
+                }
+
+                relativeUrl = temp;
+            }
+            relativeUrl = relativeUrl.Replace('/', '\\').ToLower().TrimStart('\\');
+            
+            // 确认路径
             relativeUrl = relativeUrl.Replace('/', '\\').ToLower().TrimStart('\\');
             var pclDir = Path.Combine(Basics.ExecutableDirectory, "PCL");
 
-            if (relativeUrl.Contains(":\\"))
+            if (relativeUrl.Contains(":\\")) // 绝对路径
             {
                 ModBase.Log($"[Control] 自定义事件中由绝对路径 {type}: {relativeUrl}");
                 return [relativeUrl, pclDir];
             }
-            if (File.Exists(Path.Combine(pclDir, relativeUrl)))
+            if (File.Exists(Path.Combine(pclDir, relativeUrl))) // 相对 PCL 文件夹的路径
             {
                 var fullPath = Path.Combine(pclDir, relativeUrl);
                 var resolved = Path.GetFullPath(fullPath);
@@ -337,7 +397,7 @@ namespace PCL
                 ModBase.Log($"[Control] 自定义事件中由相对 PCL 文件夹的路径 {type}: {fullPath}");
                 return [fullPath, pclDir];
             }
-            if (type is EventType.OpenFile or EventType.ExecuteCommand)
+            if (type is EventType.OpenFile or EventType.ExecuteCommand) // 直接使用原有路径启动程序
             {
                 ModBase.Log($"[Control] 自定义事件中直接 {type}: {relativeUrl}");
                 return [relativeUrl, pclDir];

--- a/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
+++ b/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.InteropServices;
 using PCL.Core.App;
 using PCL.Core.App.Configuration;
 using PCL.Core.App.Localization;
@@ -326,29 +325,58 @@ namespace PCL
         private static void _OpenHelp(string arg, EventType type)
         {
             var args = SplitArgs(arg);
-            if (!args[0].StartsWithF("http", true))
+            if (!Uri.TryCreate(args[0], UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             {
                 ModBase.OpenWebsite("https://docs.pclc.cc/ce");
                 return;
             }
-            var actualPaths = GetAbsoluteUrls(args[0], type);
-            var location = actualPaths.FirstOrDefault();
-            
-            
+
+            ModBase.RunInThread(() =>
+            {
+                try
+                {
+                    var actualPaths = GetAbsoluteUrls(args[0], type);
+                    var location = actualPaths[0];
+                    var content = PageHelpDetail.LoadContent(location);
+                    ModBase.RunInUiWait(() =>
+                    {
+                        var page = new PageHelpDetail(content);
+                        ModMain.frmMain.PageChange(new FormMain.PageStackData
+                        {
+                            page = FormMain.PageType.HelpDetail,
+                            helpPage = page
+                        });
+                    });
+                }
+                catch (Exception ex)
+                {
+                    ModBase.Log(
+                        ex,
+                        Lang.Text("Event.Error.ExecutionFailed", type, arg),
+                        ModBase.LogLevel.Msgbox,
+                        userSummary: Lang.Text("Event.Error.ExecutionFailed", type, arg));
+                }
+            });
         }
 
         public static string[] GetAbsoluteUrls(string relativeUrl, EventType type)
         {
-            if (relativeUrl.StartsWithF("http", true))
+            if (type == EventType.OpenHelp &&
+                Uri.TryCreate(relativeUrl, UriKind.Absolute, out var remoteUri) &&
+                (remoteUri.Scheme == Uri.UriSchemeHttp || remoteUri.Scheme == Uri.UriSchemeHttps))
             {
                 if (ModBase.RunInUi()) throw new Exception("能打开联网帮助页面的 MyListItem 必须手动设置 Title、Info 属性！");
-                
+
                 // 获取文件名
                 string rawFileName;
                 try
                 {
-                    rawFileName = relativeUrl.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).BeforeFirst("#").BeforeFirst("?");
-                    if (!rawFileName.EndsWithF(".json", true)) throw new Exception("未指向 .json 后缀的文件");
+                    rawFileName = Uri.UnescapeDataString(Path.GetFileName(remoteUri.AbsolutePath));
+                    if (!Path.GetExtension(rawFileName).Equals(".json", StringComparison.OrdinalIgnoreCase))
+                        throw new Exception("未指向 .json 后缀的文件");
+                    if (rawFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                        throw new Exception("文件名包含非法字符");
                 }
                 catch (Exception e)
                 {
@@ -357,14 +385,20 @@ namespace PCL
                                         " - https://www.baidu.com/test.json（填写这个路径）\n" +
                                         " - https://www.baidu.com/test.xaml（同时也需要包含这个文件）", e);
                 }
-                
+
                 // 下载文件
-                string temp = ModMain.RequestTaskTempFolder() + rawFileName;
-                ModBase.Log($"转换网络资源: {relativeUrl} -> {temp}");
+                var tempFolder = ModMain.RequestTaskTempFolder();
+                var jsonPath = Path.Combine(tempFolder, rawFileName);
+                var xamlPath = Path.ChangeExtension(jsonPath, ".xaml");
+                var xamlUri = new UriBuilder(remoteUri)
+                {
+                    Path = Path.ChangeExtension(remoteUri.AbsolutePath, ".xaml").Replace('\\', '/')
+                }.Uri.AbsoluteUri;
+                ModBase.Log($"[Control] 转换网络帮助资源：{relativeUrl} -> {jsonPath}");
                 try
                 {
-                    ModNet.NetDownloadByClient(relativeUrl, temp);
-                    ModNet.NetDownloadByClient(relativeUrl.Replace(".json", ".xaml"), temp.Replace(".json", ".xaml"));
+                    ModNet.NetDownloadByClient(remoteUri.AbsoluteUri, jsonPath);
+                    ModNet.NetDownloadByClient(xamlUri, xamlPath);
                 }
                 catch (Exception e)
                 {
@@ -375,15 +409,14 @@ namespace PCL
                                         " - https://www.baidu.com/test.xaml（同时也需要包含这个文件）", e);
                 }
 
-                relativeUrl = temp;
+                relativeUrl = jsonPath;
             }
-            relativeUrl = relativeUrl.Replace('/', '\\').ToLower().TrimStart('\\');
-            
+
             // 确认路径
-            relativeUrl = relativeUrl.Replace('/', '\\').ToLower().TrimStart('\\');
+            relativeUrl = relativeUrl.Replace('/', Path.DirectorySeparatorChar);
             var pclDir = Path.Combine(Basics.ExecutableDirectory, "PCL");
 
-            if (relativeUrl.Contains(":\\")) // 绝对路径
+            if (Path.IsPathFullyQualified(relativeUrl)) // 绝对路径
             {
                 ModBase.Log($"[Control] 自定义事件中由绝对路径 {type}: {relativeUrl}");
                 return [relativeUrl, pclDir];

--- a/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
+++ b/Plain Craft Launcher 2/Modules/Event/CustomEvent.cs
@@ -397,8 +397,10 @@ namespace PCL
                 ModBase.Log($"[Control] 转换网络帮助资源：{relativeUrl} -> {jsonPath}");
                 try
                 {
-                    ModNet.NetDownloadByClient(remoteUri.AbsoluteUri, jsonPath);
-                    ModNet.NetDownloadByClient(xamlUri, xamlPath);
+                    Task.WhenAll(
+                        ModNet.NetDownloadByClient(remoteUri.AbsoluteUri, jsonPath),
+                        ModNet.NetDownloadByClient(xamlUri, xamlPath)
+                    ).GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {

--- a/Plain Craft Launcher 2/Pages/PageHelpDetail.xaml
+++ b/Plain Craft Launcher 2/Pages/PageHelpDetail.xaml
@@ -1,0 +1,24 @@
+<local:MyPageRight x:Class="PCL.PageHelpDetail"
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:local="clr-namespace:PCL"
+                   PanScroll="{Binding ElementName=PanBack}">
+    <local:MyScrollViewer x:Name="PanBack"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+        <StackPanel x:Name="PanCustom" Margin="25,25,25,10">
+            <StackPanel.Resources>
+                <Style TargetType="TextBlock" BasedOn="{StaticResource BasedOnTextBlock}">
+                    <Setter Property="TextWrapping" Value="Wrap" />
+                </Style>
+                <Style TargetType="local:MyCard">
+                    <Setter Property="Margin" Value="0,0,0,15" />
+                </Style>
+                <Style TargetType="Image">
+                    <Setter Property="RenderOptions.BitmapScalingMode" Value="HighQuality" />
+                    <Setter Property="HorizontalAlignment" Value="Center" />
+                </Style>
+            </StackPanel.Resources>
+        </StackPanel>
+    </local:MyScrollViewer>
+</local:MyPageRight>

--- a/Plain Craft Launcher 2/Pages/PageHelpDetail.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageHelpDetail.xaml.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using System.Security;
+using System.Windows;
+using PCL.Core.App.Localization;
+
+namespace PCL;
+
+public partial class PageHelpDetail : IRefreshable
+{
+    internal sealed record HelpContent(string SourcePath, string Title, string Xaml);
+
+    private HelpContent _content = null!;
+
+    public string Title => _content.Title;
+
+    internal PageHelpDetail(HelpContent content)
+    {
+        InitializeComponent();
+        Loaded += (_, _) => PanBack.ScrollToHome();
+        ApplyContent(content);
+    }
+
+    /// <summary>
+    ///     从帮助 JSON 及同名 XAML 文件读取详情页数据。失败会抛出异常。
+    /// </summary>
+    internal static HelpContent LoadContent(string jsonPath)
+    {
+        if (!File.Exists(jsonPath))
+            throw new FileNotFoundException("未找到帮助 JSON 文件", jsonPath);
+
+        var json = ModMain.ArgumentReplace(File.ReadAllText(jsonPath), SecurityElement.Escape);
+        using var document = JsonDocument.Parse(json);
+        if (!document.RootElement.TryGetProperty("Title", out var titleElement) ||
+            titleElement.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(titleElement.GetString()))
+            throw new ArgumentException("帮助 JSON 中未找到有效的 Title 项", nameof(jsonPath));
+
+        var xamlPath = Path.ChangeExtension(jsonPath, ".xaml");
+        if (!File.Exists(xamlPath))
+            throw new FileNotFoundException("未找到帮助 JSON 对应的 XAML 文件", xamlPath);
+
+        var xaml = File.ReadAllText(xamlPath);
+        if (string.IsNullOrWhiteSpace(xaml))
+            throw new InvalidDataException("帮助 XAML 文件为空");
+
+        return new HelpContent(jsonPath, titleElement.GetString()!, xaml);
+    }
+
+    private void ApplyContent(HelpContent content)
+    {
+        // 修改时应同时修改 PageLaunchRight.LoadContent。
+        var xaml = ModMain.ArgumentReplace(content.Xaml);
+        while (xaml.Contains("xmlns"))
+            xaml = xaml.RegexReplace("xmlns[^\"']*(\"|')[^\"']*(\"|')", "").Replace("xmlns", "");
+        xaml =
+            $"<StackPanel xmlns=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\" xmlns:sys=\"clr-namespace:System;assembly=System.Runtime\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:local=\"clr-namespace:PCL;assembly=Plain Craft Launcher 2\">{xaml}</StackPanel>";
+
+        var element = (UIElement)ModBase.GetObjectFromXML(xaml, out var sanitizeResult);
+        foreach (var unsupported in sanitizeResult.UnsupportedTypesFound)
+            HintService.Hint(Lang.Text("Event.Sanitize.UnsupportedTypeHint", unsupported), HintType.Error);
+        foreach (var unknown in sanitizeResult.UnrecognizedTypes)
+            HintService.Hint(Lang.Text("Event.Sanitize.UnknownTypeHint", unknown), HintType.Error);
+
+        _content = content;
+        PanCustom.Children.Clear();
+        PanCustom.Children.Add(element);
+        if (ModMain.frmMain?.pageCurrent.page == FormMain.PageType.HelpDetail)
+            ModMain.frmMain.PageNameRefresh();
+    }
+
+    public void Refresh()
+    {
+        try
+        {
+            ApplyContent(LoadContent(_content.SourcePath));
+        }
+        catch (Exception ex)
+        {
+            ModBase.Log(
+                ex,
+                "刷新帮助详情页失败",
+                ModBase.LogLevel.Msgbox,
+                userSummary: Lang.Text("Event.Error.ExecutionFailed", EventType.OpenHelp, _content.SourcePath));
+        }
+    }
+}


### PR DESCRIPTION
Close #3517 

> Partly generated by GPT-5.6 Sol Max

## Summary by Sourcery

通过将 JSON/XAML 内容加载到专用的帮助详情页，添加从事件打开自定义帮助/主页的支持。

新特性：
- 引入 HelpDetail 页面类型，用于显示从 JSON 和 XAML 文件加载的详细帮助内容。
- 允许 `EventType.OpenHelp` 解析本地或远程帮助资源，并在启动器中导航到相应的详情页。

缺陷修复：
- 修复自定义主页/帮助事件的导航问题，使调用 `EventType.OpenHelp` 时能够正确打开目标帮助详情内容，而不再总是重定向到默认文档。

增强功能：
- 扩展自定义事件的路径解析逻辑，以处理绝对 URL，并在显示前下载关联的帮助定义文件。
- 改进页面栈相等性和标题解析，以正确处理帮助详情页及其关联实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for opening custom help/home pages from events by loading JSON/XAML content into a dedicated help detail page.

New Features:
- Introduce a HelpDetail page type for displaying detailed help content loaded from JSON and XAML files.
- Allow EventType.OpenHelp to resolve local or remote help resources and navigate to a corresponding detail page within the launcher.

Bug Fixes:
- Fix custom home/help event navigation so that invoking EventType.OpenHelp correctly opens the intended help detail content instead of always redirecting to the default documentation.

Enhancements:
- Extend path resolution logic for custom events to handle absolute URLs by downloading associated help definition files before display.
- Improve page stack equality and title resolution to account for help detail pages and their associated instances.

</details>