### PR TITLE
fix(setup-launch): Reload 时同步内存滑块可用状态

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.cs
@@ -66,6 +66,7 @@ public partial class PageSetupLaunch
             // 游戏内存
             ((MyRadioBox)FindName("RadioRamType" + Config.Launch.MemoryAllocationMode)).Checked = true;
             SliderRamCustom.Value = Config.Launch.CustomMemorySize;
+            RamType(Config.Launch.MemoryAllocationMode);
 
             // 高级设置
             ComboAdvanceRenderer.SelectedIndex = Config.Launch.Renderer;


### PR DESCRIPTION
close #3552

## Summary by Sourcery

错误修复：
- 在重新加载启动设置时，同步自定义内存滑块的启用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Synchronize the custom memory slider's enabled state when reloading launch settings.

</details>